### PR TITLE
feat: filter academies by actual content in enterprise catalog (ENT-11220)

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2114,6 +2114,11 @@ class AcademiesViewSetTests(APITestMixin):
         self.enterprise_catalog1.academies.add(self.academy1)
         self.enterprise_catalog2 = EnterpriseCatalogFactory(catalog_query=self.enterprise_catalog_query)
         self.enterprise_catalog2.academies.add(self.academy2)
+        # Create course content metadata linked to academy tags and catalog query
+        # so that the academy passes the content existence check.
+        self.content_metadata = ContentMetadataFactory(content_type=COURSE)
+        self.content_metadata.catalog_queries.add(self.enterprise_catalog_query)
+        self.tag1.content_metadata.add(self.content_metadata)
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
     @mock.patch('enterprise_catalog.apps.api.v1.serializers.get_initialized_algolia_client')
@@ -2168,6 +2173,34 @@ class AcademiesViewSetTests(APITestMixin):
             response.data['tags'][0].get('title'),
             self.mock_algolia_hits['facetHits'][0]['value']
         )
+
+    @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
+    @mock.patch('enterprise_catalog.apps.api.v1.serializers.get_initialized_algolia_client')
+    def test_list_excludes_academy_without_course_content(self, mock_algolia_client, mock_client):  # pylint: disable=unused-argument
+        """
+        Verify the viewset excludes an academy when its catalog is associated
+        but has no matching course content in the catalog query.
+        """
+        mock_algolia_client.return_value.algolia_index.search_for_facet_values.side_effect = [
+            self.mock_algolia_hits, {'facetHits': []}
+        ]
+        # Create an academy with a catalog association but explicitly no content metadata.
+        academy_no_content = AcademyFactory()
+        tag_no_content = TagFactory(title='empty-tag')
+        tag_no_content.content_metadata.clear()
+        academy_no_content.tags.add(tag_no_content)
+        enterprise_catalog_no_content = EnterpriseCatalogFactory(
+            catalog_query=CatalogQueryFactory(uuid=uuid.uuid4()),
+        )
+        enterprise_catalog_no_content.academies.add(academy_no_content)
+
+        params = {
+            'enterprise_customer': str(enterprise_catalog_no_content.enterprise_customer.uuid),
+        }
+        url = reverse('api:v1:academies-list') + '?{}'.format(urlencode(params))
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 0)
 
     def test_list_with_missing_enterprise_customer(self):
         """

--- a/enterprise_catalog/apps/api/v1/views/academies.py
+++ b/enterprise_catalog/apps/api/v1/views/academies.py
@@ -11,6 +11,8 @@ from rest_framework_xml.renderers import XMLRenderer
 
 from enterprise_catalog.apps.academy.models import Academy
 from enterprise_catalog.apps.api.v1.serializers import AcademySerializer
+from enterprise_catalog.apps.catalog.constants import COURSE
+from enterprise_catalog.apps.catalog.models import ContentMetadata
 
 
 class AcademiesReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
@@ -53,7 +55,16 @@ class AcademiesReadOnlyViewSet(viewsets.ReadOnlyModelViewSet):
                     enterprise_associated_catalogs = academy_associated_catalogs.filter(
                         enterprise_uuid=enterprise_customer
                     )
-                    if enterprise_associated_catalogs:
+                    # Verify the academy has actual course content in the enterprise catalog.
+                    catalog_query_ids = enterprise_associated_catalogs.values_list(
+                        'catalog_query_id', flat=True,
+                    )
+                    has_content = ContentMetadata.objects.filter(
+                        tags__academies=academy,
+                        content_type=COURSE,
+                        catalog_queries__in=catalog_query_ids,
+                    ).exists()
+                    if has_content:
                         user_accessible_academy_uuids.append(academy.uuid)
                 return all_academies.filter(uuid__in=user_accessible_academy_uuids)
             else:


### PR DESCRIPTION
## Context

As part of ENT-11220, Academies is being enabled by default for all Teams and Enterprise Subscription customers with search enabled.

**Acceptance Criteria (ENT-11220):**
> If a customer does not have Academy courses in their subscription catalog, then they should not be able to see Academies.

This PR is **mandatory** to fulfill the above AC. Without it, the ticket is incomplete.

## Why This Change Is Required

### The Problem (without this change)

The current academies API (`AcademiesReadOnlyViewSet.get_queryset`) only checks if an academy's catalog is **associated** with the enterprise customer:

```python
# Current code - only checks catalog association
if enterprise_associated_catalogs:
    user_accessible_academy_uuids.append(academy.uuid)  # ← always adds if associated
```

This means: if an academy's catalog is linked to an enterprise but the catalog **does not actually contain the academy's courses**, the learner still sees the academy tile. They click it and find zero or partial courses — a broken experience that **violates the AC**.

### The Fix (this PR)

We now verify that the academy has **actual course content** in the enterprise's catalog before showing it:

```python
# New code - checks catalog association AND content existence
if enterprise_associated_catalogs:
    academy_content = ContentMetadata.objects.filter(tags__academies=academy)
    catalog_query_ids = enterprise_associated_catalogs.values_list('catalog_query_id', flat=True)
    if academy_content.filter(catalog_queries__in=catalog_query_ids).exists():
        user_accessible_academy_uuids.append(academy.uuid)  # ← only adds if content exists
```

**Data flow:**
```
Academy → Tags → ContentMetadata (courses in the academy)
                        ↓
              catalog_queries (M2M)
                        ↓
              CatalogQuery ← EnterpriseCatalog (customer's catalog)
                        ↓
              If content overlap exists → show academy
              If no content overlap → hide academy
```

## Files Changed

| File | Change | Why |
|------|--------|-----|
| `views/academies.py` (line 12) | Added `ContentMetadata` import | Required for the content check query |
| `views/academies.py` (lines 49-55) | Added content existence check | Ensures academy has actual courses in the catalog before showing it |
| `tests/test_views.py` (lines 2072-2074) | Added `ContentMetadata` to test setup | Tests need content data to validate the new filtering logic |

## What Happens Without This PR

| Scenario | Without this PR | With this PR |
|----------|----------------|--------------|
| Academy catalog associated AND has courses | ✅ Shows academy | ✅ Shows academy |
| Academy catalog associated but NO courses in catalog | ❌ Shows empty academy (AC violated) | ✅ Hides academy (AC met) |
| No catalog association | ✅ Hidden | ✅ Hidden |

## Related PR
- https://github.com/openedx/edx-enterprise/pull/2594 (model default `True` + data migration for existing customers)

## Ticket
https://2u-internal.atlassian.net/browse/ENT-11220

## Test plan
- [ ] Verify academies API returns academies only when actual course content exists in the enterprise catalog
- [ ] Verify academies API returns empty list when catalog is associated but has no matching course content
- [ ] Verify all 4 existing academy tests pass (`AcademiesViewSetTests`)