### PR TITLE
feat: add superuser-only Django admin view for inspecting project settings

### DIFF
--- a/enterprise_catalog/apps/core/admin.py
+++ b/enterprise_catalog/apps/core/admin.py
@@ -7,6 +7,14 @@ from django.utils.translation import gettext_lazy as _
 from enterprise_catalog.apps.core.models import User
 
 
+# Use our custom admin index template so the dashboard can include a Tools
+# panel linking to the project settings view (see admin_views.py). The
+# template extends the upstream admin/index.html, so renaming it (rather
+# than overriding admin/index.html directly) avoids template-extends
+# recursion from our project-level templates dir.
+admin.site.index_template = 'admin/catalog_index.html'
+
+
 @admin.register(User)
 class CustomUserAdmin(UserAdmin):
     """ Admin configuration for the custom User model. """

--- a/enterprise_catalog/apps/core/admin_views.py
+++ b/enterprise_catalog/apps/core/admin_views.py
@@ -1,0 +1,38 @@
+"""
+Admin-only, read-only view that displays the resolved Django settings.
+
+Sensitive values are redacted by Django's ``SafeExceptionReporterFilter`` —
+the same filter used by the technical 500 page. The redaction regex is
+extended to cover project-specific settings that don't match the default
+``API|TOKEN|KEY|SECRET|PASS|SIGNATURE`` pattern.
+"""
+import pprint
+import re
+
+from django.contrib import admin
+from django.contrib.admin.views.decorators import staff_member_required
+from django.contrib.auth.decorators import user_passes_test
+from django.shortcuts import render
+from django.views.debug import SafeExceptionReporterFilter
+
+
+class CatalogSafeReporterFilter(SafeExceptionReporterFilter):
+    """Extends Django's redaction regex with project-specific patterns."""
+    hidden_settings = re.compile(
+        r"API|TOKEN|KEY|SECRET|PASS|SIGNATURE|CLIENT_ID|ALGOLIA|BRAZE",
+        flags=re.IGNORECASE,
+    )
+
+
+@staff_member_required
+@user_passes_test(lambda u: u.is_superuser)
+def settings_view(request):
+    """Render a read-only table of cleansed Django settings for superusers."""
+    safe = CatalogSafeReporterFilter().get_safe_settings()
+    rows = [(name, pprint.pformat(value, width=100)) for name, value in sorted(safe.items())]
+    context = {
+        **admin.site.each_context(request),
+        'title': 'Project settings',
+        'rows': rows,
+    }
+    return render(request, 'admin/settings_view.html', context)

--- a/enterprise_catalog/apps/core/tests/test_admin_views.py
+++ b/enterprise_catalog/apps/core/tests/test_admin_views.py
@@ -1,0 +1,70 @@
+"""Tests for the superuser-only admin settings view."""
+import ddt
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.urls import reverse
+
+
+User = get_user_model()
+
+
+@ddt.ddt
+class AdminSettingsViewTests(TestCase):
+    """Verify access control and redaction for the settings admin view."""
+
+    URL = reverse('admin-settings')
+
+    def _login_as(self, user_flags):
+        """Log in a user with the given flags, or stay anonymous if None."""
+        if user_flags is None:
+            return
+        user = User.objects.create_user(username='u', password='pw', **user_flags)
+        self.client.force_login(user)
+
+    @ddt.data(
+        # (user_flags, allowed)
+        (None, False),
+        ({'is_staff': False, 'is_superuser': False}, False),
+        ({'is_staff': True, 'is_superuser': False}, False),
+        ({'is_staff': False, 'is_superuser': True}, False),  # admin login requires is_staff
+        ({'is_staff': True, 'is_superuser': True}, True),
+    )
+    @ddt.unpack
+    def test_access_control(self, user_flags, allowed):
+        self._login_as(user_flags)
+        response = self.client.get(self.URL)
+        if allowed:
+            self.assertEqual(response.status_code, 200)
+            self.assertContains(response, 'INSTALLED_APPS')
+        else:
+            self.assertEqual(response.status_code, 302)
+            self.assertIn('/login/', response.url)
+
+    @ddt.data(
+        ('MY_SECRET_KEY', 'supersecret-value'),
+        ('MY_API_TOKEN', 'token-value'),
+        ('ALGOLIA_INDEX_NAME', 'public-index-name'),
+        ('BRAZE_API_URL', 'https://braze.example/'),
+        ('SOMETHING_CLIENT_ID', 'client-id-value'),
+    )
+    @ddt.unpack
+    def test_sensitive_values_redacted(self, setting_name, setting_value):
+        user = User.objects.create_user(
+            username='su', password='pw', is_staff=True, is_superuser=True,
+        )
+        self.client.force_login(user)
+        with override_settings(**{setting_name: setting_value}):
+            response = self.client.get(self.URL)
+        body = response.content.decode()
+        self.assertNotIn(setting_value, body)
+        self.assertIn('*' * 20, body)
+
+    def test_admin_index_shows_link_for_superuser(self):
+        user = User.objects.create_user(
+            username='su', password='pw', is_staff=True, is_superuser=True,
+        )
+        self.client.force_login(user)
+        response = self.client.get(reverse('admin:index'))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.URL)

--- a/enterprise_catalog/templates/admin/catalog_index.html
+++ b/enterprise_catalog/templates/admin/catalog_index.html
@@ -1,0 +1,18 @@
+{% extends "admin/index.html" %}
+
+{% block content %}
+<div id="content-main">
+  {% include "admin/app_list.html" with app_list=app_list show_changelinks=True %}
+  {% if user.is_superuser %}
+  <div class="module" id="project-tools-module">
+    <table>
+      <caption><a class="section" href="{% url 'admin-settings' %}">Tools</a></caption>
+      <tr>
+        <th scope="row"><a href="{% url 'admin-settings' %}">Project settings</a></th>
+        <td>Read-only, redacted view of Django settings (superuser only).</td>
+      </tr>
+    </table>
+  </div>
+  {% endif %}
+</div>
+{% endblock %}

--- a/enterprise_catalog/templates/admin/settings_view.html
+++ b/enterprise_catalog/templates/admin/settings_view.html
@@ -1,0 +1,28 @@
+{% extends "admin/base_site.html" %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+  <a href="{% url 'admin:index' %}">Home</a> &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<p>Read-only view of resolved Django settings. Values matching sensitive name patterns
+(<code>API</code>, <code>TOKEN</code>, <code>KEY</code>, <code>SECRET</code>, <code>PASS</code>,
+<code>SIGNATURE</code>, <code>CLIENT_ID</code>, <code>ALGOLIA</code>, <code>BRAZE</code>)
+are redacted.</p>
+
+<table style="width: 100%;">
+  <thead>
+    <tr><th style="text-align: left; width: 25%;">Name</th><th style="text-align: left;">Value</th></tr>
+  </thead>
+  <tbody>
+    {% for name, value in rows %}
+      <tr>
+        <td style="vertical-align: top;"><code>{{ name }}</code></td>
+        <td><pre style="white-space: pre-wrap; margin: 0;">{{ value }}</pre></td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/enterprise_catalog/urls.py
+++ b/enterprise_catalog/urls.py
@@ -28,6 +28,8 @@ from drf_spectacular.views import (
 from enterprise_catalog.apps.ai_curation.api import urls as ai_curation_urls
 from enterprise_catalog.apps.api import urls as api_urls
 from enterprise_catalog.apps.core import views as core_views
+from enterprise_catalog.apps.core.admin_views import \
+    settings_view as admin_settings_view
 
 
 admin.autodiscover()
@@ -48,6 +50,7 @@ urlpatterns = [
     path('', include(oauth2_urlpatterns)),
     path('', include('csrf.urls')),  # Include csrf urls from edx-drf-extensions
     path('admin/clearcache/', include('clearcache.urls')),
+    path('admin/settings/', admin_settings_view, name='admin-settings'),
     path('admin/', admin.site.urls),
     path('api/', include(api_urls), name='api'),
     path('api/', include(ai_curation_urls), name='api'),


### PR DESCRIPTION
This came out of a discussion/wish earlier today to be able to see current settings values on stage/prod.

Adds /admin/settings/, a read-only page that displays resolved Django settings with sensitive values redacted via SafeExceptionReporterFilter. The redaction regex extends Django's defaults to cover CLIENT_ID, ALGOLIA, and BRAZE settings. The admin dashboard renders a Tools panel linking to the page when the viewer is a superuser.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
