### PR TITLE
chore: add CODECOV_TOKEN to codecov CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,6 @@ jobs:
     - name: Code Coverage
       if: matrix.python-version == '3.12' && matrix.django-version=='django52'
       uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false


### PR DESCRIPTION
Adds the required token and fail_ci_if_error configuration to the existing codecov/codecov-action@v5 step.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>