### PR TITLE
chore: let private override devstack settings

### DIFF
--- a/enterprise_catalog/settings/devstack.py
+++ b/enterprise_catalog/settings/devstack.py
@@ -87,3 +87,7 @@ CACHES = {
         'LOCATION': 'enterprise.catalog.memcached:11211',
     }
 }
+
+# Lastly, see if the developer has any local overrides.
+if os.path.isfile(join(dirname(abspath(__file__)), 'private.py')):
+    from .private import *  # pylint: disable=import-error


### PR DESCRIPTION
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
