### PR TITLE
fix: define throttle rates directly inside REST_FRAMEWORK setting

### DIFF
--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -142,17 +142,16 @@ DATABASES = {
 }
 
 # Django Rest Framework
-DEFAULT_THROTTLE_RATES = {
-    'get_content_metadata_hour': '120/hour',
-    'get_content_metadata_minute': '6/minute',
-}
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'edx_rest_framework_extensions.paginators.DefaultPagination',
     'DEFAULT_PERMISSION_CLASSES': (
         'rest_framework.permissions.IsAuthenticated',
     ),
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
-    'DEFAULT_THROTTLE_RATES': DEFAULT_THROTTLE_RATES,
+    'DEFAULT_THROTTLE_RATES': {
+        'get_content_metadata_hour': '300/hour',
+        'get_content_metadata_minute': '30/minute',
+    },
     'PAGE_SIZE': 10,
     'TEST_REQUEST_DEFAULT_FORMAT': 'json',
 }

--- a/enterprise_catalog/settings/production.py
+++ b/enterprise_catalog/settings/production.py
@@ -21,7 +21,7 @@ ALLOWED_HOSTS = ['*']
 
 # Keep track of the names of settings that represent dicts. Instead of overriding the values in base.py,
 # the values read from disk should UPDATE the pre-configured dicts.
-DICT_UPDATE_KEYS = ('JWT_AUTH',)
+DICT_UPDATE_KEYS = ('JWT_AUTH', 'REST_FRAMEWORK')
 
 # This may be overridden by the YAML in catalog_CFG,
 # but it should be here as a default.


### PR DESCRIPTION
Because of the interaction of YAML env configs and how settings logic applies those config overrides, we can't define throttle rates in an isolated variable via YAML. This also makes the base throttle rates identical to those currently used in stage and prod.
https://2u-internal.atlassian.net/browse/ENT-11791

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
