### PR TITLE
feat: skip metadata updates when Discovery content unchanged

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+Enterprise Catalog is a Django-based microservice that manages enterprise catalogs, associating enterprise customers with curated courses from the full course catalog. It integrates with multiple edX services including course-discovery, LMS, and Algolia for search functionality.
+
+## Development Commands
+
+### Testing and Quality
+
+You must enter a docker container shell to run tests and linters.
+```bash
+# Run tests via docker container
+docker exec enterprise.catalog.app bash -c "pytest -c pytest.local.ini <TEST_FILES>"
+docker exec enterprise.catalog.app bash -c "make isort style lint"
+```
+
+Important: make use of ddt to reduce test setup boilerplate.
+
+### Management Commands
+Key management commands (run via `docker exec` as you do for tests)
+- `./manage.py update_content_metadata` - Sync content from discovery service to enterprise catalogs
+- `./manage.py update_full_content_metadata` - Fetch additional course metadata
+- `./manage.py reindex_algolia` - Rebuild Algolia search index
+- `./manage.py migrate` - Apply database migrations
+
+Add `--force` flag to override celery task deduplication (tasks won't run more than once per hour by default).
+
+## Architecture
+
+### Core Apps Structure
+- `enterprise_catalog/apps/catalog/` - Core catalog models and business logic
+- `enterprise_catalog/apps/api/` - REST API endpoints (v1 and v2)
+- `enterprise_catalog/apps/api_client/` - External service clients (Discovery, Enterprise, Algolia, etc.)
+- `enterprise_catalog/apps/curation/` - Content curation and highlights
+- `enterprise_catalog/apps/ai_curation/` - AI-powered content curation
+- `enterprise_catalog/apps/video_catalog/` - Video content management
+- `enterprise_catalog/apps/jobs/` - Enterprise jobs integration
+
+### Key Models
+- `EnterpriseCatalog` - Associates enterprises with content filters
+- `CatalogQuery` - Defines content filtering rules
+- `ContentMetadata` - Cached content from discovery service
+- `EnterpriseCatalogRoleAssignment` - Permission management
+
+### External Integrations
+- **Discovery Service** - Source of truth for course content
+- **LMS** - Authentication and enterprise user management
+- **Algolia** - Search indexing and query functionality
+- **Enterprise Service** - Enterprise customer data
+- **Celery/Redis** - Asynchronous task processing
+
+### Permission System
+Two authorization mechanisms:
+1. JWT Roles encoded in cookies from LMS
+2. Feature-based Role Assignments via `EnterpriseCatalogRoleAssignment` model
+
+## Development Notes
+
+### Settings
+- Development settings in `enterprise_catalog/settings/`
+- Create `private.py` for local overrides (gitignored)
+- Docker configuration uses `devstack.py` settings
+
+### Monitoring tools
+You can use edx-django-utils `monitoring.function_trace()` decorator to explicitly wrap
+functions as a segment in our monitoring tool (datadog), but we get traces on most python
+view and celery operations out of the box.

--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -112,6 +112,9 @@ class DiscoveryApiClient(BaseOAuthClient):
             'page_size': 100,
             # Ensure paginated results are consistently ordered by `aggregation_key` and `start`
             'ordering': 'aggregation_key,start',
+            # Ensures we get the course modified field in the response payload
+            # Important for de-duplication of ContentMetadata updates.
+            'detail_fields': 'true',
         }
         page = 1
         results = []

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -1,6 +1,7 @@
 import collections
 import copy
 import json
+from datetime import datetime
 from logging import getLogger
 from uuid import uuid4
 
@@ -1150,6 +1151,15 @@ def _get_defaults_from_metadata(entry, exists=False):
         for field in settings.COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL:
             if value := entry.get(field):
                 entry_minimal[field] = value
+        # Always include 'modified' for staleness detection in incremental Algolia indexing,
+        # regardless of COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL. Without this, the skip logic
+        # in _should_skip_course_update() would fail on subsequent syncs:
+        #   Sync 1: Discovery modified='2024-02-01', DB='2024-01-01' → Different, UPDATE
+        #           (but if 'modified' not persisted, DB stays '2024-01-01')
+        #   Sync 2: Discovery modified='2024-02-01', DB='2024-01-01' → Different, UPDATE again
+        #   (repeats forever until update_full_content_metadata overwrites json_metadata)
+        if modified := entry.get('modified'):
+            entry_minimal['modified'] = modified
         if entry_minimal:
             defaults.update({'_json_metadata': entry_minimal})
     elif not exists or (content_type != 'course'):
@@ -1158,6 +1168,34 @@ def _get_defaults_from_metadata(entry, exists=False):
         # does not yet exist in the database.
         defaults.update({'_json_metadata': entry})
     return defaults
+
+
+def _parse_datetime_string(dt_string):
+    """
+    Parse a datetime string into a datetime object for comparison.
+
+    Handles different ISO 8601 timezone formats that may differ between
+    Discovery API responses and our stored JSON metadata:
+      - '2024-10-21T20:31:23.006470+00:00' (explicit offset)
+      - '2024-10-21T20:31:23.006470Z' (Zulu time)
+
+    Returns:
+        datetime or None: Parsed datetime object, or None if parsing fails.
+    """
+    if not dt_string or not isinstance(dt_string, str):
+        return None
+
+    dt_string = dt_string.strip()
+
+    # Normalize trailing 'Z' (Zulu time) to an explicit UTC offset so that
+    # datetime.fromisoformat can parse it efficiently.
+    if dt_string.endswith('Z'):
+        dt_string = dt_string[:-1] + '+00:00'
+
+    try:
+        return datetime.fromisoformat(dt_string)
+    except ValueError:
+        return None
 
 
 def _should_skip_course_update(entry, existing_content):
@@ -1182,8 +1220,10 @@ def _should_skip_course_update(entry, existing_content):
     if existing_content.content_type != COURSE:
         return False
 
-    new_modified = entry.get('modified')
-    old_modified = existing_content._json_metadata.get('modified')  # pylint: disable=protected-access
+    new_modified = _parse_datetime_string(entry.get('modified'))
+    old_modified = _parse_datetime_string(
+        existing_content._json_metadata.get('modified')  # pylint: disable=protected-access
+    )
 
     if new_modified and old_modified and new_modified == old_modified:
         return True
@@ -1456,7 +1496,7 @@ def _execute_updates_existing_records_avoid_deadlock(content_keys, filtered_batc
 
     if skipped_count > 0:
         LOGGER.info(
-            'Skipped %d course updates where Discovery modified timestamp was unchanged',
+            'Skipped %d course updates in this batch where Discovery modified timestamp was unchanged',
             skipped_count,
         )
 

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -1160,11 +1160,46 @@ def _get_defaults_from_metadata(entry, exists=False):
     return defaults
 
 
+def _should_skip_course_update(entry, existing_content):
+    """
+    Determine if a course update should be skipped because Discovery's 'modified' timestamp
+    is unchanged.
+
+    For courses, we compare the 'modified' timestamp from the Discovery /search/all response
+    with the existing 'modified' value in our database. If they match, there's no need to
+    update the ContentMetadata record, which avoids unnecessary churn in ContentMetadata.modified
+    and enables accurate staleness detection for incremental Algolia indexing.
+
+    Programs and pathways don't have a 'modified' field from Discovery, so they never skip.
+
+    Arguments:
+        entry (dict): The metadata entry from Discovery's /search/all API response.
+        existing_content (ContentMetadata): The existing ContentMetadata database object.
+
+    Returns:
+        bool: True if the update should be skipped, False otherwise.
+    """
+    if existing_content.content_type != COURSE:
+        return False
+
+    new_modified = entry.get('modified')
+    old_modified = existing_content._json_metadata.get('modified')  # pylint: disable=protected-access
+
+    if new_modified and old_modified and new_modified == old_modified:
+        return True
+
+    return False
+
+
 def _partition_content_metadata_defaults(batched_metadata, existing_metadata_by_key):
     """
     Given a batch of metadata entries and a list of existing ContentMetadata objects, this function
     determines the default fields to use for creates/updates depending on whether a database object exists
     for each metadata entry.
+
+    For existing courses, this function also checks if the Discovery 'modified' timestamp has changed.
+    If the timestamp is unchanged, the course is skipped to avoid unnecessary ContentMetadata.modified
+    updates (which enables accurate staleness detection for incremental Algolia indexing).
 
     Arguments:
         batched_metadata (list): List of metadata entries from the /search/all API response.
@@ -1172,27 +1207,45 @@ def _partition_content_metadata_defaults(batched_metadata, existing_metadata_by_
             database by content key.
 
     Returns:
-        (existing_metadata_defaults, nonexisting_metadata_defaults): Tuple containing lists of both
-            the default fields for ContentMetadata objects that already exist in the DB and for ContentMetadata
-            objects that will be newly created.
+        (existing_metadata_defaults, nonexisting_metadata_defaults, skipped_count): Tuple containing:
+            - List of default fields for ContentMetadata objects that already exist and need updating
+            - List of default fields for ContentMetadata objects that will be newly created
+            - Count of existing courses skipped due to unchanged 'modified' timestamp
     """
-    existing_metadata_defaults = [
-        _get_defaults_from_metadata(entry, exists=True)
-        for entry in batched_metadata
-        if get_content_key(entry) in existing_metadata_by_key
-    ]
+    existing_metadata_defaults = []
+    skipped_count = 0
+
+    for entry in batched_metadata:
+        content_key = get_content_key(entry)
+        if content_key not in existing_metadata_by_key:
+            continue
+
+        existing_content = existing_metadata_by_key[content_key]
+
+        # Skip courses where Discovery's 'modified' timestamp is unchanged
+        if _should_skip_course_update(entry, existing_content):
+            skipped_count += 1
+            continue
+
+        existing_metadata_defaults.append(_get_defaults_from_metadata(entry, exists=True))
+
     nonexisting_metadata_defaults = [
         _get_defaults_from_metadata(entry)
         for entry in batched_metadata
-        if not get_content_key(entry) in existing_metadata_by_key
+        if get_content_key(entry) not in existing_metadata_by_key
     ]
-    return existing_metadata_defaults, nonexisting_metadata_defaults
+
+    return existing_metadata_defaults, nonexisting_metadata_defaults, skipped_count
 
 
 def _update_existing_content_metadata(existing_metadata_defaults, existing_metadata_by_key, dry_run=False):
     """
     Iterates through existing ContentMetadata database objects, updating the values of various
     fields based on the defaults provided.
+
+    Note: Courses with unchanged Discovery 'modified' timestamps are filtered out earlier
+    in _partition_content_metadata_defaults(), so this function only receives records
+    that actually need updating.
 
     Arguments:
         existing_metadata_defaults (list): List of default values for various fields
@@ -1397,9 +1450,15 @@ def _execute_updates_existing_records_avoid_deadlock(content_keys, filtered_batc
         content_key__in=content_keys
     ).order_by('pk').select_for_update()
     existing_metadata_by_key = {metadata.content_key: metadata for metadata in existing_metadata}
-    existing_metadata_defaults, nonexisting_metadata_defaults = _partition_content_metadata_defaults(
+    existing_metadata_defaults, nonexisting_metadata_defaults, skipped_count = _partition_content_metadata_defaults(
         filtered_batched_metadata, existing_metadata_by_key
     )
+
+    if skipped_count > 0:
+        LOGGER.info(
+            'Skipped %d course updates where Discovery modified timestamp was unchanged',
+            skipped_count,
+        )
 
     # Update existing ContentMetadata records
     updated_metadata = _update_existing_content_metadata(

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -26,6 +26,7 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     RestrictedCourseMetadata,
+    _get_defaults_from_metadata,
     _partition_content_metadata_defaults,
     _should_allow_metadata,
     _should_skip_course_update,
@@ -1785,6 +1786,57 @@ class TestCreateContentMetadata(TestCase):
         self.assertEqual(len(result), 1)  # Only the successful item from second batch
 
 
+class TestGetDefaultsFromMetadata(TestCase):
+    """
+    Tests for _get_defaults_from_metadata to ensure proper field handling.
+    """
+
+    def test_modified_included_for_existing_courses(self):
+        """
+        Test that 'modified' is always included in defaults for existing courses,
+        even though it's not in COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL.
+
+        This is critical for staleness detection - without persisting 'modified',
+        the skip logic would fail on subsequent syncs:
+          Sync 1: Discovery modified='2024-02-01', DB='2024-01-01' → UPDATE
+                  (but if 'modified' not persisted, DB stays '2024-01-01')
+          Sync 2: Discovery modified='2024-02-01', DB='2024-01-01' → UPDATE again
+        """
+        entry = {
+            'key': 'course-v1:edX+Test+2024',
+            'aggregation_key': 'course:course-v1:edX+Test+2024',
+            'content_type': 'course',
+            'title': 'Test Course',
+            'modified': '2024-06-15T10:30:00Z',
+            'seat_types': ['verified'],
+            'end_date': '2025-01-01T00:00:00Z',
+        }
+
+        defaults = _get_defaults_from_metadata(entry, exists=True)
+
+        # Verify 'modified' is included even though it's not in the pluck list
+        self.assertIn('_json_metadata', defaults)
+        self.assertEqual(defaults['_json_metadata'].get('modified'), '2024-06-15T10:30:00Z')
+
+    def test_modified_not_included_when_missing_from_entry(self):
+        """
+        Test that if Discovery doesn't provide 'modified', we don't add a None value.
+        """
+        entry = {
+            'key': 'course-v1:edX+Test+2024',
+            'aggregation_key': 'course:course-v1:edX+Test+2024',
+            'content_type': 'course',
+            'title': 'Test Course',
+            'seat_types': ['verified'],
+            # No 'modified' field
+        }
+
+        defaults = _get_defaults_from_metadata(entry, exists=True)
+
+        self.assertIn('_json_metadata', defaults)
+        self.assertNotIn('modified', defaults['_json_metadata'])
+
+
 @ddt.ddt
 class TestShouldSkipCourseUpdate(TestCase):
     """
@@ -1806,6 +1858,11 @@ class TestShouldSkipCourseUpdate(TestCase):
         (PROGRAM, None, None, False, 'program_never_skips'),
         # Program with modified timestamps - should still never skip
         (PROGRAM, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', False, 'program_ignores_modified'),
+        # Different timezone formats representing the same time - should skip
+        # Discovery returns '+00:00' format, DB stores 'Z' format
+        (COURSE, '2024-10-21T20:31:23.006470Z', '2024-10-21T20:31:23.006470+00:00', True, 'course_tz_format_diff'),
+        # Same time with microseconds in different formats - should skip
+        (COURSE, '2024-10-21T20:31:23Z', '2024-10-21T20:31:23+00:00', True, 'course_tz_format_no_micro'),
     )
     @ddt.unpack
     def test_should_skip_course_update(

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -26,7 +26,10 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     RestrictedCourseMetadata,
+    _partition_content_metadata_defaults,
     _should_allow_metadata,
+    _should_skip_course_update,
+    _update_existing_content_metadata,
 )
 from enterprise_catalog.apps.catalog.models import \
     create_content_metadata as create_content_metadata_func
@@ -1780,3 +1783,310 @@ class TestCreateContentMetadata(TestCase):
         # Should be: 2 initial batches + 2 retries = 4 total calls
         self.assertEqual(mock_execute_updates.call_count, 4)
         self.assertEqual(len(result), 1)  # Only the successful item from second batch
+
+
+@ddt.ddt
+class TestShouldSkipCourseUpdate(TestCase):
+    """
+    Tests for _should_skip_course_update which determines if a course update should be skipped
+    based on unchanged Discovery 'modified' timestamp.
+    """
+
+    @ddt.data(
+        # (content_type, existing_modified, new_modified, should_skip, description)
+        # Course with unchanged modified timestamp - should skip
+        (COURSE, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', True, 'course_unchanged_modified'),
+        # Course with changed modified timestamp - should NOT skip
+        (COURSE, '2024-01-01T00:00:00Z', '2024-02-01T00:00:00Z', False, 'course_changed_modified'),
+        # Course with no existing modified - should NOT skip (can't compare)
+        (COURSE, None, '2024-02-01T00:00:00Z', False, 'course_no_existing_modified'),
+        # Course with no new modified - should NOT skip (can't compare)
+        (COURSE, '2024-01-01T00:00:00Z', None, False, 'course_no_new_modified'),
+        # Program - should never skip (no modified field from Discovery)
+        (PROGRAM, None, None, False, 'program_never_skips'),
+        # Program with modified timestamps - should still never skip
+        (PROGRAM, '2024-01-01T00:00:00Z', '2024-01-01T00:00:00Z', False, 'program_ignores_modified'),
+    )
+    @ddt.unpack
+    def test_should_skip_course_update(
+        self, content_type, existing_modified, new_modified, should_skip, description
+    ):
+        """
+        Test that _should_skip_course_update correctly determines whether to skip an update
+        based on the Discovery 'modified' timestamp.
+
+        Courses should skip only when the 'modified' timestamp is unchanged.
+        Programs/pathways should never skip since they don't have 'modified' from Discovery.
+        """
+        content_key = f'test-content-{description}'
+
+        # Build existing json_metadata
+        existing_json = {'title': 'Original Title'}
+        if existing_modified:
+            existing_json['modified'] = existing_modified
+
+        # Create the existing content
+        existing_content = factories.ContentMetadataFactory(
+            content_key=content_key,
+            content_type=content_type,
+            _json_metadata=existing_json,
+        )
+
+        # Build the Discovery entry
+        entry = {
+            'key': content_key,
+            'aggregation_key': f'{content_type}:{content_key}',
+            'content_type': content_type,
+            'title': 'New Title',
+        }
+        if new_modified:
+            entry['modified'] = new_modified
+
+        # Call the function
+        result = _should_skip_course_update(entry, existing_content)
+
+        self.assertEqual(
+            result, should_skip,
+            f"Expected should_skip={should_skip} for {description}, got {result}"
+        )
+
+
+class TestPartitionContentMetadataDefaultsSkipLogic(TestCase):
+    """
+    Tests for skip logic in _partition_content_metadata_defaults.
+    """
+
+    def test_partition_skips_unchanged_courses(self):
+        """
+        Test that _partition_content_metadata_defaults skips courses with unchanged 'modified'.
+        """
+        content_key = 'course-v1:edX+TestCourse+2024'
+        modified_timestamp = '2024-06-15T10:30:00Z'
+
+        # Create existing content with a specific modified timestamp
+        existing_content = factories.ContentMetadataFactory(
+            content_key=content_key,
+            content_type=COURSE,
+            _json_metadata={
+                'title': 'Original Course Title',
+                'modified': modified_timestamp,
+                'aggregation_key': f'course:{content_key}',
+            },
+        )
+
+        # Simulate a Discovery API response with the SAME modified timestamp
+        discovery_entry = {
+            'key': content_key,
+            'aggregation_key': f'course:{content_key}',
+            'content_type': 'course',
+            'title': 'Updated Course Title',
+            'modified': modified_timestamp,  # Same as existing
+            'seat_types': ['verified'],
+        }
+
+        existing_metadata_by_key = {content_key: existing_content}
+
+        # Call _partition_content_metadata_defaults
+        existing_defaults, nonexisting_defaults, skipped_count = _partition_content_metadata_defaults(
+            [discovery_entry],
+            existing_metadata_by_key
+        )
+
+        # Should have skipped the course
+        self.assertEqual(skipped_count, 1)
+        self.assertEqual(len(existing_defaults), 0)
+        self.assertEqual(len(nonexisting_defaults), 0)
+
+    def test_partition_updates_changed_courses(self):
+        """
+        Test that _partition_content_metadata_defaults includes courses with changed 'modified'.
+        """
+        content_key = 'course-v1:edX+TestCourse+2024'
+        old_modified = '2024-01-01T00:00:00Z'
+        new_modified = '2024-06-15T10:30:00Z'
+
+        # Create existing content
+        existing_content = factories.ContentMetadataFactory(
+            content_key=content_key,
+            content_type=COURSE,
+            _json_metadata={
+                'title': 'Original Course Title',
+                'modified': old_modified,
+                'aggregation_key': f'course:{content_key}',
+            },
+        )
+
+        # Simulate a Discovery API response with a NEW modified timestamp
+        discovery_entry = {
+            'key': content_key,
+            'aggregation_key': f'course:{content_key}',
+            'content_type': 'course',
+            'title': 'Updated Course Title',
+            'modified': new_modified,  # Different from existing
+            'seat_types': ['verified'],
+        }
+
+        existing_metadata_by_key = {content_key: existing_content}
+
+        # Call _partition_content_metadata_defaults
+        existing_defaults, nonexisting_defaults, skipped_count = _partition_content_metadata_defaults(
+            [discovery_entry],
+            existing_metadata_by_key
+        )
+
+        # Should NOT have skipped the course
+        self.assertEqual(skipped_count, 0)
+        self.assertEqual(len(existing_defaults), 1)
+        self.assertEqual(existing_defaults[0]['content_key'], content_key)
+        self.assertEqual(len(nonexisting_defaults), 0)
+
+    def test_partition_always_updates_programs(self):
+        """
+        Test that _partition_content_metadata_defaults always includes programs (never skips).
+        """
+        content_key = 'test-program-uuid'
+
+        # Create existing program
+        existing_content = factories.ContentMetadataFactory(
+            content_key=content_key,
+            content_type=PROGRAM,
+            _json_metadata={
+                'title': 'Original Program Title',
+                'aggregation_key': f'program:{content_key}',
+            },
+        )
+
+        # Simulate a Discovery API response
+        discovery_entry = {
+            'uuid': content_key,
+            'aggregation_key': f'program:{content_key}',
+            'content_type': 'program',
+            'title': 'Updated Program Title',
+        }
+
+        existing_metadata_by_key = {content_key: existing_content}
+
+        # Call _partition_content_metadata_defaults
+        existing_defaults, nonexisting_defaults, skipped_count = _partition_content_metadata_defaults(
+            [discovery_entry],
+            existing_metadata_by_key
+        )
+
+        # Programs should never be skipped
+        self.assertEqual(skipped_count, 0)
+        self.assertEqual(len(existing_defaults), 1)
+        self.assertEqual(len(nonexisting_defaults), 0)
+
+
+class TestFullPathSkipUnchangedCourse(TestCase):
+    """
+    Integration tests for the full code path from Discovery entry to ContentMetadata update,
+    verifying that courses with unchanged 'modified' timestamps are skipped.
+    """
+
+    def test_full_path_skip_unchanged_course(self):
+        """
+        Integration test that exercises the full code path:
+        _partition_content_metadata_defaults → _update_existing_content_metadata
+
+        This verifies that the 'modified' field from the Discovery API response is used
+        to skip updates, ensuring ContentMetadata.modified doesn't churn unnecessarily.
+        """
+        content_key = 'course-v1:edX+IntegrationTest+2024'
+        modified_timestamp = '2024-06-15T10:30:00Z'
+
+        # Create existing content with a specific modified timestamp
+        existing_content = factories.ContentMetadataFactory(
+            content_key=content_key,
+            content_type=COURSE,
+            _json_metadata={
+                'title': 'Original Course Title',
+                'modified': modified_timestamp,
+                'aggregation_key': f'course:{content_key}',
+            },
+        )
+
+        # Simulate a Discovery API response with the SAME modified timestamp
+        discovery_entry_unchanged = {
+            'key': content_key,
+            'aggregation_key': f'course:{content_key}',
+            'content_type': 'course',
+            'title': 'Updated Course Title',  # Title changed but modified timestamp same
+            'modified': modified_timestamp,  # Same as existing
+            'seat_types': ['verified'],
+            'end_date': '2025-01-01T00:00:00Z',
+        }
+
+        existing_metadata_by_key = {content_key: existing_content}
+
+        # Run through the full update path
+        existing_defaults, _, skipped_count = _partition_content_metadata_defaults(
+            [discovery_entry_unchanged],
+            existing_metadata_by_key
+        )
+
+        # Should have skipped because modified is unchanged
+        self.assertEqual(skipped_count, 1)
+        self.assertEqual(len(existing_defaults), 0)
+
+        # Call update function with the (empty) defaults
+        result = _update_existing_content_metadata(
+            existing_defaults,
+            existing_metadata_by_key
+        )
+
+        # No updates should have happened
+        self.assertEqual(len(result), 0)
+
+        # Content should not have been modified
+        existing_content.refresh_from_db()
+        self.assertEqual(existing_content.json_metadata.get('title'), 'Original Course Title')
+
+    def test_full_path_updates_course_when_modified_changes(self):
+        """
+        Integration test verifying that updates DO happen when the modified timestamp changes.
+        """
+        content_key = 'course-v1:edX+IntegrationTest2+2024'
+        old_modified = '2024-01-01T00:00:00Z'
+        new_modified = '2024-06-15T10:30:00Z'
+
+        # Create existing content
+        existing_content = factories.ContentMetadataFactory(
+            content_key=content_key,
+            content_type=COURSE,
+            _json_metadata={
+                'title': 'Original Course Title',
+                'modified': old_modified,
+                'aggregation_key': f'course:{content_key}',
+            },
+        )
+
+        # Simulate a Discovery API response with a NEW modified timestamp
+        discovery_entry_changed = {
+            'key': content_key,
+            'aggregation_key': f'course:{content_key}',
+            'content_type': 'course',
+            'title': 'Updated Course Title',
+            'modified': new_modified,  # Different from existing
+            'seat_types': ['verified'],
+        }
+
+        existing_metadata_by_key = {content_key: existing_content}
+
+        # Run through the full update path
+        existing_defaults, _, skipped_count = _partition_content_metadata_defaults(
+            [discovery_entry_changed],
+            existing_metadata_by_key
+        )
+
+        # Should NOT have skipped
+        self.assertEqual(skipped_count, 0)
+        self.assertEqual(len(existing_defaults), 1)
+
+        result = _update_existing_content_metadata(
+            existing_defaults,
+            existing_metadata_by_key
+        )
+
+        # Should have updated because modified timestamp changed
+        self.assertEqual(len(result), 1, "Should update when modified timestamp changed")


### PR DESCRIPTION
For courses, check Discovery's json_metadata.modified timestamp before updating ContentMetadata. If the timestamp is unchanged, skip the update to avoid unnecessary ContentMetadata.modified updates. This enables accurate staleness detection for incremental Algolia indexing and will generally improve performance.

Sends a `detail_fields` query param to search/all so that we can fetch the `modified` value of courses: [course search serializer](https://github.com/openedx/course-discovery/blob/ab250b5b58b90bd214685e53a6cb220fc5eeee38/course_discovery/apps/course_metadata/search_indexes/serializers/course.py#L165)

Programs/pathways don't have a 'modified' field from Discovery, so they always update as before.
[program serializer](https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/course_metadata/search_indexes/serializers/program.py)
[pathway serializer](https://github.com/openedx/course-discovery/blob/master/course_discovery/apps/course_metadata/search_indexes/serializers/learner_pathway.py)

Also commits a fairly non-controversial CLAUDE.md file.

https://2u-internal.atlassian.net/browse/ENT-11453

## How to test
```
./manage.py update_content_metadata --no-async --force
```
Look for a string like "Skipped N course updates where Discovery modified timestamp was unchanged". N should be > 0.

## Larger context
https://2u-internal.atlassian.net/wiki/spaces/SOL/pages/3294265374/Tech+Spec+Course-based+incremental+Algolia+Reindexing#Phase-0:-Prerequisite-Fix

## Impact
Many fewer SQL UPDATEs in the course of the `update_content_metadata` command. Also tees us up for success in re-architecting algolia index management.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
