### PR TITLE
fix: preserve catalog associations for skipped courses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ tx
 
 # claude code personalization
 .claude/settings.local.json
+prompts.db
 
 # Ralph
 .ralph/.*

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -148,9 +148,11 @@ class AlgoliaSearchClient:
             # index must exist to continue, nothing left to do
             return
 
+        # The 'safe' field makes the client wait for asynchronous indexing operations to complete
+        use_safe = getattr(settings, 'USE_REPLACE_ALL_OBJECTS_SAFE', True)
         try:
             self.algolia_index.replace_all_objects(algolia_objects, {
-                'safe': True,  # wait for asynchronous indexing operations to complete
+                'safe': use_safe,
             })
             logger.info('The %s Algolia index was successfully indexed.', self.algolia_index_name)
         except AlgoliaException as exc:

--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -220,8 +220,9 @@ class CatalogQueryAdmin(UnchangeableMixin):
         'uuid',
         'title',
         'content_filter',
+        'get_content_count',
     )
-    readonly_fields = ('uuid',)
+    readonly_fields = ('uuid', 'get_content_count')
     list_display = (
         'uuid',
         'content_filter_hash',
@@ -231,11 +232,14 @@ class CatalogQueryAdmin(UnchangeableMixin):
         'content_filter_hash',
     )
 
-    @admin.display(
-        description='Content Filter'
-    )
+    @admin.display(description='Content Filter')
     def get_content_filter(self, obj):
         return obj.pretty_print_content_filter()
+
+    @admin.display(description='Content Count')
+    def get_content_count(self, obj):
+        return obj.contentmetadata_set.count()
+
     form = CatalogQueryForm
 
 

--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -805,7 +805,7 @@ class ContentMetadata(BaseContentMetadata):
         # runs were actually found for this specific course and the requester's
         # specific Catalog.
         if restricted_course_metadata_for_catalog_query:
-            # pylint: disable=protected-access, unsubscriptable-object
+            # pylint: disable=protected-access
             return restricted_course_metadata_for_catalog_query[0]._json_metadata
         return self._json_metadata
 
@@ -1247,13 +1247,14 @@ def _partition_content_metadata_defaults(batched_metadata, existing_metadata_by_
             database by content key.
 
     Returns:
-        (existing_metadata_defaults, nonexisting_metadata_defaults, skipped_count): Tuple containing:
+        (existing_metadata_defaults, nonexisting_metadata_defaults, skipped_metadata): Tuple containing:
             - List of default fields for ContentMetadata objects that already exist and need updating
             - List of default fields for ContentMetadata objects that will be newly created
-            - Count of existing courses skipped due to unchanged 'modified' timestamp
+            - List of existing ContentMetadata objects skipped due to unchanged 'modified' timestamp
+              (these must still be included in catalog associations even though they don't need updating)
     """
     existing_metadata_defaults = []
-    skipped_count = 0
+    skipped_metadata = []
 
     for entry in batched_metadata:
         content_key = get_content_key(entry)
@@ -1262,9 +1263,10 @@ def _partition_content_metadata_defaults(batched_metadata, existing_metadata_by_
 
         existing_content = existing_metadata_by_key[content_key]
 
-        # Skip courses where Discovery's 'modified' timestamp is unchanged
+        # Skip courses where Discovery's 'modified' timestamp is unchanged.
+        # We still need to track these objects for catalog associations.
         if _should_skip_course_update(entry, existing_content):
-            skipped_count += 1
+            skipped_metadata.append(existing_content)
             continue
 
         existing_metadata_defaults.append(_get_defaults_from_metadata(entry, exists=True))
@@ -1275,7 +1277,7 @@ def _partition_content_metadata_defaults(batched_metadata, existing_metadata_by_
         if get_content_key(entry) not in existing_metadata_by_key
     ]
 
-    return existing_metadata_defaults, nonexisting_metadata_defaults, skipped_count
+    return existing_metadata_defaults, nonexisting_metadata_defaults, skipped_metadata
 
 
 def _update_existing_content_metadata(existing_metadata_defaults, existing_metadata_by_key, dry_run=False):
@@ -1481,23 +1483,44 @@ def _update_or_create_content_metadata(content_keys, filtered_batched_metadata, 
 def _execute_updates_existing_records_avoid_deadlock(content_keys, filtered_batched_metadata, dry_run):
     """
     Finds and updates existing metadata records matching the given content keys, returning
-    a list of the updated records, along with a set of metadata defaults for content_keys that
-    do *not* already exist in the system. This version tries to avoid deadlocks by using
-    a transaction with select_for_update().
+    a list of the updated records (including skipped records that don't need updating),
+    along with a set of metadata defaults for content_keys that do *not* already exist
+    in the system. This version tries to avoid deadlocks by using a transaction with
+    select_for_update().
+
+    Note: Skipped records (courses with unchanged 'modified' timestamps) are included in
+    the returned list even though they weren't updated. This is critical because the
+    returned list is used for catalog associations - excluding skipped records would
+    cause them to be disassociated from their catalogs.
     """
     # see https://docs.djangoproject.com/en/5.2/ref/models/querysets/#select-for-update
     existing_metadata = ContentMetadata.objects.filter(
         content_key__in=content_keys
     ).order_by('pk').select_for_update()
     existing_metadata_by_key = {metadata.content_key: metadata for metadata in existing_metadata}
-    existing_metadata_defaults, nonexisting_metadata_defaults, skipped_count = _partition_content_metadata_defaults(
+    existing_metadata_defaults, nonexisting_metadata_defaults, skipped_metadata = _partition_content_metadata_defaults(
         filtered_batched_metadata, existing_metadata_by_key
     )
 
-    if skipped_count > 0:
+    # Safeguard: Verify all items in the batch are accounted for (updated, created, or skipped).
+    # This catches bugs where items are accidentally "lost" from the pipeline.
+    accounted_count = len(existing_metadata_defaults) + len(nonexisting_metadata_defaults) + len(skipped_metadata)
+    batch_count = len(filtered_batched_metadata)
+    if accounted_count != batch_count:
+        LOGGER.error(
+            '[CONTENT_METADATA_SAFEGUARD] Batch item count mismatch: batch=%d, accounted=%d '
+            '(existing=%d, new=%d, skipped=%d). This may indicate a bug in the update pipeline.',
+            batch_count,
+            accounted_count,
+            len(existing_metadata_defaults),
+            len(nonexisting_metadata_defaults),
+            len(skipped_metadata),
+        )
+
+    if skipped_metadata:
         LOGGER.info(
             'Skipped %d course updates in this batch where Discovery modified timestamp was unchanged',
-            skipped_count,
+            len(skipped_metadata),
         )
 
     # Update existing ContentMetadata records
@@ -1506,6 +1529,11 @@ def _execute_updates_existing_records_avoid_deadlock(content_keys, filtered_batc
         existing_metadata_by_key,
         dry_run
     )
+
+    # Include skipped metadata in the returned list so they maintain their catalog associations.
+    # These records don't need updating but must still be associated with catalogs.
+    updated_metadata.extend(skipped_metadata)
+
     return updated_metadata, nonexisting_metadata_defaults
 
 
@@ -1523,6 +1551,19 @@ def _check_content_association_threshold(catalog_query, metadata_list):
     """
     existing_relations_size = catalog_query.contentmetadata_set.count()
     new_relations_size = len(metadata_list)
+
+    # Safeguard: Never allow wiping out a catalog's associations entirely.
+    # This catches severe bugs where the metadata pipeline returns an empty list
+    # when it should have returned content.
+    if existing_relations_size > 0 and new_relations_size == 0:
+        LOGGER.error(
+            '[CONTENT_METADATA_SAFEGUARD] Blocked attempt to remove all %d content associations from query %s. '
+            'This likely indicates a bug in the content metadata pipeline.',
+            existing_relations_size,
+            catalog_query,
+        )
+        return True
+
     # To prevent false positives, this content association action stop gap will only apply to reasonably sized
     # content sets
     LOGGER.info(

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -26,6 +26,8 @@ from enterprise_catalog.apps.catalog.constants import (
 from enterprise_catalog.apps.catalog.models import (
     ContentMetadata,
     RestrictedCourseMetadata,
+    _check_content_association_threshold,
+    _execute_updates_existing_records_avoid_deadlock,
     _get_defaults_from_metadata,
     _partition_content_metadata_defaults,
     _should_allow_metadata,
@@ -1944,13 +1946,14 @@ class TestPartitionContentMetadataDefaultsSkipLogic(TestCase):
         existing_metadata_by_key = {content_key: existing_content}
 
         # Call _partition_content_metadata_defaults
-        existing_defaults, nonexisting_defaults, skipped_count = _partition_content_metadata_defaults(
+        existing_defaults, nonexisting_defaults, skipped_metadata = _partition_content_metadata_defaults(
             [discovery_entry],
             existing_metadata_by_key
         )
 
-        # Should have skipped the course
-        self.assertEqual(skipped_count, 1)
+        # Should have skipped the course but returned it in skipped_metadata
+        self.assertEqual(len(skipped_metadata), 1)
+        self.assertEqual(skipped_metadata[0], existing_content)
         self.assertEqual(len(existing_defaults), 0)
         self.assertEqual(len(nonexisting_defaults), 0)
 
@@ -1986,13 +1989,13 @@ class TestPartitionContentMetadataDefaultsSkipLogic(TestCase):
         existing_metadata_by_key = {content_key: existing_content}
 
         # Call _partition_content_metadata_defaults
-        existing_defaults, nonexisting_defaults, skipped_count = _partition_content_metadata_defaults(
+        existing_defaults, nonexisting_defaults, skipped_metadata = _partition_content_metadata_defaults(
             [discovery_entry],
             existing_metadata_by_key
         )
 
         # Should NOT have skipped the course
-        self.assertEqual(skipped_count, 0)
+        self.assertEqual(len(skipped_metadata), 0)
         self.assertEqual(len(existing_defaults), 1)
         self.assertEqual(existing_defaults[0]['content_key'], content_key)
         self.assertEqual(len(nonexisting_defaults), 0)
@@ -2024,13 +2027,13 @@ class TestPartitionContentMetadataDefaultsSkipLogic(TestCase):
         existing_metadata_by_key = {content_key: existing_content}
 
         # Call _partition_content_metadata_defaults
-        existing_defaults, nonexisting_defaults, skipped_count = _partition_content_metadata_defaults(
+        existing_defaults, nonexisting_defaults, skipped_metadata = _partition_content_metadata_defaults(
             [discovery_entry],
             existing_metadata_by_key
         )
 
         # Programs should never be skipped
-        self.assertEqual(skipped_count, 0)
+        self.assertEqual(len(skipped_metadata), 0)
         self.assertEqual(len(existing_defaults), 1)
         self.assertEqual(len(nonexisting_defaults), 0)
 
@@ -2077,13 +2080,14 @@ class TestFullPathSkipUnchangedCourse(TestCase):
         existing_metadata_by_key = {content_key: existing_content}
 
         # Run through the full update path
-        existing_defaults, _, skipped_count = _partition_content_metadata_defaults(
+        existing_defaults, _, skipped_metadata = _partition_content_metadata_defaults(
             [discovery_entry_unchanged],
             existing_metadata_by_key
         )
 
-        # Should have skipped because modified is unchanged
-        self.assertEqual(skipped_count, 1)
+        # Should have skipped because modified is unchanged, but returned in skipped_metadata
+        self.assertEqual(len(skipped_metadata), 1)
+        self.assertEqual(skipped_metadata[0], existing_content)
         self.assertEqual(len(existing_defaults), 0)
 
         # Call update function with the (empty) defaults
@@ -2131,13 +2135,13 @@ class TestFullPathSkipUnchangedCourse(TestCase):
         existing_metadata_by_key = {content_key: existing_content}
 
         # Run through the full update path
-        existing_defaults, _, skipped_count = _partition_content_metadata_defaults(
+        existing_defaults, _, skipped_metadata = _partition_content_metadata_defaults(
             [discovery_entry_changed],
             existing_metadata_by_key
         )
 
         # Should NOT have skipped
-        self.assertEqual(skipped_count, 0)
+        self.assertEqual(len(skipped_metadata), 0)
         self.assertEqual(len(existing_defaults), 1)
 
         result = _update_existing_content_metadata(
@@ -2147,3 +2151,236 @@ class TestFullPathSkipUnchangedCourse(TestCase):
 
         # Should have updated because modified timestamp changed
         self.assertEqual(len(result), 1, "Should update when modified timestamp changed")
+
+    def test_skipped_courses_maintain_catalog_associations(self):
+        """
+        Regression test: Verify that skipped courses (unchanged 'modified' timestamp) still
+        maintain their catalog associations.
+
+        Previously, skipped courses were excluded from the metadata_list used for catalog
+        associations, causing them to be disassociated when `catalog_query.contentmetadata_set.set()`
+        was called with `clear=True`. This resulted in search results disappearing for customers
+        whose catalogs contained courses with unchanged modified timestamps.
+
+        This test verifies the fix: skipped courses should be included in the returned metadata
+        list so they maintain their catalog associations even though they don't need updating.
+        """
+        content_key_unchanged = 'course-v1:edX+UnchangedCourse+2024'
+        content_key_changed = 'course-v1:edX+ChangedCourse+2024'
+        modified_timestamp = '2024-06-15T10:30:00Z'
+        old_modified = '2024-01-01T00:00:00Z'
+        new_modified = '2024-06-15T10:30:00Z'
+
+        # Create two existing courses - one with unchanged modified, one with changed
+        course_unchanged = factories.ContentMetadataFactory(
+            content_key=content_key_unchanged,
+            content_type=COURSE,
+            _json_metadata={
+                'title': 'Unchanged Course',
+                'modified': modified_timestamp,
+                'aggregation_key': f'course:{content_key_unchanged}',
+            },
+        )
+        course_changed = factories.ContentMetadataFactory(
+            content_key=content_key_changed,
+            content_type=COURSE,
+            _json_metadata={
+                'title': 'Changed Course Original',
+                'modified': old_modified,
+                'aggregation_key': f'course:{content_key_changed}',
+            },
+        )
+
+        # Discovery entries - one unchanged, one with new modified timestamp
+        discovery_entries = [
+            {
+                'key': content_key_unchanged,
+                'aggregation_key': f'course:{content_key_unchanged}',
+                'content_type': 'course',
+                'title': 'Unchanged Course',
+                'modified': modified_timestamp,  # Same as existing
+                'seat_types': ['verified'],
+            },
+            {
+                'key': content_key_changed,
+                'aggregation_key': f'course:{content_key_changed}',
+                'content_type': 'course',
+                'title': 'Changed Course Updated',
+                'modified': new_modified,  # Different from existing
+                'seat_types': ['verified'],
+            },
+        ]
+
+        existing_metadata_by_key = {
+            content_key_unchanged: course_unchanged,
+            content_key_changed: course_changed,
+        }
+
+        # Partition the entries
+        existing_defaults, _, skipped_metadata = _partition_content_metadata_defaults(
+            discovery_entries,
+            existing_metadata_by_key
+        )
+
+        # One should be skipped (unchanged), one should be updated (changed)
+        self.assertEqual(len(skipped_metadata), 1)
+        self.assertEqual(skipped_metadata[0], course_unchanged)
+        self.assertEqual(len(existing_defaults), 1)
+        self.assertEqual(existing_defaults[0]['content_key'], content_key_changed)
+
+        # Update existing content
+        updated_metadata = _update_existing_content_metadata(
+            existing_defaults,
+            existing_metadata_by_key
+        )
+
+        # The updated list should contain ONLY the changed course
+        self.assertEqual(len(updated_metadata), 1)
+        self.assertEqual(updated_metadata[0].content_key, content_key_changed)
+
+        # Combine updated + skipped (as the real code does in _execute_updates_existing_records_avoid_deadlock)
+        all_existing_metadata = updated_metadata + list(skipped_metadata)
+
+        # CRITICAL: Both courses should be in the combined list for catalog associations
+        self.assertEqual(len(all_existing_metadata), 2)
+        content_keys_in_result = {m.content_key for m in all_existing_metadata}
+        self.assertIn(content_key_unchanged, content_keys_in_result)
+        self.assertIn(content_key_changed, content_keys_in_result)
+
+
+class TestContentAssociationSafeguards(TestCase):
+    """
+    Tests for safeguards that prevent accidental catalog association wipeouts.
+    """
+
+    def test_zero_association_blocker_prevents_wipeout(self):
+        """
+        Test that _check_content_association_threshold blocks setting a non-empty catalog to empty.
+        """
+        # Create a catalog query with existing content
+        catalog = factories.EnterpriseCatalogFactory()
+        query = catalog.catalog_query
+
+        # Add some content to the catalog
+        content_metadata = factories.ContentMetadataFactory.create_batch(
+            5,
+            content_type=COURSE,
+        )
+        query.contentmetadata_set.set(content_metadata)
+
+        # Attempt to set associations to empty list - should be blocked
+        empty_list = []
+        result = _check_content_association_threshold(query, empty_list)
+
+        # Should return True, indicating the update should be blocked
+        self.assertTrue(result)
+
+    def test_zero_association_blocker_allows_empty_to_empty(self):
+        """
+        Test that setting an already-empty catalog to empty is allowed.
+        """
+        # Create a catalog query with NO existing content
+        catalog = factories.EnterpriseCatalogFactory()
+        query = catalog.catalog_query
+
+        # Verify it starts empty
+        self.assertEqual(query.contentmetadata_set.count(), 0)
+
+        # Attempt to set associations to empty list - should be allowed
+        empty_list = []
+        result = _check_content_association_threshold(query, empty_list)
+
+        # Should return False, indicating the update is allowed
+        self.assertFalse(result)
+
+    def test_zero_association_blocker_allows_normal_updates(self):
+        """
+        Test that normal updates (non-empty to non-empty) are allowed through the blocker.
+        """
+        # Create a catalog query with existing content
+        catalog = factories.EnterpriseCatalogFactory()
+        query = catalog.catalog_query
+
+        # Add some content to the catalog
+        content_metadata = factories.ContentMetadataFactory.create_batch(
+            5,
+            content_type=COURSE,
+        )
+        query.contentmetadata_set.set(content_metadata)
+
+        # Create new metadata list (non-empty)
+        new_metadata = factories.ContentMetadataFactory.create_batch(
+            3,
+            content_type=COURSE,
+        )
+
+        # This should NOT be blocked by the zero-association blocker
+        # (may still be blocked by other guardrails, but that's not what we're testing)
+        result = _check_content_association_threshold(query, new_metadata)
+
+        # The zero-association blocker should allow this through
+        # (the result depends on other guardrail settings, but we're just testing
+        # that empty-list blocking doesn't interfere with normal updates)
+        # For small catalogs under the floor, this should return False
+        self.assertFalse(result)
+
+    @mock.patch('enterprise_catalog.apps.catalog.models._partition_content_metadata_defaults')
+    @mock.patch('enterprise_catalog.apps.catalog.models.LOGGER')
+    def test_batch_count_validation_logs_mismatch(self, mock_logger, mock_partition):
+        """
+        Test that the batch count validation logs an error when items are 'lost' from the pipeline.
+
+        This safeguard catches bugs where the partition function doesn't account for all items
+        in the batch (e.g., items dropped due to a code bug).
+        """
+        content_key = 'course-v1:edX+TestCourse+2024'
+
+        # Create existing content
+        factories.ContentMetadataFactory(
+            content_key=content_key,
+            content_type=COURSE,
+            _json_metadata={
+                'title': 'Test Course',
+                'aggregation_key': f'course:{content_key}',
+            },
+        )
+
+        # Simulate a Discovery API batch with 3 entries
+        batch_entries = [
+            {
+                'key': content_key,
+                'aggregation_key': f'course:{content_key}', 'content_type': 'course',
+            },
+            {
+                'key': 'course-v1:edX+Test2+2024',
+                'aggregation_key': 'course:course-v1:edX+Test2+2024', 'content_type': 'course',
+            },
+            {
+                'key': 'course-v1:edX+Test3+2024',
+                'aggregation_key': 'course:course-v1:edX+Test3+2024', 'content_type': 'course',
+            },
+        ]
+
+        # Mock partition to return only 1 item (simulating a bug where 2 items are "lost")
+        mock_partition.return_value = (
+            [{'content_key': content_key, 'content_type': COURSE}],  # existing_defaults (1 item)
+            [],  # nonexisting_defaults (0 items)
+            [],  # skipped_metadata (0 items)
+        )
+        # Total accounted = 1, but batch size = 3 -> mismatch!
+
+        # Run the function
+        _execute_updates_existing_records_avoid_deadlock(
+            [content_key, 'course-v1:edX+Test2+2024', 'course-v1:edX+Test3+2024'],
+            batch_entries,
+            dry_run=True,
+        )
+
+        # Verify the error was logged
+        mock_logger.error.assert_called_once()
+        call_args = mock_logger.error.call_args
+        self.assertIn('[CONTENT_METADATA_SAFEGUARD]', call_args[0][0])
+        self.assertIn('Batch item count mismatch', call_args[0][0])
+        # Verify the counts are in the log message
+        self.assertEqual(call_args[0][1], 3)  # batch_count
+        self.assertEqual(call_args[0][2], 1)  # accounted_count

--- a/enterprise_catalog/settings/test.py
+++ b/enterprise_catalog/settings/test.py
@@ -30,3 +30,7 @@ CELERY_TASK_ALWAYS_EAGER = True
 
 results_dir = tempfile.TemporaryDirectory()
 CELERY_RESULT_BACKEND = f'file://{results_dir.name}'
+
+# A faster (but less secure) password hasher like MD5 makes UserFactory faster, shaving ~80% off
+# test runtimes compared with the more secure PBKDF2-based hasher used in production.
+PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']


### PR DESCRIPTION
When courses were skipped (unchanged modified timestamp), they were excluded from `metadata_list`. Since catalog associations use `set(metadata_list, clear=True)`, skipped courses were disassociated, causing them to disappear from Algolia search results.

Fix: Return skipped ContentMetadata objects from partition function and include them in the final metadata list for catalog associations.

Added two safeguards to prevent future catalog wipeouts:

1. Batch count validation: Logs error if processed items dont match batch size, catching bugs where items are lost from the pipeline.

2. Zero-association blocker: Blocks setting a non-empty catalog to zero associations, preventing total wipeouts regardless of catalog size.

Generated with Claude Code

## Manual test instructions
I wasn't intentional enough with this in my first go-round. Here's how to test this:
1. pull down this code and restart devserver.
2. Observe a CatalogQuery in http://localhost:18160/admin/catalog/catalogquery/, find a particular record and note the new "Content Count" value.
3. run `./manage.py update_content_metadata --no-async --force`.
4. observe count from step above and verify its the same.
5. run the command again, then re-check your counts as above - should be no change, even though we didn't change the `modified` value on our second run of the job.
6. Check the logs to see the update skip logic still works.
7. run `./manage.py reindex_algolia --no-async --force`, ensure you test index state (count, included catalog query uuids) stays the same.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
