### PR TITLE
chore: add Claude Code AI enablement [ENT-11674]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,20 @@
+{
+  "permissions": {
+    "allow": [
+      "Skill(quality-tests)",
+      "Skill(unit-tests)"
+    ]
+  },
+  "extraKnownMarketplaces": {
+    "edx-enterprise-team-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "edx/ai-devtools-internal"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "pyright-lsp@claude-plugins-official": true,
+    "edx-enterprise-backend@edx-enterprise-team-marketplace": true
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,69 +2,91 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Repository Overview
+Enterprise Catalog is a Django-based microservice within the Open edX ecosystem that manages enterprise customer catalogs. It acts as an intermediary between enterprise customers and the course catalog, providing curated content based on enterprise-specific requirements and filters, with integrated search capabilities and bulk content management.
 
-Enterprise Catalog is a Django-based microservice that manages enterprise catalogs, associating enterprise customers with curated courses from the full course catalog. It integrates with multiple edX services including course-discovery, LMS, and Algolia for search functionality.
+## Test and Quality Instructions
 
-## Development Commands
+- To run unit tests or generate coverage reports, invoke the `unit-tests` skill.
+- To run quality checks (linting, style), invoke the `quality-tests` skill.
 
-### Testing and Quality
+## Key Principles
 
-You must enter a docker container shell to run tests and linters.
-```bash
-# Run tests via docker container
-docker exec enterprise.catalog.app bash -c "pytest -c pytest.local.ini <TEST_FILES>"
-docker exec enterprise.catalog.app bash -c "make isort style lint"
-```
+- Search the codebase before assuming something isn't implemented
+- Write comprehensive tests with clear documentation
+- Follow Test-Driven Development when refactoring or modifying existing functionality
+- Always write tests for new functionality you implement
+- Keep changes focused and minimal
+- Follow existing code patterns
+- Prefer the `ddt` package for parameterized tests to reduce code duplication
 
-Important: make use of ddt to reduce test setup boilerplate.
+## Documentation & Institutional Memory
+
+- Document new functionality in `docs/how_to/` or `docs/architecture_overview.rst`
+- When you learn something important about how this codebase works (gotchas, non-obvious patterns, integration quirks), add it to the relevant section in `docs/architecture_overview.rst` or create new documentation in `docs/how_to/`
+- These docs are institutional memory - future sessions (yours or others) will benefit from what you record here
+
+## Architecture Overview
+
+This is a Django service for managing enterprise catalogs within the Open edX ecosystem. It curates course content for enterprise customers based on custom filters and provides search integration through Algolia.
+
+Read `docs/architecture_overview.rst` for comprehensive architecture details.
+
+### Core Applications
+
+- **catalog** - Core catalog models (EnterpriseCatalog, CatalogQuery, ContentMetadata) and business logic
+- **api** - REST API endpoints with versioned views (v1, v2), serializers, and filters
+- **api_client** - External service integrations (Discovery, LMS, Algolia, Enterprise)
+- **curation** - Content curation features and content highlights management
+- **ai_curation** - AI-powered content recommendations and curation
+- **video_catalog** - Video content metadata management
+- **jobs** - Enterprise jobs data integration
+- **academy** - Academy content metadata organization
+- **core** - Shared utilities, base models, and common functionality
+- **track** - Analytics and tracking integration
+- **search** - Search functionality and Algolia integration
+
+### Key Concepts
+
+- **EnterpriseCatalog**: Associates enterprise customers with content collections via catalog queries
+- **CatalogQuery**: Defines reusable content filtering rules using JSON-based parameters
+- **ContentMetadata**: Local cache of course/program metadata synchronized from Discovery Service
+- **RestrictedCourseMetadata**: Query-specific versions of courses with filtered restricted runs
+- **Normalized Metadata**: Enterprise Catalog provides normalized metadata fields that create consistent data structures across different course types (open courses vs. executive education)
+
+### External Service Integration
+
+- **Course Discovery Service**: Source of truth for course content and metadata
+- **LMS**: User authentication, OAuth2 provider, and enterprise customer management
+- **Algolia**: Search indexing and query functionality for course discovery
+- **Enterprise Service**: Enterprise customer configuration data
+- **Celery/Redis**: Asynchronous task processing and job queuing
+
+### Local Development
+
+- This service is included in the [edx/devstack](https://github.com/openedx/devstack) repository for integration testing alongside the rest of the Open edX ecosystem
+- Server runs on `localhost:18160`
+- Uses Docker Compose with MySQL 8.0, Memcache, Redis, and multiple Celery workers
+- Celery workers are organized by queue: default, curations, and algolia
 
 ### Management Commands
-Key management commands (run via `docker exec` as you do for tests)
-- `./manage.py update_content_metadata` - Sync content from discovery service to enterprise catalogs
-- `./manage.py update_full_content_metadata` - Fetch additional course metadata
+
+Key management commands (run via `make app-shell` then execute):
+- `./manage.py update_content_metadata` - Sync content from Discovery Service to enterprise catalogs
+- `./manage.py update_full_content_metadata` - Fetch additional detailed course metadata
 - `./manage.py reindex_algolia` - Rebuild Algolia search index
 - `./manage.py migrate` - Apply database migrations
 
 Add `--force` flag to override celery task deduplication (tasks won't run more than once per hour by default).
 
-## Architecture
+### Permissions and Authorization
 
-### Core Apps Structure
-- `enterprise_catalog/apps/catalog/` - Core catalog models and business logic
-- `enterprise_catalog/apps/api/` - REST API endpoints (v1 and v2)
-- `enterprise_catalog/apps/api_client/` - External service clients (Discovery, Enterprise, Algolia, etc.)
-- `enterprise_catalog/apps/curation/` - Content curation and highlights
-- `enterprise_catalog/apps/ai_curation/` - AI-powered content curation
-- `enterprise_catalog/apps/video_catalog/` - Video content management
-- `enterprise_catalog/apps/jobs/` - Enterprise jobs integration
-
-### Key Models
-- `EnterpriseCatalog` - Associates enterprises with content filters
-- `CatalogQuery` - Defines content filtering rules
-- `ContentMetadata` - Cached content from discovery service
-- `EnterpriseCatalogRoleAssignment` - Permission management
-
-### External Integrations
-- **Discovery Service** - Source of truth for course content
-- **LMS** - Authentication and enterprise user management
-- **Algolia** - Search indexing and query functionality
-- **Enterprise Service** - Enterprise customer data
-- **Celery/Redis** - Asynchronous task processing
-
-### Permission System
 Two authorization mechanisms:
-1. JWT Roles encoded in cookies from LMS
-2. Feature-based Role Assignments via `EnterpriseCatalogRoleAssignment` model
+1. **JWT Roles**: Encoded in cookies from LMS (`enterprise_openedx_operator`, `enterprise_catalog_admin`)
+2. **Feature-based Role Assignments**: Persisted via `EnterpriseCatalogRoleAssignment` model
 
-## Development Notes
+## Testing Notes
 
-### Settings
-- Development settings in `enterprise_catalog/settings/`
-- Create `private.py` for local overrides (gitignored)
-- Docker configuration uses `devstack.py` settings
-
-### Monitoring tools
-You can use edx-django-utils `monitoring.function_trace()` decorator to explicitly wrap
-functions as a segment in our monitoring tool (datadog), but we get traces on most python
-view and celery operations out of the box.
+- Uses pytest with Django integration
+- Coverage reporting enabled by default
+- PII annotation checks required for Django models
+- Docker-based test execution via `make app-shell`

--- a/docs/developing-with-ai.md
+++ b/docs/developing-with-ai.md
@@ -1,0 +1,40 @@
+# Developing with AI
+
+This repository supports Claude Code out of the box via a top-level `CLAUDE.md` file and
+team plugins from our shared marketplace.
+
+## Getting Started
+
+For complete setup instructions, security best practices, and workflow guidance, see the
+**[Getting Started with Claude Code](https://github.com/edx/ai-devtools-internal/blob/main/docs/getting-started.md)**
+guide in our team's ai-devtools-internal repository.
+
+## Quick Reference
+
+### Available Skills
+
+| Skill | Command | Description |
+|-------|---------|-------------|
+| Unit Tests | `/unit-tests` | Run Django tests in Docker |
+| Quality Tests | `/quality-tests` | Run linting and style checks |
+
+### Key Files
+
+- `CLAUDE.md` - Project context and instructions for Claude
+- `.claude/settings.json` - Plugin and permission configuration
+- `.claude/settings.local.json` - Personal overrides (gitignored)
+
+### Enabled Plugins
+
+This repo uses the `edx-enterprise-backend` plugin which provides skills for:
+- Django model and query patterns
+- Celery task patterns
+- Security best practices
+- System integration patterns
+
+## Security Reminder
+
+Always ensure you have [gitleaks](https://github.com/gitleaks/gitleaks) installed with a
+pre-commit hook to prevent accidental credential commits. See the
+[Getting Started guide](https://github.com/edx/ai-devtools-internal/blob/main/docs/getting-started.md#security-best-practices)
+for setup instructions.


### PR DESCRIPTION
Add CLAUDE.md, .claude/settings.json, and docs/developing-with-ai.md to enable Claude Code with team plugins from ai-devtools-internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
