### PR TITLE
[ENT-11407] Add atomic highlight edit flow and harden highlight validations

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -2,6 +2,7 @@
 Tests for curation-related views.
 """
 import itertools
+import json
 import uuid
 from unittest import mock
 
@@ -19,6 +20,7 @@ from enterprise_catalog.apps.api.v1.tests.mixins import (
 from enterprise_catalog.apps.api.v1.views.curation.highlights import (
     CONTENT_PER_HIGHLIGHTSET_LIMIT,
     HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT,
+    HighlightSetPartialUpdateSerializer,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE, PROGRAM
 from enterprise_catalog.apps.catalog.tests.factories import (
@@ -1203,9 +1205,9 @@ class HighlightSetViewSetTests(CurationAPITestBase):
         url = reverse('api:v1:highlight-sets-admin-detail', kwargs={'uuid': str(self.highlight_set_one.uuid)})
         self.set_up_staff()
         patch_data = {'title': 'Patch title'}
-        response = self.client.patch(url, patch_data)
+        response = self.client.patch(url, patch_data, content_type='application/json')
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()['title'] == 'Patch title'
+        assert response.json()['highlight_set']['title'] == 'Patch title'
 
         # May as well confirm that it persisted in the database:
         url = reverse('api:v1:highlight-sets-detail', kwargs={'uuid': str(self.highlight_set_one.uuid)})
@@ -1280,36 +1282,429 @@ class HighlightSetViewSetTests(CurationAPITestBase):
         assert len(response.json()['highlight_set']['highlighted_content']) == 0
         assert response.json()['highlight_set']['card_image_url'] is None
 
-    def test_edit_title(self):
+    @mock.patch('enterprise_catalog.apps.api.v1.event_utils.track_event')
+    def test_edit_title(self, mock_track_event):
         """
-        Test editing HighlightSet's title
+        Test editing HighlightSet's title - success and validation failures.
         """
-        # Success case
         edit_url = reverse(
             'api:v1:highlight-sets-admin-edit-highlight-title',
             kwargs={'uuid': str(self.highlight_set_one.uuid)}
         )
         self.set_up_staff()
         new_title = 'new title'
-        response = self.client.post(
-            edit_url, {'title': new_title},
-        )
-        assert response.status_code == status.HTTP_201_CREATED
-        assert response.json()['title'] == new_title
+
+        # Success case: returns 200 with full serialized HighlightSet
+        response = self.client.post(edit_url, {'title': new_title})
+        assert response.status_code == status.HTTP_200_OK
+        response_data = response.json()
+        assert response_data['title'] == new_title
+        assert response_data['uuid'] == str(self.highlight_set_one.uuid)
+        assert 'highlighted_content' in response_data
         self.highlight_set_one.refresh_from_db()
         assert self.highlight_set_one.title == new_title
+        mock_track_event.assert_called_once()
 
-        # No title parameter
-        response = self.client.post(
-            edit_url, {},
-        )
+        # No title parameter -> 400
+        response = self.client.post(edit_url, {})
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
-        # Too long title
-        response = self.client.post(
-            edit_url, {'title': new_title * 10},
+        # Too long title (>60 chars) -> 400 (validation error, not 403)
+        response = self.client.post(edit_url, {'title': new_title * 10})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'exceed' in response.json()['Error']
+
+    def test_edit_highlight_title_whitespace_only(self):
+        """
+        edit-highlight-title: whitespace-only title is treated as empty and returns 400.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-edit-highlight-title',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        for bad_title in ('   ', '\t', '\n  \n'):
+            response = self.client.post(edit_url, {'title': bad_title})
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, f'Expected 400 for title={bad_title!r}'
+
+    def test_edit_highlight_title_invalid_uuid(self):
+        """
+        edit-highlight-title: invalid UUID format returns 400.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-edit-highlight-title',
+            kwargs={'uuid': 'not-a-uuid'}
+        )
+        self.set_up_staff()
+        response = self.client.post(edit_url, {'title': 'some title'})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        error_text = response.json().get('Error') or str(response.json().get('detail', ''))
+        assert 'Invalid UUID' in error_text
+
+    def test_edit_highlight_title_invalid_uuid_with_enterprise_param(self):
+        """
+        edit-highlight-title: invalid UUID with enterprise_customer query param returns 400 (not 500).
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-edit-highlight-title',
+            kwargs={'uuid': 'not-a-uuid'}
+        ) + f'?enterprise_customer={self.enterprise_uuid}'
+        self.set_up_staff()
+        response = self.client.post(edit_url, {'title': 'some title'})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'Invalid UUID' in response.json()['Error']
+
+    def test_edit_highlight_title_non_string(self):
+        """
+        edit-highlight-title: non-string title returns 400.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-edit-highlight-title',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.post(edit_url, {'title': 12345})
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()['Error'] == 'title must be a string'
+
+    def test_edit_title_not_found(self):
+        """
+        Requesting edit-highlight-title for a non-existent UUID returns 404.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-edit-highlight-title',
+            kwargs={'uuid': str(uuid.uuid4())}
+        )
+        self.set_up_staff()
+        response = self.client.post(edit_url, {'title': 'some title'})
+        # edx-rbac permission check returns 403 for non-existent objects; document this behavior.
+        assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
+
+    def test_edit_title_unauthenticated(self):
+        """
+        Unauthenticated requests to edit-highlight-title return 401.
+        """
+        self.client.logout()
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-edit-highlight-title',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        response = self.client.post(edit_url, {'title': 'title'})
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_edit_title_learner_forbidden(self):
+        """
+        A catalog learner (non-admin) cannot call edit-highlight-title.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-edit-highlight-title',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_catalog_learner()
+        response = self.client.post(edit_url, {'title': 'learner title attempt'})
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @mock.patch('enterprise_catalog.apps.api.v1.event_utils.track_event')
+    def test_edit_highlight_title_only(self, mock_track_event):
+        """
+        PATCH edit-highlight: update only the title, no content changes.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.patch(edit_url, {'title': 'Updated Title'}, content_type='application/json')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['highlight_set']['title'] == 'Updated Title'
+        assert data['added_content_keys'] == []
+        assert data['removed_content_keys'] == []
+        assert data['ignored_content_keys'] == []
+        self.highlight_set_one.refresh_from_db()
+        assert self.highlight_set_one.title == 'Updated Title'
+        mock_track_event.assert_called_once()
+
+    @mock.patch('enterprise_catalog.apps.api.v1.event_utils.track_event')
+    def test_edit_highlight_add_and_remove_content(self, mock_track_event):
+        """
+        PATCH edit-highlight: add and remove course content in one atomic request.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        new_content = ContentMetadataFactory(content_type=COURSE)
+        key_to_add = new_content.content_key
+        key_to_remove = self.highlighted_content_metadata_one[0].content_key
+
+        payload = {
+            'add_content_keys': [key_to_add],
+            'remove_content_keys': [key_to_remove],
+        }
+        response = self.client.patch(edit_url, payload, content_type='application/json')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert key_to_add in data['added_content_keys']
+        assert key_to_remove in data['removed_content_keys']
+        final_keys = [
+            hc['content_key'] for hc in data['highlight_set']['highlighted_content']
+        ]
+        assert key_to_add in final_keys
+        assert key_to_remove not in final_keys
+        mock_track_event.assert_called_once()
+
+    @mock.patch('enterprise_catalog.apps.api.v1.event_utils.track_event')
+    def test_edit_highlight_combined(self, mock_track_event):
+        """
+        PATCH edit-highlight: update title AND add/remove courses in one request.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        new_content = ContentMetadataFactory(content_type=COURSE)
+        payload = {
+            'title': 'Combined Update',
+            'add_content_keys': [new_content.content_key],
+            'remove_content_keys': [self.highlighted_content_metadata_one[4].content_key],
+        }
+        response = self.client.patch(edit_url, payload, content_type='application/json')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        assert data['highlight_set']['title'] == 'Combined Update'
+        assert new_content.content_key in data['added_content_keys']
+        assert self.highlighted_content_metadata_one[4].content_key in data['removed_content_keys']
+        mock_track_event.assert_called_once()
+
+    def test_edit_highlight_patch_title_whitespace_only(self):
+        """
+        PATCH edit-highlight: whitespace-only title is treated as empty and returns 400.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        for bad_title in ('   ', '\t', '\n  \n'):
+            response = self.client.patch(
+                edit_url, {'title': bad_title}, content_type='application/json'
+            )
+            assert response.status_code == status.HTTP_400_BAD_REQUEST, f'Expected 400 for title={bad_title!r}'
+
+    def test_edit_highlight_nothing_provided(self):
+        """
+        PATCH edit-highlight: 400 when none of title, add, or remove keys are provided.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.patch(edit_url, {}, content_type='application/json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'At least one' in response.json()['Error']
+
+    def test_edit_highlight_title_too_long(self):
+        """
+        PATCH edit-highlight: 400 when title exceeds 60 characters.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.patch(
+            edit_url, {'title': 'x' * 61}, content_type='application/json'
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'exceed' in response.json()['Error']
+
+    def test_edit_highlight_invalid_uuid(self):
+        """
+        PATCH edit-highlight: invalid UUID format returns 400.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': 'not-a-uuid'}
+        )
+        self.set_up_staff()
+        response = self.client.patch(edit_url, {'title': 'title'}, content_type='application/json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        error_text = response.json().get('Error') or str(response.json().get('detail', ''))
+        assert 'Invalid UUID' in error_text
+
+    def test_edit_highlight_invalid_uuid_with_enterprise_param(self):
+        """
+        PATCH edit-highlight: invalid UUID with enterprise_customer query param returns 400 (not 500).
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': 'not-a-uuid'}
+        ) + f'?enterprise_customer={self.enterprise_uuid}'
+        self.set_up_staff()
+        response = self.client.patch(edit_url, {'title': 'title'}, content_type='application/json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'Invalid UUID' in response.json()['Error']
+
+    def test_edit_highlight_non_string_title(self):
+        """
+        PATCH edit-highlight: non-string title returns 400.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.patch(edit_url, {'title': {'bad': 'type'}}, content_type='application/json')
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()['Error'] == 'title must be a string'
+
+    def test_edit_highlight_invalid_add_content_keys_type(self):
+        """
+        PATCH edit-highlight: add_content_keys must be a list of strings.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.patch(
+            edit_url, {'add_content_keys': 'course-v1:edX+DemoX+Demo_Course'}, content_type='application/json'
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()['Error'] == 'add_content_keys must be a list of strings'
+
+    def test_edit_highlight_invalid_remove_content_keys_type(self):
+        """
+        PATCH edit-highlight: remove_content_keys must be a list of strings.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.patch(
+            edit_url, {'remove_content_keys': ['valid-key', 123]}, content_type='application/json'
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json()['Error'] == 'remove_content_keys must be a list of strings'
+
+    def test_edit_highlight_not_found(self):
+        """
+        PATCH edit-highlight: 403/404 when highlight set UUID doesn't exist.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(uuid.uuid4())}
+        )
+        self.set_up_staff()
+        response = self.client.patch(
+            edit_url, {'title': 'title'}, content_type='application/json'
+        )
+        # edx-rbac returns 403 for non-existent objects in permission checks.
+        assert response.status_code in (status.HTTP_403_FORBIDDEN, status.HTTP_404_NOT_FOUND)
+
+    def test_edit_highlight_unauthenticated(self):
+        """
+        PATCH edit-highlight: unauthenticated user gets 401.
+        """
+        self.client.logout()
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        response = self.client.patch(
+            edit_url, {'title': 'title'}, content_type='application/json'
+        )
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+    def test_edit_highlight_learner_forbidden(self):
+        """
+        PATCH edit-highlight: catalog learner (non-admin) gets 403.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_catalog_learner()
+        response = self.client.patch(
+            edit_url, {'title': 'learner attempt'}, content_type='application/json'
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_edit_highlight_add_exceeds_limit(self):
+        """
+        PATCH edit-highlight: 403 when adding content would exceed the per-highlight-set limit.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        content_to_add = [
+            ContentMetadataFactory(content_type=COURSE)
+            for _ in range(CONTENT_PER_HIGHLIGHTSET_LIMIT)
+        ]
+        payload = {'add_content_keys': [cm.content_key for cm in content_to_add]}
+        response = self.client.patch(edit_url, payload, content_type='application/json')
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert 'exceed' in response.json()['Error']
+
+    def test_edit_highlight_non_dict_body(self):
+        """
+        PATCH edit-highlight: 400 when request body is a JSON array (non-object).
+        The Mapping guard in to_internal_value() must surface a clean error, not a 500.
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        response = self.client.patch(
+            edit_url,
+            data=json.dumps([{'title': 'oops'}]),
+            content_type='application/json',
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert 'Error' in response.json()
+
+    @mock.patch('enterprise_catalog.apps.api.v1.event_utils.track_event')
+    def test_edit_highlight_add_duplicate_content_keys(self, _mock_track_event):
+        """
+        PATCH edit-highlight: duplicate keys in add_content_keys are deduplicated;
+        the item is added once and the duplicate is ignored (exercises the
+        first-occurrence key_index_map branch).
+        """
+        edit_url = reverse(
+            'api:v1:highlight-sets-admin-detail',
+            kwargs={'uuid': str(self.highlight_set_one.uuid)}
+        )
+        self.set_up_staff()
+        new_content = ContentMetadataFactory(content_type=COURSE)
+        # Send the same key twice.
+        payload = {'add_content_keys': [new_content.content_key, new_content.content_key]}
+        response = self.client.patch(edit_url, payload, content_type='application/json')
+        assert response.status_code == status.HTTP_200_OK
+        data = response.json()
+        # The key should be added only once.
+        assert data['added_content_keys'].count(new_content.content_key) == 1
+
+    def test_partial_update_serializer_raises_without_view_context(self):
+        """
+        Unit test: HighlightSetPartialUpdateSerializer.update() raises ValueError
+        when 'view' is absent from context, guarding against silent AttributeError.
+        """
+        serializer = HighlightSetPartialUpdateSerializer(
+            self.highlight_set_one,
+            data={'title': 'New Title'},
+            context={'request': None},  # view intentionally omitted
+        )
+        assert serializer.is_valid()
+        with self.assertRaises(ValueError, msg="Serializer requires 'view' in context"):
+            serializer.save()
 
     def test_toggle_favorite_highlight(self):
         """

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Mapping
 from uuid import UUID
 
 from django.db import transaction
@@ -8,6 +9,7 @@ from django.views.decorators.vary import vary_on_cookie
 from edx_django_utils.cache import RequestCache
 from edx_rbac.decorators import permission_required
 from edx_rbac.mixins import PermissionRequiredForListingMixin
+from rest_framework import serializers as drf_serializers
 from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ParseError
@@ -64,6 +66,129 @@ class LimitExceeded(Exception):
     highlight set.
     """
     pass
+
+
+class HighlightSetPartialUpdateSerializer(drf_serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Request serializer for PATCH /api/v1/highlight-sets-admin/<uuid>/.
+
+    Validates all input fields and persists all changes atomically inside update().
+    Validation errors are always returned in the ``{'Error': '...'}`` format used
+    throughout the rest of this API surface.
+    """
+    title = drf_serializers.CharField(required=False, allow_null=True, default=None)
+    add_content_keys = drf_serializers.ListField(
+        child=drf_serializers.CharField(), required=False, default=list
+    )
+    remove_content_keys = drf_serializers.ListField(
+        child=drf_serializers.CharField(), required=False, default=list
+    )
+
+    def to_internal_value(self, data):
+        """
+        Pre-validate raw input types before DRF's field-level conversion runs so that
+        all error messages are surfaced in the standard ``{'Error': '...'}`` format.
+        """
+        if not isinstance(data, Mapping):
+            raise drf_serializers.ValidationError(
+                {'Error': 'Request body must be a JSON object.'}
+            )
+        raw_title = data.get('title')
+        if raw_title is not None and not isinstance(raw_title, str):
+            raise drf_serializers.ValidationError({'Error': 'title must be a string'})
+        raw_add = data.get('add_content_keys')
+        if raw_add is not None and (
+            not isinstance(raw_add, list) or not all(isinstance(k, str) for k in raw_add)
+        ):
+            raise drf_serializers.ValidationError({'Error': 'add_content_keys must be a list of strings'})
+        raw_remove = data.get('remove_content_keys')
+        if raw_remove is not None and (
+            not isinstance(raw_remove, list) or not all(isinstance(k, str) for k in raw_remove)
+        ):
+            raise drf_serializers.ValidationError({'Error': 'remove_content_keys must be a list of strings'})
+        return super().to_internal_value(data)
+
+    def validate(self, data):  # pylint: disable=arguments-renamed
+        """
+        Cross-field validation: strip/validate title and ensure at least one field is provided.
+        """
+        title = data.get('title')
+        if title is not None:
+            title = title.strip()
+            if not title:
+                raise drf_serializers.ValidationError({'Error': 'title cannot be empty'})
+            if len(title) > 60:
+                raise drf_serializers.ValidationError({'Error': 'title cannot exceed 60 characters'})
+            data['title'] = title
+        add_content_keys = data.get('add_content_keys', [])
+        remove_content_keys = data.get('remove_content_keys', [])
+        if title is None and not add_content_keys and not remove_content_keys:
+            raise drf_serializers.ValidationError(
+                {'Error': 'At least one of title, add_content_keys, or remove_content_keys must be provided.'}
+            )
+        return data
+
+    def update(self, instance, validated_data):
+        """
+        Atomically persist all validated updates to the HighlightSet instance.
+
+        Mutation results are stored as instance attributes
+        (``self.added_content_keys``, ``self.ignored_content_keys``,
+        ``self.removed_content_keys``) for the view to include in its response.
+
+        Raises:
+            LimitExceeded: If adding the requested content would exceed the per-highlight-set limit.
+        """
+        title = validated_data.get('title')
+        add_keys = validated_data.get('add_content_keys', [])
+        remove_keys = validated_data.get('remove_content_keys', [])
+        request = self.context.get('request')
+        user_id = request.user.id if request else None
+        # Access the viewset so we can reuse its _add_requested_content helper.
+        view = self.context.get('view')
+        if view is None:
+            raise ValueError(
+                "HighlightSetPartialUpdateSerializer requires 'view' in serializer context."
+            )
+
+        self.added_content_keys = []
+        self.ignored_content_keys = []
+        self.removed_content_keys = []
+
+        with transaction.atomic():
+            if title is not None:
+                instance.title = title
+                instance.save()
+                logger.info(
+                    'HighlightSet %s title updated to "%s" by user %s',
+                    instance.uuid, title, user_id,
+                )
+
+            # remove_keys is filtered through instance.highlighted_content so it
+            # is already scoped to this highlight set only — no cross-set leakage.
+            if remove_keys:
+                content_to_remove = instance.highlighted_content.filter(
+                    content_metadata__content_key__in=remove_keys
+                )
+                self.removed_content_keys = [
+                    item.content_metadata.content_key for item in content_to_remove
+                ]
+                content_to_remove.delete()
+                logger.info(
+                    'HighlightSet %s: removed %d content keys by user %s',
+                    instance.uuid, len(self.removed_content_keys), user_id,
+                )
+
+            if add_keys:
+                self.added_content_keys, self.ignored_content_keys, _ = view._add_requested_content(  # pylint: disable=protected-access
+                    instance, content_keys=add_keys
+                )
+                logger.info(
+                    'HighlightSet %s: added %d content keys by user %s',
+                    instance.uuid, len(self.added_content_keys), user_id,
+                )
+
+        return instance
 
 
 class EnterpriseCurationConfigBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
@@ -226,7 +351,23 @@ class HighlightSetBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
 
     @property
     def requested_highlight_set_uuid(self):
-        return self.kwargs.get('uuid')
+        """
+        Returns the highlight set UUID from the URL kwargs as a ``UUID`` object,
+        validating and caching the result on first access.
+
+        Raises:
+            rest_framework.exceptions.ParseError: If the value is present but not a valid UUID.
+        """
+        if not hasattr(self, '_requested_highlight_set_uuid_object'):
+            uuid_value = self.kwargs.get('uuid')
+            if uuid_value is None:
+                self._requested_highlight_set_uuid_object = None  # pylint: disable=attribute-defined-outside-init
+            else:
+                try:
+                    self._requested_highlight_set_uuid_object = UUID(uuid_value)  # pylint: disable=attribute-defined-outside-init
+                except (ValueError, AttributeError) as exc:
+                    raise ParseError({'Error': f'Invalid UUID: {uuid_value}'}) from exc
+        return self._requested_highlight_set_uuid_object
 
     @property
     def requested_content_keys(self):
@@ -260,6 +401,7 @@ class HighlightSetBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
         if self.requested_enterprise_uuid:
             return str(self.requested_enterprise_uuid)
 
+        # Accessing the property validates and caches the UUID (raises ParseError if invalid).
         try:
             highlight_set = HighlightSet.objects.get(uuid=self.requested_highlight_set_uuid)
             return str(highlight_set.enterprise_curation.enterprise_uuid)
@@ -277,6 +419,8 @@ class HighlightSetBaseViewSet(PermissionRequiredForListingMixin, BaseViewSet):
         if self.requested_enterprise_uuid:
             kwargs.update({'enterprise_curation__enterprise_uuid': self.requested_enterprise_uuid})
         if self.requested_highlight_set_uuid:
+            # Accessing the property validates the UUID; use the UUID object directly so
+            # Django's ORM receives a typed value rather than a raw string.
             kwargs.update({'uuid': self.requested_highlight_set_uuid})
         return HighlightSet.objects.filter(**kwargs).prefetch_related(
             'enterprise_curation',
@@ -331,12 +475,14 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
 
         return existing_curation_config_for_enterprise
 
-    def _add_requested_content(self, highlight_set):
+    def _add_requested_content(self, highlight_set, content_keys=None):
         """
         Helper function to add requested content to the given highlight set.
 
         Arguments:
             highlight_set (HighlightSet model instance): The highlight set to attempt to add content to.
+            content_keys (list of str, optional): Explicit list of content keys to add.  When omitted,
+                falls back to ``self.requested_content_keys`` (i.e. reads from the request body).
 
         Returns:
             3-tuple of lists of str: Each tuple element represents "added", "ignored", and "existing" content_keys.
@@ -349,6 +495,8 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                 If the requested content keys would cause the resulting highlight set to contain more than the maximum
                 allowed content.
         """
+        effective_content_keys = content_keys if content_keys is not None else self.requested_content_keys
+
         # Prepare the 3 output lists that collectively bucket all elements in the requested `content_keys` argument.
         added_content_keys = []  # requested content_keys that are successfully added as part of handling this request.
         ignored_content_keys = []  # requested content_keys that do not exist in the catalog.
@@ -356,15 +504,21 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
 
         # Determine `valid_requested_content_keys_to_add`.  Eventually equivalent to the union of `added_content_keys`
         # and `existing_content_keys`.  I.e. These are content_keys which are valid options to add to a highlight set.
+        # Precompute index map for O(n) sorting while preserving first-occurrence order
+        # for duplicate request keys (last-wins dict comprehension would break ordering).
+        key_index_map = {}
+        for i, key in enumerate(effective_content_keys):
+            if key not in key_index_map:
+                key_index_map[key] = i
         valid_requested_content_to_add = sorted(
-            ContentMetadata.objects.filter(content_key__in=self.requested_content_keys),
-            key=lambda cm: self.requested_content_keys.index(cm.content_key)
+            ContentMetadata.objects.filter(content_key__in=effective_content_keys),
+            key=lambda cm: key_index_map.get(cm.content_key, 0)
         )
         valid_requested_content_keys_to_add = [cm.content_key for cm in valid_requested_content_to_add]
 
         # Store the remainder in `ignored_content_keys`, representing content_keys that we will not even attempt to add.
         # Use a comprehension instead of set logic so that order is preserved.
-        ignored_content_keys = [k for k in self.requested_content_keys if k not in valid_requested_content_keys_to_add]
+        ignored_content_keys = [k for k in effective_content_keys if k not in valid_requested_content_keys_to_add]
         if ignored_content_keys:
             logger.warning('The following content_keys were not found: %s', ignored_content_keys)
 
@@ -381,7 +535,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         proposed_final_count = len(set(all_prior_content_keys).union(valid_requested_content_keys_to_add))
         if proposed_final_count > CONTENT_PER_HIGHLIGHTSET_LIMIT:
             raise LimitExceeded(
-                'Request exceeds the backend maximum content count per highlight set'
+                'Request exceeds the backend maximum content count per highlight set '
                 f'({CONTENT_PER_HIGHLIGHTSET_LIMIT}).'
             )
 
@@ -413,7 +567,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                 403: If the requester does not have delete permission, or the object UUID wasn't found.
                 204: Indicates success, and response body will be empty.
         """
-        highlight_set = HighlightSet.objects.get(uuid=kwargs['uuid'])
+        highlight_set = HighlightSet.objects.get(uuid=self.requested_highlight_set_uuid)
         deletion_response = super().destroy(request, *args, **kwargs)
         if status.is_success(deletion_response.status_code):
             track_highlight_set_changes(request, highlight_set, SegmentEvents.HIGHLIGHT_SET_DELETED)
@@ -541,23 +695,136 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
             rest_framework.response.Response:
                 400: If there are missing or otherwise invalid input parameters.  Response body is JSON with a single
                      `Error` key.
-                403: If the requester has insufficient write permissions or enters title greater than 60 character.
+                403: If the requester has insufficient write permissions.
                     Response body is JSON with a single `Error` key.
-                201: If highlight set name was successfully updated.  Response body is JSON with a single `title` key.
+                404: If no HighlightSet exists for the given UUID.
+                200: If highlight set name was successfully updated.  Response body is a serialized HighlightSet
+                     containing uuid, title, is_published, enterprise_curation, card_image_url, and highlighted_content.
         """
-        highlight_set = HighlightSet.objects.get(uuid=uuid)
-        title = request.data.get('title')
+        # UUID validation is handled by the requested_highlight_set_uuid property (raises
+        # ParseError → 400 if the UUID is malformed); no manual try/except needed here.
+        try:
+            highlight_set = self.get_queryset().get(uuid=self.requested_highlight_set_uuid)
+        except HighlightSet.DoesNotExist:
+            return Response(
+                {'Error': f'No HighlightSet found with uuid {uuid}'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        raw_title = request.data.get('title')
+        if raw_title is not None and not isinstance(raw_title, str):
+            return Response({'Error': 'title must be a string'}, status=status.HTTP_400_BAD_REQUEST)
+        title = (raw_title or '').strip()
         if not title:
             return Response({'Error': 'Missing title parameter'}, status=status.HTTP_400_BAD_REQUEST)
         if len(title) > 60:
-            return Response({'Error': 'title cannot exceed 60 characters'}, status=status.HTTP_403_FORBIDDEN)
+            return Response({'Error': 'title cannot exceed 60 characters'}, status=status.HTTP_400_BAD_REQUEST)
         highlight_set.title = title
         highlight_set.save()
+        logger.info(
+            'HighlightSet %s title updated to "%s" by user %s',
+            uuid, title, request.user.id,
+        )
+        track_highlight_set_changes(request, highlight_set, SegmentEvents.HIGHLIGHT_SET_UPDATED)
+        serializer = self.get_serializer(highlight_set)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def partial_update(self, request, *args, **kwargs):
+        """
+        Atomically update a HighlightSet's title and/or associated course content in a single request.
+
+        PATCH /api/v1/highlight-sets-admin/<uuid>/
+
+        Request URL Arguments:
+            uuid (str): UUID of the HighlightSet to update.
+
+        Request JSON Arguments:
+            title (str, optional): New title for the HighlightSet.
+            add_content_keys (list of str, optional): Content keys to add to the highlight set.
+            remove_content_keys (list of str, optional): Content keys to remove from the highlight set.
+
+        Returns:
+            rest_framework.response.Response:
+                400: If validation fails (empty title, title > 60 chars, or neither title nor content keys given).
+                     Response body is JSON with a single `Error` key.
+                403: If the requester has insufficient write permissions, or if adding content would exceed limits.
+                     Response body is JSON with a single `Error` key.
+                404: If no HighlightSet exists for the given UUID.
+                200: Update successful.  Response body contains:
+                     {
+                         "highlight_set": <serialized HighlightSet with uuid, title, highlighted_content, ...>,
+                         "added_content_keys": <list of content keys successfully added>,
+                         "removed_content_keys": <list of content keys successfully removed>,
+                         "ignored_content_keys": <list of requested add keys that were not found in the catalog>,
+                     }
+        """
+        # UUID validation is handled by the requested_highlight_set_uuid property (raises
+        # ParseError → 400 if the UUID is malformed); no manual try/except needed here.
+        # Use get_queryset() (backed by base_queryset) so the lookup is automatically scoped
+        # to the caller's enterprise — prevents a caller from targeting a HighlightSet that
+        # belongs to a different enterprise even if they hold a valid enterprise role.
+        try:
+            highlight_set = self.get_queryset().get(uuid=self.requested_highlight_set_uuid)
+        except HighlightSet.DoesNotExist:
+            return Response(
+                {'Error': f'No HighlightSet found with uuid {kwargs["uuid"]}'},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        # Delegate input validation to the request serializer.
+        req_serializer = HighlightSetPartialUpdateSerializer(
+            highlight_set,
+            data=request.data,
+            context=self.get_serializer_context(),
+        )
+        if not req_serializer.is_valid():
+            # DRF wraps ValidationError values in lists; unwrap to keep the
+            # ``{'Error': '<message>'}`` format used across this API surface.
+            errors = req_serializer.errors
+            first_key = next(iter(errors))
+            first_val = errors[first_key]
+            msg = first_val[0] if isinstance(first_val, list) else first_val
+            # If the nested value is itself a dict (e.g. raised as {'Error': '...'}),
+            # surface it directly so the response key is still 'Error'.
+            if isinstance(msg, dict):
+                return Response(msg, status=status.HTTP_400_BAD_REQUEST)
+            return Response({'Error': str(msg)}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Persist changes atomically via the serializer's update() method.
+        try:
+            req_serializer.save()
+        except LimitExceeded:
+            logger.warning(
+                'HighlightSet %s update exceeded content limit for user %s',
+                kwargs['uuid'],
+                request.user.id,
+                exc_info=True,
+            )
+            return Response(
+                {'Error': 'Unable to update highlight set because the content limit was exceeded.'},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        # Refresh to clear prefetch cache so the response serializer reflects the
+        # actual post-mutation state (added/removed highlighted_content).
+        highlight_set.refresh_from_db()
+
+        track_highlight_set_changes(
+            request, highlight_set, SegmentEvents.HIGHLIGHT_SET_UPDATED,
+            additional_properties={
+                'added_content_keys': req_serializer.added_content_keys,
+                'removed_content_keys': req_serializer.removed_content_keys,
+            },
+        )
+
+        response_serializer = self.get_serializer(highlight_set)
         return Response(
             {
-                'title': title
+                'highlight_set': response_serializer.data,
+                'added_content_keys': req_serializer.added_content_keys,
+                'removed_content_keys': req_serializer.removed_content_keys,
+                'ignored_content_keys': req_serializer.ignored_content_keys,
             },
-            status=status.HTTP_201_CREATED,
+            status=status.HTTP_200_OK,
         )
 
     @action(detail=True, methods=['post'], url_path='toggle-favorite-highlight')
@@ -582,7 +849,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                     `Error` key.
                 201: If highlighted content favorite state was successfully updated.
         """
-        highlight_set = HighlightSet.objects.get(uuid=uuid)
+        highlight_set = HighlightSet.objects.get(uuid=self.requested_highlight_set_uuid)
         content_uuid = request.data.get('content_uuid')
         favorite_param = request.data.get('favorite')
         if not favorite_param:
@@ -633,7 +900,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
                          "highlight_set": <a serialized HighlightSet representing the final state>,
                      }
         """
-        highlight_set = HighlightSet.objects.get(uuid=uuid)
+        highlight_set = HighlightSet.objects.get(uuid=self.requested_highlight_set_uuid)
         try:
             added_content_keys, ignored_content_keys, existing_content_keys = self._add_requested_content(highlight_set)
         except LimitExceeded as e:
@@ -780,7 +1047,7 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
         content_keys = self.requested_content_keys
         removed_content_keys = set()
 
-        highlight_set = HighlightSet.objects.get(uuid=uuid)
+        highlight_set = HighlightSet.objects.get(uuid=self.requested_highlight_set_uuid)
         existing_content = highlight_set.highlighted_content
         existing_content_to_remove = existing_content.filter(content_metadata__content_key__in=content_keys)
         if existing_content_to_remove:

--- a/enterprise_catalog/apps/curation/models.py
+++ b/enterprise_catalog/apps/curation/models.py
@@ -280,9 +280,9 @@ class HighlightedContent(TimeStampedModel):
         content_type = self.content_type
         owners = []
         if content_type == COURSE:
-            owners = self.content_metadata.json_metadata.get('owners')
+            owners = self.content_metadata.json_metadata.get('owners') or []
         elif content_type == PROGRAM:
-            owners = self.content_metadata.json_metadata.get('authoring_organizations')
+            owners = self.content_metadata.json_metadata.get('authoring_organizations') or []
 
         return [
             {

--- a/enterprise_catalog/apps/curation/tests/test_models.py
+++ b/enterprise_catalog/apps/curation/tests/test_models.py
@@ -49,6 +49,22 @@ class TestModels(TestCase):
         assert authoring_organizations_under_test[0]['logo_image_url'].endswith('.jpg')
 
     @ddt.data(
+        {'content_type': COURSE, 'metadata_key': 'owners'},
+        {'content_type': PROGRAM, 'metadata_key': 'authoring_organizations'},
+    )
+    @ddt.unpack
+    def test_authoring_organizations_missing_returns_empty_list(self, content_type, metadata_key):
+        """
+        Ensure missing owner metadata does not raise and instead returns an empty list.
+        """
+        content_metadata = ContentMetadataFactory(content_type=content_type)
+        content_metadata.json_metadata[metadata_key] = None
+        content_metadata.save(update_fields=['_json_metadata'])
+
+        highlighted_content = HighlightedContentFactory(content_metadata=content_metadata)
+        assert highlighted_content.authoring_organizations == []
+
+    @ddt.data(
         {'content_type': COURSE, 'content_title': 'Test Course Title'},
         {'content_type': COURSE_RUN, 'content_title': 'Test Courserun Title'},
         {'content_type': PROGRAM, 'content_title': 'Test Program Title'},


### PR DESCRIPTION
# [ENT-11407] Add atomic highlight edit flow and validations

## Summary

Extends the standard **`PATCH /api/v1/highlight-sets-admin/<uuid>/`** endpoint (via DRF `partial_update`) to allow the admin portal to update a `HighlightSet` title, add content, and remove content in a **single atomic request** — replacing the previous pattern of sequencing three separate API calls.

Also hardens input validation to prevent malformed payloads from causing `500`s, deduplicates UUID validation logic, and improves model resilience for missing owner metadata.

---

## What Changed

### Extended endpoint: `PATCH /api/v1/highlight-sets-admin/<uuid>/`

Overrides DRF's `partial_update` to support combined title + content updates in one transaction:

```json
{
  "title": "New Title",
  "add_content_keys": ["course-v1:edX+DemoX+Demo_Course"],
  "remove_content_keys": ["course-v1:edX+OldCourse+2023"]
}
```

At least one of `title`, `add_content_keys`, or `remove_content_keys` must be provided; empty payloads are rejected with `400`.

Response (`200`):

```json
{
  "highlight_set": { "uuid": "...", "title": "...", "highlighted_content": [...] },
  "added_content_keys": ["course-v1:edX+..."],
  "removed_content_keys": ["course-v1:edX+..."],
  "ignored_content_keys": ["course-v1:edX+NotInCatalog"]
}
```

### Validation hardening

| Scenario | Before | After |
|---|---|---|
| Invalid UUID path param | could raise `500` | explicit UUID validation → `400` |
| Non-string `title` | `.strip()` could raise `AttributeError` (`500`) | type validation → `400` |
| Non-list / non-string items in `add_content_keys` / `remove_content_keys` | inconsistent behavior | strict list-of-strings validation → `400` |
| `LimitExceeded` response | raw exception message surfaced to client | generic client-safe error + server-side `warning` log with `exc_info` |

### Refactor: `_add_requested_content(...)`

Now accepts optional explicit `content_keys`, enabling clean reuse by `partial_update` while preserving backwards compatibility for existing call sites (`add_content` action).

### Model robustness

In `HighlightedContent.authoring_organizations`, missing upstream owner fields now safely fall back to `[]` (`owners` / `authoring_organizations`), preventing `TypeError` when metadata is `None`.

---

## Testing

```bash
# Targeted test suites
./manage.py test enterprise_catalog/apps/api/v1/tests/test_curation_views.py
./manage.py test enterprise_catalog/apps/curation/tests/test_models.py

# Quality checks
make quality
```

Coverage includes:

- `partial_update` success paths (title-only, add/remove-only, combined)
- validation failures (empty payload, whitespace/too-long title, malformed types)
- auth/permission cases (`401` / `403`)
- not-found and invalid UUID handling
- limit-exceeded rollback behavior (transaction atomicity)
- `authoring_organizations` `None` metadata regression

---

## Files Changed

- `enterprise_catalog/apps/api/v1/views/curation/highlights.py`
- `enterprise_catalog/apps/api/v1/tests/test_curation_views.py`
- `enterprise_catalog/apps/curation/models.py`
- `enterprise_catalog/apps/curation/tests/test_models.py`

---
## 🔗 Jira

- [ENT-11407](https://jira.edx.org/browse/ENT-11407)
Test results:
<img width="1659" height="878" alt="image" src="https://github.com/user-attachments/assets/d339a3d2-82c8-4400-b05f-704a75defa06" />
Test result with title more than 60 characters
<img width="1644" height="267" alt="image" src="https://github.com/user-attachments/assets/36f6dbad-9f3a-4b0f-909f-6c7a08189f2b" />


