### PR TITLE
feat: throttle non-staff users on get_content_metadata endpoint

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -9,7 +9,9 @@ from urllib.parse import urljoin
 import ddt
 import pytz
 from django.conf import settings
+from django.core.cache import cache
 from django.db import IntegrityError
+from django.test import override_settings
 from django.utils.http import urlencode
 from django.utils.text import slugify
 from rest_framework import status
@@ -1776,6 +1778,74 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
             json.dumps(actual_metadata, sort_keys=True),
             json.dumps(expected_metadata, sort_keys=True),
         )
+
+
+def _throttle_rates_override(hour_rate, minute_rate):
+    """
+    Build a REST_FRAMEWORK override dict with the given rates so throttle
+    tests can enable low limits without affecting other tests.
+    """
+    return {
+        **settings.REST_FRAMEWORK,
+        'DEFAULT_THROTTLE_RATES': {
+            'get_content_metadata_hour': hour_rate,
+            'get_content_metadata_minute': minute_rate,
+        },
+    }
+
+
+@ddt.ddt
+class EnterpriseCatalogGetContentMetadataThrottleTests(APITestMixin):
+    """
+    Tests that non-staff users are rate limited on the get_content_metadata endpoint
+    and that staff users bypass the limits entirely.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.enterprise_catalog = EnterpriseCatalogFactory(enterprise_uuid=self.enterprise_uuid)
+        self.enterprise_catalog.catalog_query.save()
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+        super().tearDown()
+
+    def _url(self):
+        return reverse('api:v1:get-content-metadata', kwargs={'uuid': self.enterprise_catalog.uuid})
+
+    @ddt.data(
+        ('2/hour', None),
+        (None, '2/minute'),
+    )
+    @ddt.unpack
+    def test_non_staff_user_is_throttled(self, hour_rate, minute_rate):
+        """
+        Non-staff users should receive 429 once they exceed either the per-minute
+        or per-hour limit. Only one scope is active per parameterization so each
+        case isolates a single throttle class.
+        """
+        self.set_up_catalog_learner()
+        url = self._url()
+        with override_settings(REST_FRAMEWORK=_throttle_rates_override(hour_rate, minute_rate)):
+            for _ in range(2):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    def test_staff_user_is_not_throttled(self):
+        """
+        Staff users should bypass throttling even when both rates are set to
+        extremely restrictive values.
+        """
+        self.set_up_staff()
+        url = self._url()
+        with override_settings(REST_FRAMEWORK=_throttle_rates_override('1/hour', '1/minute')):
+            for _ in range(5):
+                response = self.client.get(url)
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):

--- a/enterprise_catalog/apps/api/v1/throttles.py
+++ b/enterprise_catalog/apps/api/v1/throttles.py
@@ -1,0 +1,39 @@
+"""
+Throttle classes for v1 API endpoints.
+
+Rates are configured in ``REST_FRAMEWORK['DEFAULT_THROTTLE_RATES']`` keyed by
+each class's ``scope``. We override ``get_rate`` to read live from DRF's
+``api_settings`` so that ``override_settings`` works in tests — DRF's default
+implementation caches ``THROTTLE_RATES`` as a class attribute at import time.
+"""
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework.settings import api_settings
+from rest_framework.throttling import UserRateThrottle
+
+
+class NonStaffUserRateThrottleMixin:
+    """
+    Skip rate limiting for staff users and read the rate live from settings so
+    ``override_settings(REST_FRAMEWORK=...)`` takes effect in tests.
+    """
+    def get_rate(self):
+        try:
+            return api_settings.DEFAULT_THROTTLE_RATES[self.scope]
+        except KeyError as exc:  # pragma: no cover
+            raise ImproperlyConfigured(
+                f"No default throttle rate set for '{self.scope}' scope"
+            ) from exc
+
+    def allow_request(self, request, view):
+        user = getattr(request, 'user', None)
+        if user is not None and user.is_authenticated and user.is_staff:
+            return True
+        return super().allow_request(request, view)
+
+
+class GetContentMetadataHourlyThrottle(NonStaffUserRateThrottleMixin, UserRateThrottle):
+    scope = 'get_content_metadata_hour'
+
+
+class GetContentMetadataMinuteThrottle(NonStaffUserRateThrottleMixin, UserRateThrottle):
+    scope = 'get_content_metadata_minute'

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -21,6 +21,10 @@ from enterprise_catalog.apps.api.v1.serializers import (
     ContentMetadataListResponseSerializer,
     ContentMetadataSerializer,
 )
+from enterprise_catalog.apps.api.v1.throttles import (
+    GetContentMetadataHourlyThrottle,
+    GetContentMetadataMinuteThrottle,
+)
 from enterprise_catalog.apps.api.v1.utils import is_any_course_run_active
 from enterprise_catalog.apps.api.v1.views.base import BaseViewSet
 from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
@@ -35,6 +39,7 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
     renderer_classes = [JSONRenderer, XMLRenderer]
     lookup_field = 'uuid'
     pagination_class = DefaultPagination
+    throttle_classes = [GetContentMetadataHourlyThrottle, GetContentMetadataMinuteThrottle]
     MAX_GET_CONTENT_KEYS = 100
 
     @cached_property

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -142,12 +142,17 @@ DATABASES = {
 }
 
 # Django Rest Framework
+DEFAULT_THROTTLE_RATES = {
+    'get_content_metadata_hour': '120/hour',
+    'get_content_metadata_minute': '6/minute',
+}
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'edx_rest_framework_extensions.paginators.DefaultPagination',
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_THROTTLE_RATES': DEFAULT_THROTTLE_RATES,
     'PAGE_SIZE': 10,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/enterprise_catalog/settings/test.py
+++ b/enterprise_catalog/settings/test.py
@@ -34,3 +34,13 @@ CELERY_RESULT_BACKEND = f'file://{results_dir.name}'
 # A faster (but less secure) password hasher like MD5 makes UserFactory faster, shaving ~80% off
 # test runtimes compared with the more secure PBKDF2-based hasher used in production.
 PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
+
+# Disable API throttling by default in tests; individual tests can re-enable
+# specific rates via ``override_settings``. DRF treats a ``None`` rate as no limit.
+REST_FRAMEWORK = {
+    **REST_FRAMEWORK,
+    'DEFAULT_THROTTLE_RATES': {
+        'get_content_metadata_hour': None,
+        'get_content_metadata_minute': None,
+    },
+}


### PR DESCRIPTION
Adds per-user rate limits of 120/hour and 6/minute to the EnterpriseCatalogGetContentMetadata viewset. Staff users bypass both limits.

https://2u-internal.atlassian.net/browse/ENT-11483

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
