### PR TITLE
feat(ENT-10745): add set-content endpoint to reconcile HighlightSet contents

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -445,6 +445,21 @@ class HighlightSetSerializer(serializers.ModelSerializer):
         return HighlightedContentSerializer(qs, many=True, context=self.context).data
 
 
+class HighlightSetReconcileResponseSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Response shape for the `set-content` admin action on `HighlightSetViewSet`.
+
+    The endpoint reconciles a HighlightSet's membership to a requested list of
+    content keys; this serializer encapsulates the per-bucket breakdown of what
+    changed plus the final serialized HighlightSet.
+    """
+    added_content_keys = serializers.ListField(child=serializers.CharField())
+    removed_content_keys = serializers.ListField(child=serializers.CharField())
+    existing_content_keys = serializers.ListField(child=serializers.CharField())
+    ignored_content_keys = serializers.ListField(child=serializers.CharField())
+    highlight_set = HighlightSetSerializer()
+
+
 class EnterpriseCurationConfigSerializer(serializers.ModelSerializer):
     """
     Serializer for the `EnterpriseCurationConfig` model.

--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -972,6 +972,211 @@ class HighlightSetViewSetTests(CurationAPITestBase):
             },
         )
 
+    @mock.patch('enterprise_catalog.apps.api.v1.event_utils.track_event')
+    def test_set_content_replaces_full(self, mock_track_event):
+        """
+        set-content with a list of brand-new content keys replaces the entire set:
+        all pre-existing items are removed and all new items are added.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+        new_content_metadata = [ContentMetadataFactory(content_type=COURSE) for _ in range(3)]
+        new_keys = [cm.content_key for cm in new_content_metadata]
+
+        response = self.client.post(url, {'content_keys': new_keys})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert sorted(body['added_content_keys']) == sorted(new_keys)
+        assert sorted(body['removed_content_keys']) == sorted(original_keys)
+        assert body['existing_content_keys'] == []
+        assert body['ignored_content_keys'] == []
+
+        final_keys = [hc['content_key'] for hc in body['highlight_set']['highlighted_content']]
+        assert sorted(final_keys) == sorted(new_keys)
+
+        mock_track_event.assert_called_once_with(
+            STATIC_LMS_USER_ID,
+            SegmentEvents.HIGHLIGHT_SET_UPDATED,
+            {
+                'highlight_set_uuid': str(self.highlight_set_one.uuid),
+                'enterprise_customer_uuid': str(self.curation_config_one.enterprise_uuid),
+                'enterprise_curation_uuid': str(self.curation_config_one.uuid),
+                'added_content_keys': mock.ANY,
+                'removed_content_keys': mock.ANY,
+            },
+        )
+        call_props = mock_track_event.call_args[0][2]
+        assert sorted(call_props['added_content_keys']) == sorted(new_keys)
+        assert sorted(call_props['removed_content_keys']) == sorted(original_keys)
+
+    def test_set_content_with_overlap(self):
+        """
+        set-content with a mix of existing and new keys: only the diff is mutated.
+        Existing keys stay (reported as 'existing'), missing keys are removed, new keys are added.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+        keep_keys = original_keys[:3]
+        drop_keys = original_keys[3:]
+        new_content_metadata = [ContentMetadataFactory(content_type=COURSE) for _ in range(2)]
+        new_keys = [cm.content_key for cm in new_content_metadata]
+        requested = keep_keys + new_keys
+
+        response = self.client.post(url, {'content_keys': requested})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert sorted(body['added_content_keys']) == sorted(new_keys)
+        assert sorted(body['removed_content_keys']) == sorted(drop_keys)
+        assert sorted(body['existing_content_keys']) == sorted(keep_keys)
+        assert body['ignored_content_keys'] == []
+
+        final_keys = [hc['content_key'] for hc in body['highlight_set']['highlighted_content']]
+        assert sorted(final_keys) == sorted(requested)
+
+    def test_set_content_preserves_existing_order(self):
+        """
+        set-content reconciles membership only; it does not reorder rows already
+        on the set based on the position of keys in the request. Posting the
+        existing keys in reversed order is a no-op for ordering.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+        pre_response = self.client.get(
+            reverse('api:v1:highlight-sets-admin-detail', kwargs={'uuid': str(self.highlight_set_one.uuid)})
+        )
+        pre_order = [hc['content_key'] for hc in pre_response.json()['highlighted_content']]
+
+        response = self.client.post(url, {'content_keys': list(reversed(original_keys))})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert body['added_content_keys'] == []
+        assert body['removed_content_keys'] == []
+        assert sorted(body['existing_content_keys']) == sorted(original_keys)
+
+        final_keys = [hc['content_key'] for hc in body['highlight_set']['highlighted_content']]
+        assert final_keys == pre_order
+
+    def test_set_content_with_empty_list_clears_set(self):
+        """
+        set-content with an empty list removes all highlighted content from the set.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+
+        response = self.client.post(url, {'content_keys': []})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert body['added_content_keys'] == []
+        assert sorted(body['removed_content_keys']) == sorted(original_keys)
+        assert body['highlight_set']['highlighted_content'] == []
+
+    def test_set_content_exceeds_limit(self):
+        """
+        set-content with more than CONTENT_PER_HIGHLIGHTSET_LIMIT keys is rejected with 403
+        and leaves the existing highlight set untouched.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+        too_many_content = [
+            ContentMetadataFactory(content_type=COURSE)
+            for _ in range(CONTENT_PER_HIGHLIGHTSET_LIMIT + 1)
+        ]
+        too_many_keys = [cm.content_key for cm in too_many_content]
+
+        response = self.client.post(url, {'content_keys': too_many_keys})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert 'exceeds' in response.json()['Error']
+
+        # Original contents untouched.
+        self.highlight_set_one.refresh_from_db()
+        assert self.highlight_set_one.highlighted_content.count() == len(self.highlighted_content_metadata_one)
+
+    def test_set_content_ignores_unknown_keys(self):
+        """
+        Content keys that don't correspond to any ContentMetadata row are returned as 'ignored'
+        rather than causing a failure.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+        real_content = ContentMetadataFactory(content_type=COURSE)
+        requested = [real_content.content_key, 'course-v1:bogus+NOPE+2026']
+
+        response = self.client.post(url, {'content_keys': requested})
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body['added_content_keys'] == [real_content.content_key]
+        assert body['ignored_content_keys'] == ['course-v1:bogus+NOPE+2026']
+
+    @ddt.data(
+        ({}, 'missing field'),
+        ({'content_keys': None}, 'null value'),
+        ({'content_keys': 'course-v1:edX+DemoX+Demo_Course'}, 'non-list string'),
+        ({'content_keys': {'foo': 'bar'}}, 'non-list dict'),
+    )
+    @ddt.unpack
+    def test_set_content_rejects_invalid_payload(self, payload, _label):
+        """
+        A request whose body is missing `content_keys` or whose value is not a list
+        must return 400 and leave the HighlightSet untouched. An explicit empty list
+        ([]) is the only way to clear the set.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+        original_count = self.highlight_set_one.highlighted_content.count()
+        assert original_count > 0  # sanity: the fixture has items to lose
+
+        response = self.client.post(url, payload, format='json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'content_keys' in response.json()['Error']
+
+        # Set is untouched: nothing was cleared.
+        self.highlight_set_one.refresh_from_db()
+        assert self.highlight_set_one.highlighted_content.count() == original_count
+
+    def test_set_content_unauthorized_other_customer(self):
+        """
+        A staff user for customer one cannot reconcile customer two's highlight set.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_two.uuid)},
+        )
+        self.set_up_staff()
+        response = self.client.post(url, {'content_keys': []})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     @ddt.data(
         {'highlight_set_exists': False},
         {'highlight_set_exists': False},

--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -972,6 +972,153 @@ class HighlightSetViewSetTests(CurationAPITestBase):
             },
         )
 
+    @mock.patch('enterprise_catalog.apps.api.v1.event_utils.track_event')
+    def test_set_content_replaces_full(self, mock_track_event):
+        """
+        set-content with a list of brand-new content keys replaces the entire set:
+        all pre-existing items are removed and all new items are added.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+        new_content_metadata = [ContentMetadataFactory(content_type=COURSE) for _ in range(3)]
+        new_keys = [cm.content_key for cm in new_content_metadata]
+
+        response = self.client.post(url, {'content_keys': new_keys})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert sorted(body['added_content_keys']) == sorted(new_keys)
+        assert sorted(body['removed_content_keys']) == sorted(original_keys)
+        assert body['existing_content_keys'] == []
+        assert body['ignored_content_keys'] == []
+
+        final_keys = [hc['content_key'] for hc in body['highlight_set']['highlighted_content']]
+        assert sorted(final_keys) == sorted(new_keys)
+
+        mock_track_event.assert_called_once_with(
+            STATIC_LMS_USER_ID,
+            SegmentEvents.HIGHLIGHT_SET_UPDATED,
+            {
+                'highlight_set_uuid': str(self.highlight_set_one.uuid),
+                'enterprise_customer_uuid': str(self.curation_config_one.enterprise_uuid),
+                'enterprise_curation_uuid': str(self.curation_config_one.uuid),
+                'added_content_keys': mock.ANY,
+                'removed_content_keys': mock.ANY,
+            },
+        )
+        call_props = mock_track_event.call_args[0][2]
+        assert sorted(call_props['added_content_keys']) == sorted(new_keys)
+        assert sorted(call_props['removed_content_keys']) == sorted(original_keys)
+
+    def test_set_content_with_overlap(self):
+        """
+        set-content with a mix of existing and new keys: only the diff is mutated.
+        Existing keys stay (reported as 'existing'), missing keys are removed, new keys are added.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+        keep_keys = original_keys[:3]
+        drop_keys = original_keys[3:]
+        new_content_metadata = [ContentMetadataFactory(content_type=COURSE) for _ in range(2)]
+        new_keys = [cm.content_key for cm in new_content_metadata]
+        requested = keep_keys + new_keys
+
+        response = self.client.post(url, {'content_keys': requested})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert sorted(body['added_content_keys']) == sorted(new_keys)
+        assert sorted(body['removed_content_keys']) == sorted(drop_keys)
+        assert sorted(body['existing_content_keys']) == sorted(keep_keys)
+        assert body['ignored_content_keys'] == []
+
+        final_keys = [hc['content_key'] for hc in body['highlight_set']['highlighted_content']]
+        assert sorted(final_keys) == sorted(requested)
+
+    def test_set_content_with_empty_list_clears_set(self):
+        """
+        set-content with an empty list removes all highlighted content from the set.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+
+        response = self.client.post(url, {'content_keys': []})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert body['added_content_keys'] == []
+        assert sorted(body['removed_content_keys']) == sorted(original_keys)
+        assert body['highlight_set']['highlighted_content'] == []
+
+    def test_set_content_exceeds_limit(self):
+        """
+        set-content with more than CONTENT_PER_HIGHLIGHTSET_LIMIT keys is rejected with 403
+        and leaves the existing highlight set untouched.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+        too_many_content = [
+            ContentMetadataFactory(content_type=COURSE)
+            for _ in range(CONTENT_PER_HIGHLIGHTSET_LIMIT + 1)
+        ]
+        too_many_keys = [cm.content_key for cm in too_many_content]
+
+        response = self.client.post(url, {'content_keys': too_many_keys})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert 'exceeds' in response.json()['Error']
+
+        # Original contents untouched.
+        self.highlight_set_one.refresh_from_db()
+        assert self.highlight_set_one.highlighted_content.count() == len(self.highlighted_content_metadata_one)
+
+    def test_set_content_ignores_unknown_keys(self):
+        """
+        Content keys that don't correspond to any ContentMetadata row are returned as 'ignored'
+        rather than causing a failure.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+        real_content = ContentMetadataFactory(content_type=COURSE)
+        requested = [real_content.content_key, 'course-v1:bogus+NOPE+2026']
+
+        response = self.client.post(url, {'content_keys': requested})
+        assert response.status_code == status.HTTP_200_OK
+        body = response.json()
+        assert body['added_content_keys'] == [real_content.content_key]
+        assert body['ignored_content_keys'] == ['course-v1:bogus+NOPE+2026']
+
+    def test_set_content_unauthorized_other_customer(self):
+        """
+        A staff user for customer one cannot reconcile customer two's highlight set.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_two.uuid)},
+        )
+        self.set_up_staff()
+        response = self.client.post(url, {'content_keys': []})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
     @ddt.data(
         {'highlight_set_exists': False},
         {'highlight_set_exists': False},

--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -1045,6 +1045,35 @@ class HighlightSetViewSetTests(CurationAPITestBase):
         final_keys = [hc['content_key'] for hc in body['highlight_set']['highlighted_content']]
         assert sorted(final_keys) == sorted(requested)
 
+    def test_set_content_preserves_existing_order(self):
+        """
+        set-content reconciles membership only; it does not reorder rows already
+        on the set based on the position of keys in the request. Posting the
+        existing keys in reversed order is a no-op for ordering.
+        """
+        url = reverse(
+            'api:v1:highlight-sets-admin-set-content',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)},
+        )
+        self.set_up_staff()
+
+        original_keys = [cm.content_key for cm in self.highlighted_content_metadata_one]
+        pre_response = self.client.get(
+            reverse('api:v1:highlight-sets-admin-detail', kwargs={'uuid': str(self.highlight_set_one.uuid)})
+        )
+        pre_order = [hc['content_key'] for hc in pre_response.json()['highlighted_content']]
+
+        response = self.client.post(url, {'content_keys': list(reversed(original_keys))})
+        assert response.status_code == status.HTTP_200_OK
+
+        body = response.json()
+        assert body['added_content_keys'] == []
+        assert body['removed_content_keys'] == []
+        assert sorted(body['existing_content_keys']) == sorted(original_keys)
+
+        final_keys = [hc['content_key'] for hc in body['highlight_set']['highlighted_content']]
+        assert final_keys == pre_order
+
     def test_set_content_with_empty_list_clears_set(self):
         """
         set-content with an empty list removes all highlighted content from the set.

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -1,6 +1,7 @@
 import logging
 from uuid import UUID
 
+from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie
@@ -649,6 +650,92 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                 'highlight_set': HighlightSetSerializer(highlight_set).data,
             },
             status=status.HTTP_201_CREATED,
+        )
+
+    @action(detail=True, methods=['post'], url_path='set-content')
+    def set_content(self, request, uuid, *args, **kwargs):
+        """
+        Replace the full contents of an existing HighlightSet.
+
+        Reconciles HighlightedContent rows so the set contains exactly the
+        provided content_keys: items not present are added, and items
+        currently on the set but not in the request are removed.
+
+        POST /v1/highlight-sets-admin/<uuid>/set-content/
+
+        Request URL Arguments:
+            uuid (str): UUID of the HighlightSet to edit.
+
+        Request JSON Arguments:
+            content_keys (list of str): The desired final list of content keys
+                for the HighlightSet.  Pass an empty list to clear the set.
+
+        Returns:
+            rest_framework.response.Response:
+                400: Missing/invalid input parameters.
+                403: Insufficient write permissions, or requested content count
+                     exceeds the backend limit.
+                200: Contents were reconciled successfully.  Body shape:
+                     {
+                         "added_content_keys": [...],
+                         "removed_content_keys": [...],
+                         "existing_content_keys": [...],
+                         "ignored_content_keys": [...],
+                         "highlight_set": <serialized HighlightSet>,
+                     }
+        """
+        requested_content_keys = self.requested_content_keys
+
+        if len(requested_content_keys) > CONTENT_PER_HIGHLIGHTSET_LIMIT:
+            return Response(
+                {
+                    'Error': (
+                        'Request exceeds the backend maximum content count per highlight set '
+                        f'({CONTENT_PER_HIGHLIGHTSET_LIMIT}).'
+                    ),
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        highlight_set = HighlightSet.objects.get(uuid=uuid)
+
+        with transaction.atomic():
+            current_content_keys = set(
+                highlight_set.highlighted_content.values_list(
+                    'content_metadata__content_key', flat=True,
+                )
+            )
+            removed_content_keys = list(current_content_keys - set(requested_content_keys))
+            if removed_content_keys:
+                highlight_set.highlighted_content.filter(
+                    content_metadata__content_key__in=removed_content_keys,
+                ).delete()
+
+            try:
+                added_content_keys, ignored_content_keys, existing_content_keys = (
+                    self._add_requested_content(highlight_set)
+                )
+            except LimitExceeded as e:
+                return Response({'Error': str(e)}, status=status.HTTP_403_FORBIDDEN)
+
+        additional_properties = {
+            'added_content_keys': added_content_keys,
+            'removed_content_keys': removed_content_keys,
+        }
+        track_highlight_set_changes(
+            request, highlight_set, SegmentEvents.HIGHLIGHT_SET_UPDATED,
+            additional_properties=additional_properties,
+        )
+
+        return Response(
+            {
+                'added_content_keys': added_content_keys,
+                'removed_content_keys': removed_content_keys,
+                'existing_content_keys': existing_content_keys,
+                'ignored_content_keys': ignored_content_keys,
+                'highlight_set': HighlightSetSerializer(highlight_set).data,
+            },
+            status=status.HTTP_200_OK,
         )
 
     @action(detail=True, methods=['post'], url_path='remove-content')

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -661,6 +661,11 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         provided content_keys: items not present are added, and items
         currently on the set but not in the request are removed.
 
+        This endpoint reconciles membership only; the ordering of items
+        already on the set is preserved (newly-added items are appended).
+        The position of a content_key within the request list is not used
+        to reorder existing rows.
+
         POST /v1/highlight-sets-admin/<uuid>/set-content/
 
         Request URL Arguments:

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -1,6 +1,7 @@
 import logging
 from uuid import UUID
 
+from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
 from django.views.decorators.vary import vary_on_cookie
@@ -28,6 +29,7 @@ from enterprise_catalog.apps.api.v1.event_utils import (
 from enterprise_catalog.apps.api.v1.serializers import (
     ContentMetadataSerializer,
     EnterpriseCurationConfigSerializer,
+    HighlightSetReconcileResponseSerializer,
     HighlightSetSerializer,
 )
 from enterprise_catalog.apps.api.v1.utils import str_to_bool
@@ -650,6 +652,104 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
             },
             status=status.HTTP_201_CREATED,
         )
+
+    @action(detail=True, methods=['post'], url_path='set-content')
+    def set_content(self, request, uuid, *args, **kwargs):
+        """
+        Replace the full contents of an existing HighlightSet.
+
+        Reconciles HighlightedContent rows so the set contains exactly the
+        provided content_keys: items not present are added, and items
+        currently on the set but not in the request are removed.
+
+        This endpoint reconciles membership only; the ordering of items
+        already on the set is preserved (newly-added items are appended).
+        The position of a content_key within the request list is not used
+        to reorder existing rows.
+
+        POST /v1/highlight-sets-admin/<uuid>/set-content/
+
+        Request URL Arguments:
+            uuid (str): UUID of the HighlightSet to edit.
+
+        Request JSON Arguments:
+            content_keys (list of str): The desired final list of content keys
+                for the HighlightSet.  Pass an empty list to clear the set.
+
+        Returns:
+            rest_framework.response.Response:
+                400: Request body is missing `content_keys`, or it is not a
+                     list.  Pass an explicit empty list to clear the set.
+                403: Insufficient write permissions, or requested content count
+                     exceeds the backend limit.
+                200: Contents were reconciled successfully.  Body shape:
+                     {
+                         "added_content_keys": [...],
+                         "removed_content_keys": [...],
+                         "existing_content_keys": [...],
+                         "ignored_content_keys": [...],
+                         "highlight_set": <serialized HighlightSet>,
+                     }
+        """
+        if not isinstance(request.data.get('content_keys'), list):
+            return Response(
+                {
+                    'Error': (
+                        'Request body must include "content_keys" as a list. '
+                        'Pass an empty list ([]) to clear the set.'
+                    ),
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        requested_content_keys = self.requested_content_keys
+
+        if len(requested_content_keys) > CONTENT_PER_HIGHLIGHTSET_LIMIT:
+            return Response(
+                {
+                    'Error': (
+                        'Request exceeds the backend maximum content count per highlight set '
+                        f'({CONTENT_PER_HIGHLIGHTSET_LIMIT}).'
+                    ),
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        highlight_set = HighlightSet.objects.get(uuid=uuid)
+
+        with transaction.atomic():
+            current_content_keys = set(
+                highlight_set.highlighted_content.values_list(
+                    'content_metadata__content_key', flat=True,
+                )
+            )
+            removed_content_keys = list(current_content_keys - set(requested_content_keys))
+            if removed_content_keys:
+                highlight_set.highlighted_content.filter(
+                    content_metadata__content_key__in=removed_content_keys,
+                ).delete()
+
+            added_content_keys, ignored_content_keys, existing_content_keys = (
+                self._add_requested_content(highlight_set)
+            )
+
+        additional_properties = {
+            'added_content_keys': added_content_keys,
+            'removed_content_keys': removed_content_keys,
+        }
+        track_highlight_set_changes(
+            request, highlight_set, SegmentEvents.HIGHLIGHT_SET_UPDATED,
+            additional_properties=additional_properties,
+        )
+
+        response_serializer = HighlightSetReconcileResponseSerializer({
+            'added_content_keys': added_content_keys,
+            'removed_content_keys': removed_content_keys,
+            'existing_content_keys': existing_content_keys,
+            'ignored_content_keys': ignored_content_keys,
+            'highlight_set': highlight_set,
+        })
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=['post'], url_path='remove-content')
     def remove_content(self, request, uuid, *args, **kwargs):

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -672,7 +672,6 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
 
         Returns:
             rest_framework.response.Response:
-                400: Missing/invalid input parameters.
                 403: Insufficient write permissions, or requested content count
                      exceeds the backend limit.
                 200: Contents were reconciled successfully.  Body shape:
@@ -711,12 +710,9 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                     content_metadata__content_key__in=removed_content_keys,
                 ).delete()
 
-            try:
-                added_content_keys, ignored_content_keys, existing_content_keys = (
-                    self._add_requested_content(highlight_set)
-                )
-            except LimitExceeded as e:
-                return Response({'Error': str(e)}, status=status.HTTP_403_FORBIDDEN)
+            added_content_keys, ignored_content_keys, existing_content_keys = (
+                self._add_requested_content(highlight_set)
+            )
 
         additional_properties = {
             'added_content_keys': added_content_keys,


### PR DESCRIPTION
## Summary

Adds a new admin-only endpoint that **replaces** the contents of a `HighlightSet` with a given list of `content_keys` in a single atomic call — reconciling (adding what's missing, removing what's extra) instead of requiring the caller to fire separate add/remove requests.

**New endpoint**
```
POST /api/v1/highlight-sets-admin/<uuid>/set-content/
Body: { "content_keys": ["...", "..."] }
```

**Response (200):**
```json
{
  "added_content_keys": [...],
  "removed_content_keys": [...],
  "existing_content_keys": [...],
  "ignored_content_keys": [...],
  "highlight_set": { ...serialized... }
}
```

## Why

The new "Edit content" Figma flow lets an admin build a draft list locally (add/remove/reorder freely), then commit all changes on **Save** (or discard on **Cancel**). That maps cleanly to "send the desired final state in one request":

- **One call** on Save instead of computing a diff and firing add-content + remove-content.
- **Atomic** — wrapped in `transaction.atomic()` so the set is never left half-synced.
- **No change to existing endpoints** — `PATCH`, `add-content`, `remove-content`, `edit-highlight-title`, `toggle-favorite-highlight` are untouched.

## Implementation notes

- New `@action(url_path='set-content')` on `HighlightSetViewSet`.
- Reuses `self._add_requested_content(highlight_set)` for the add side — no duplicated validation, ordering, or \`ignored_content_keys\` logic.
- Removal is a single \`filter(content_metadata__content_key__in=...).delete()\` on the diff.
- Enforces \`CONTENT_PER_HIGHLIGHTSET_LIMIT\` (24) up front → 403.
- Emits one \`HIGHLIGHT_SET_UPDATED\` track event with both \`added_content_keys\` and \`removed_content_keys\` populated.

**Code reuse:** new logic is ~6 lines; everything else leans on helpers already on the viewset. **No new** models, migrations, serializers, URL patterns, or Python packages.

## Frontend contract

The new "Edit Content" UI (separate ticket) will:
- Hold the draft \`content_keys\` array in component state while in edit mode.
- On **Save** → one \`POST .../set-content/\` with the final array.
- On **Cancel** → discard local state, no network call.

## Test plan

- [x] \`test_set_content_replaces_full\`
- [x] \`test_set_content_with_overlap\`
- [x] \`test_set_content_with_empty_list_clears_set\`
- [x] \`test_set_content_exceeds_limit\`
- [x] \`test_set_content_ignores_unknown_keys\`
- [x] \`test_set_content_unauthorized_other_customer\`
- [x] Full \`HighlightSetViewSetTests\` class: **22 passed, 0 failed** (no regression)

<img width="1296" height="829" alt="image" src="https://github.com/user-attachments/assets/806d683f-67b8-413c-b8b5-4b44791bab5e" />
<img width="1293" height="776" alt="image" src="https://github.com/user-attachments/assets/a0995e35-ac9f-4e02-9ecd-f9f98dc70fa1" />
<img width="1153" height="814" alt="image" src="https://github.com/user-attachments/assets/047fbc95-99c1-4e82-a894-b52a3a016076" />
<img width="1270" height="773" alt="image" src="https://github.com/user-attachments/assets/ae955ad0-30cc-407d-aa9d-6073dad14230" />
<img width="1297" height="773" alt="image" src="https://github.com/user-attachments/assets/a2030b68-7211-4630-92e1-a585a5832721" />
<img width="1290" height="764" alt="image" src="https://github.com/user-attachments/assets/cd13daa4-6f07-4202-af43-051bff933873" />


\`\`\`
DJANGO_SETTINGS_MODULE=enterprise_catalog.settings.test \\
  pytest enterprise_catalog/apps/api/v1/tests/test_curation_views.py::HighlightSetViewSetTests -v
\`\`\`

Ticket: ENT-10745