### PR TITLE
chore: Normalize coverage settings across all of enterprise

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,10 +3,13 @@ branch = True
 data_file = .coverage
 source=enterprise_catalog
 omit =
-    enterprise_catalog/settings*
-    enterprise_catalog/conf*
-    *wsgi.py
-    *migrations*
-    *admin.py
-    *static*
-    *templates*
+    enterprise_catalog/settings/*
+    enterprise_catalog/conf/*
+    */wsgi.py
+    */urls.py
+    */migrations/*
+    */admin.py
+    */static/*
+    */templates/*
+    */tests/*
+    test_*

--- a/.gitignore
+++ b/.gitignore
@@ -98,5 +98,16 @@ tx
 # pyenv
 .python-version
 
+# claude code personalization
+.claude/settings.local.json
+
+# Ralph
+.ralph/.*
+.ralph/status.json
+.ralph/progress.json
+.ralph/specs/
+.ralph/logs
+.ralph/live.log
+
+# devstack
 .dev/
-CLAUDE.md

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,8 @@
-comment: off
 coverage:
   status:
     patch:
       default:
-        target: 91
+        target: 91%
     project:
       default:
-        target: 91
+        target: auto  # Just make sure it doesn't get worse

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,18 @@
+# Standard settings used by CI and Makefile targets.
+#
+# Designed to run all tests and produce comprehensive coverage reporting.
+#
+# Example usage:
+# ```
+# pytest
+# ```
+[pytest]
+DJANGO_SETTINGS_MODULE = enterprise_catalog.settings.test
+addopts = --cov enterprise_catalog --cov-report term-missing --cov-report xml
+norecursedirs = .* docs requirements
+
+# Filter depr warnings coming from packages that we can't control.
+filterwarnings =
+	ignore:.*urlresolvers is deprecated in favor of.*:DeprecationWarning:auth_backends.views:5
+	ignore:.*invalid escape sequence.*:DeprecationWarning:.*(newrelic|uritemplate|psutil).*
+	ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*distutils.*

--- a/pytest.local.ini
+++ b/pytest.local.ini
@@ -1,8 +1,20 @@
-# This makes it easier to get coverage reports for only specific modules
-# when running pytest locally, for example:
-# pytest -x enterprise_access/apps/events/  --cov=enterprise_access.apps.events -c pytest.local.ini
+# pytest settings optimized for development cycles.
+#
+# Differences from pytest.ini:
+# - Removing `--cov enterprise_catalog` makes it possible to scope coverage reports to specific modules.
+# - Warnings are ignored.
+#
+# Example usage:
+# ```
+# # Test only one domain and report coverage only for that domain:
+# pytest -c pytest.local.ini enterprise_catalog/apps/core --cov=enterprise_catalog.apps.core
+# pytest -c pytest.local.ini enterprise_catalog/apps/catalog --cov=enterprise_catalog.apps.catalog
+#
+# # Test only one file or function without generating coverage.
+# pytest -c pytest.local.ini enterprise_catalog/apps/catalog/tests/test_models.py
+# ```
 [pytest]
-DJANGO_SETTINGS_MODULE = enterprise_access.settings.test
+DJANGO_SETTINGS_MODULE = enterprise_catalog.settings.test
 addopts = --cov-report term-missing --cov-report xml -W ignore
 norecursedirs = .* docs requirements site-packages
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,16 +13,5 @@ skip=
     settings
     migrations
 
-[tool:pytest]
-DJANGO_SETTINGS_MODULE = enterprise_catalog.settings.test
-addopts = --cov enterprise_catalog --cov-report term-missing --cov-report xml
-norecursedirs = .* docs requirements
-
-# Filter depr warnings coming from packages that we can't control.
-filterwarnings =
-	ignore:.*urlresolvers is deprecated in favor of.*:DeprecationWarning:auth_backends.views:5
-	ignore:.*invalid escape sequence.*:DeprecationWarning:.*(newrelic|uritemplate|psutil).*
-	ignore:.*the imp module is deprecated in favour of importlib.*:DeprecationWarning:.*distutils.*
-
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
Fix two bugs:
- fix bug in pytest.local.ini referencing `enterprise_access`.
- fix .coveragerc omission bugs

Normalization:
- reorganize pytest settings to live as pytest.ini + pytest.local.ini
- turn on coverage commits in PRs.
- gitignore various claude/ralph files.
- codecov project target should just be auto (= don't make it worse)