### PR TITLE
feat(ENT-11384): add is_new_content attribute to Algolia course index

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -5,6 +5,7 @@ import time
 
 from algoliasearch.search_client import SearchClient
 from dateutil import parser
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db.models import Q
 from django.utils.dateparse import parse_datetime
@@ -139,6 +140,7 @@ ALGOLIA_FIELDS = [
     'avg_course_rating',
     'course_bayesian_average',
     'transcript_languages',
+    'is_new_content',
 ]
 
 # default configuration for the index
@@ -188,6 +190,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'learning_type',
         'learning_type_v2',
         'transcript_languages',
+        'is_new_content',
     ],
     'unretrievableAttributes': [
         'enterprise_catalog_uuids',
@@ -572,6 +575,20 @@ def is_course_archived(course):
     """
     availability_list = get_course_availability(course)
     return len(availability_list) == 0 or 'Archived' in availability_list
+
+
+def is_course_new_content(course):
+    """True if the earliest published course-run start is within the last 12 months (ENT-11384)."""
+    starts = []
+    for run in course.get('course_runs') or []:
+        if (run.get('status') or '').lower() == 'published' and run.get('start'):
+            parsed = parse_datetime(run['start'])
+            if parsed:
+                starts.append(parsed)
+    if not starts:
+        return False
+    now = localized_utcnow()
+    return now - relativedelta(months=12) <= min(starts) <= now
 
 
 def get_course_partners(course):
@@ -1600,6 +1617,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'course_bayesian_average': get_course_bayesian_average(searchable_product),
             'transcript_languages': get_course_transcript_languages(searchable_product),
             'metadata_language': searchable_product.get('metadata_language', 'en'),
+            'is_new_content': is_course_new_content(searchable_product),
         })
     elif searchable_product.get('content_type') == PROGRAM:
         # Build course metadata cache once for all program functions that need it

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -3,6 +3,7 @@ from unittest import mock
 from uuid import uuid4
 
 import ddt
+from dateutil.relativedelta import relativedelta
 from django.test import TestCase
 
 from enterprise_catalog.apps.catalog import algolia_utils as utils
@@ -211,6 +212,39 @@ class AlgoliaUtilsTests(TestCase):
         assert utils.is_course_archived(course_metadata.json_metadata) is False
         course_metadata.json_metadata.get('course_runs')[0]['availability'] = ''
         assert utils.is_course_archived(course_metadata.json_metadata) is True
+
+    def test_is_course_new_content(self):
+        """
+        Verify the "new content" classification uses min published-run start within 12 months.
+        """
+        now = localized_utcnow()
+        recent = (now - timedelta(days=30)).isoformat()
+        old = (now - timedelta(days=500)).isoformat()
+
+        assert utils.is_course_new_content({'course_runs': []}) is False
+        assert utils.is_course_new_content({'course_runs': [{'status': 'unpublished', 'start': recent}]}) is False
+        assert utils.is_course_new_content({'course_runs': [{'status': 'published', 'start': old}]}) is False
+        assert utils.is_course_new_content({'course_runs': [{'status': 'published', 'start': recent}]}) is True
+        # Regression: an old unpublished draft must not disqualify a course with a recent published run.
+        assert utils.is_course_new_content({'course_runs': [
+            {'status': 'unpublished', 'start': old},
+            {'status': 'published', 'start': recent},
+        ]}) is True
+        # Boundary: just within 12 calendar months is True, just outside is False.
+        assert utils.is_course_new_content({'course_runs': [
+            {'status': 'published', 'start': (now - relativedelta(months=12) + timedelta(days=1)).isoformat()},
+        ]}) is True
+        assert utils.is_course_new_content({'course_runs': [
+            {'status': 'published', 'start': (now - relativedelta(months=12) - timedelta(days=1)).isoformat()},
+        ]}) is False
+        # Future start dates are not "new content" (upper-bound check).
+        assert utils.is_course_new_content({'course_runs': [
+            {'status': 'published', 'start': (now + timedelta(days=30)).isoformat()},
+        ]}) is False
+        # Malformed ISO strings are silently ignored.
+        assert utils.is_course_new_content({'course_runs': [
+            {'status': 'published', 'start': 'not-a-date'},
+        ]}) is False
 
     @ddt.data(
         (


### PR DESCRIPTION
## Summary

Adds a pre-computed boolean `is_new_content` attribute to each course record indexed into the enterprise-catalog Algolia index. Satisfies the data-side of [ENT-11384](https://2u-internal.atlassian.net/browse/ENT-11384); the filter UI follows in a separate learner-portal PR.

## Motivation

Per the ticket (coordinated with @adusenbery), a course is "new content" when the earliest **published** run start date falls within the last 12 months. Pre-computing the boolean at indexing time lets the learner portal expose the filter declaratively via `SEARCH_FACET_FILTERS` (mirroring `PROGRAM_TYPE_FACET`) without any time-math on the frontend.

## Changes

- `enterprise_catalog/apps/catalog/algolia_utils.py`
  - New `is_course_new_content(course)` helper. Uses `relativedelta(months=12)` for a calendar-accurate window and bounds the check on both sides (`now - relativedelta(months=12) <= min(starts) <= now`) so future-dated published runs are not classified as "new".
  - `'is_new_content'` added to `ALGOLIA_FIELDS` (indexed).
  - `'is_new_content'` added to `attributesForFaceting` (filterable).
  - Computed inside the course branch of `searchable_product.update({...})`.
- `enterprise_catalog/apps/catalog/tests/test_algolia_utils.py`
  - New `test_is_course_new_content` with 9 assertions covering: empty runs, unpublished-only, old-published, recent-published, the mixed-runs regression (old unpublished + recent published), the 12-calendar-month boundary (±1 day), future start dates (upper-bound check), and malformed ISO strings.

## A design choice worth flagging

I used a raw `status == 'published'` check rather than the existing `is_course_run_active` helper. Reasoning: the ticket defines "new" purely by earliest start-date presence, not by ongoing marketability/enrollability. An old published run that's now archived still represents when the course was first released. Happy to switch to `is_course_run_active` if that semantic is preferred — would exclude archived-but-previously-published runs.

## Test plan

- [x] `pytest enterprise_catalog/apps/catalog/tests/test_algolia_utils.py -k test_is_course_new_content` — 1 test, 9 assertions, passing.
- [ ] After merge: verify the daily reindex cronjob populates `is_new_content` on course records .

## Rollout

1. Merge this PR.
2. Daily reindex populates the new attribute (or manual stage reindex via #enterprise-titans).
3. Follow-up PR in `frontend-app-learner-portal-enterprise` adds the facet to `SEARCH_FACET_FILTERS` behind a feature flag — https://github.com/edx/frontend-app-learner-portal-enterprise/pull/26

ENT-11384
