### PR TITLE
feat: upgrade algoliasearch v3 -> v4 + sandbox integration tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ branch = True
 data_file = .coverage
 source=enterprise_catalog
 omit =
+    scripts/
     enterprise_catalog/settings/*
     enterprise_catalog/conf/*
     */wsgi.py

--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,9 @@ acceptance_tests.*.png
 override.cfg
 private.py
 
+# Integration test secrets
+scripts/.env
+
 # JetBrains
 .idea
 

--- a/docs/how_to/algolia_integration_tests_pattern.md
+++ b/docs/how_to/algolia_integration_tests_pattern.md
@@ -1,0 +1,130 @@
+# Pattern: scripts/<name>_integration (modeled on enterprise-access)
+
+This is the structure used by `~/code/enterprise-access/scripts/billing_integration`. We're going to mirror it for Algolia sandbox integration tests.
+
+## Layout
+
+```
+scripts/
+├── .env.example              # documents every env var the runner needs
+├── .env                      # gitignored, holds real credentials locally
+├── requirements.txt          # requests + python-dotenv (and SDK we're testing)
+├── test_<name>_integration.py  # runner: argparse, dependency resolver, colored output
+└── <name>_integration/       # supporting package
+    ├── __init__.py
+    ├── config.py             # @dataclass Config + from_env() + validate() + mask_secrets()
+    ├── auth.py               # token acquisition / caching (skipped for Algolia — API key auth)
+    ├── client.py             # thin wrapper around the SDK or HTTP API under test
+    └── test_scenarios.py     # @dataclass TestScenario + TEST_SCENARIOS registry
+```
+
+## How the pieces fit together
+
+**`config.py`** — single `Config` dataclass loaded via `Config.from_env(env_file)`. Required vs optional vars are listed explicitly; `from_env` raises if any required var is missing. `mask_secrets()` is used by the runner's `--verbose` mode so credentials don't leak into stdout. All real values come from `.env` (loaded via `python-dotenv`) or the process environment.
+
+**`auth.py`** — a `JWTAuthenticator` for the billing case (OAuth client-credentials → JWT, with caching and a 60s pre-expiry buffer). For Algolia we don't need this: the SDK accepts the application ID and admin API key directly.
+
+**`client.py`** — high-level wrapper around the API under test. For billing it wraps HTTP calls (`requests`); for Algolia it'll wrap `SearchClientSync` (or instantiate the project's own `AlgoliaSearchClient`).
+
+**`test_scenarios.py`** — each test is a function `(client, config) -> {'status': 'PASS', 'data': ...}` that uses `assert` for failures. Functions are registered as `TestScenario(name, description, run, depends_on=[...], skip_on_error=False)` in a `TEST_SCENARIOS` list. Helpers `get_scenario_by_name` and `list_scenario_names` round it out.
+
+**Runner (`test_<name>_integration.py`)**:
+
+- argparse flags: `--all`, `--test NAME` (repeatable), `--list`, `--env PATH`, `--verbose`, `--debug`, `--stop-on-fail`.
+- Resolves `depends_on` topologically before execution; skips a scenario whose dependency failed (the skipped run is reported separately from a hard fail).
+- Catches `AssertionError` (logical failure) and `Exception` (unexpected error) per scenario, so one failure doesn't kill the run unless `--stop-on-fail` is set.
+- Colored terminal output via a small `Colors` class (no extra deps).
+- Exit code `0` if everything passed, `1` if anything failed, `130` on Ctrl-C.
+
+## Why the pattern works for sandbox-style tests
+
+- **Secrets stay in `.env`** — never on the command line, never in code, masked in logs.
+- **Each scenario is an independent function** — easy to add new ones, easy to run a single scenario when iterating.
+- **Dependency declarations** make multi-step flows (create-then-verify, update-then-cache-bust) safe to run individually.
+- **No test framework lock-in** — plain Python + requests/SDK, no pytest/Django machinery to wire up.
+
+## What to keep, drop, or change for Algolia
+
+- **Drop:** `auth.py`. Algolia auth is just the admin API key.
+- **Keep:** `config.py`, `client.py`, `test_scenarios.py`, the runner skeleton.
+- **Change:** `config.py` carries `ALGOLIA_APPLICATION_ID`, `ALGOLIA_ADMIN_API_KEY`, `ALGOLIA_SEARCH_API_KEY`, and the names of the stable sandbox indices we own (`ALGOLIA_INDEX_NAME`, `ALGOLIA_REPLICA_INDEX_NAME`). `client.py` bootstraps Django and instantiates the project's `AlgoliaSearchClient` so the wrapper code path is exercised end-to-end; a few low-level scenarios construct a raw `SearchClientSync` directly. Each scenario verifies one operation against the sandbox index. Index contents are overwritten on each run, so the same index is safe to reuse.
+
+## To run against your Algolia sandbox account
+
+### One-time setup
+
+1. Create or pick a sandbox Algolia application (never production). Provision a primary and replica index inside it.
+2. Copy the example env file and fill it in:
+   ```
+   cp scripts/.env.example scripts/.env
+   ```
+   Required vars in `scripts/.env`: `ALGOLIA_APPLICATION_ID`, `ALGOLIA_ADMIN_API_KEY`, `ALGOLIA_INDEX_NAME`, `ALGOLIA_REPLICA_INDEX_NAME`. `ALGOLIA_SEARCH_API_KEY` is optional and only needed for the `generate_secured_api_key` scenario. The runner refuses to start if `ALGOLIA_INDEX_NAME` contains the substring `prod` as a guardrail.
+3. Install the runner's extra dependencies inside the catalog container (only `python-dotenv` — `algoliasearch` is already in the project requirements):
+   ```
+   docker exec enterprise.catalog.app pip install -r scripts/requirements.txt
+   ```
+   This pip install lives only in the running container layer; if the container is rebuilt, repeat the step.
+
+### Running scenarios
+
+List the available scenarios:
+
+```
+docker exec enterprise.catalog.app python scripts/test_algolia_integration.py --list
+```
+
+Run the full default suite (everything except scenarios marked `[opt-in]`):
+
+```
+docker exec enterprise.catalog.app python scripts/test_algolia_integration.py --all -v
+```
+
+Run a single scenario (skips dependency resolution if the scenario has none, or runs its dependency chain first):
+
+```
+docker exec enterprise.catalog.app python scripts/test_algolia_integration.py \
+  --test browse_by_aggregation_key -v
+```
+
+Useful flags: `--verbose` / `-v` prints scenario result data and the masked configuration; `--debug` enables debug-level Python logging; `--stop-on-fail` halts after the first failure; `--env PATH` overrides the default `scripts/.env` lookup.
+
+### Default scenarios (run by `--all`)
+
+| Scenario | What it verifies |
+| --- | --- |
+| `init_and_index_exists` | Wrapper can talk to Algolia and both sandbox indices exist. |
+| `set_index_settings` | `set_settings` works for primary and replica (replica gets `customRanking`, the only setting virtual replicas accept here). |
+| `seed_sample_records` | Five sample records land in the sandbox index, verified via `get_objects` polling. |
+| `browse_by_aggregation_key` | `get_all_objects_associated_with_aggregation_key` returns every seeded objectID via the v4 aggregator-callback path. |
+| `delete_objects` | `remove_objects` deletes the requested ids; remaining ids are still browsable. |
+| `list_indices_shape` | `list_indices_with_http_info()` returns parseable JSON with the expected camelCase keys. (See production-bug note below.) |
+| `create_and_delete_temporary_index` | `delete_index` removes a tmp index this scenario creates. |
+| `generate_secured_api_key` | Wrapper generates a restricted secured key; the key is usable for a search and the restriction filter is enforced. Skipped if `ALGOLIA_SEARCH_API_KEY` is not set. |
+
+### Opt-in scenarios
+
+`replace_all_objects_and_search` exercises the wrapper's `replace_all_objects` path. It is excluded from `--all` because the v4 SDK's `wait_for_task` helper has a fixed retry budget that busy sandbox apps blow past, even when the underlying copy/index/swap eventually completes server-side. Run it explicitly when you want to test that path:
+
+```
+docker exec enterprise.catalog.app python scripts/test_algolia_integration.py \
+  --test replace_all_objects_and_search -v
+```
+
+### Notes on sandbox timing
+
+Algolia's task queue can be slow on busy sandbox apps. Several scenarios poll until the operation is observable rather than relying on the SDK's `wait_for_task`:
+
+- `seed_sample_records` polls `get_objects` for up to 5 minutes.
+- `delete_objects` polls `get_objects` for up to 3 minutes.
+- `create_and_delete_temporary_index` polls `index_exists` for up to 1 minute on each side.
+- `generate_secured_api_key` polls `search_single_index` for up to 2 minutes (the secured-key search depends on `attributesForFaceting` having propagated, which can lag the writes).
+
+If a scenario fails with "not visible after Ns", it usually means the sandbox queue was congested. Wait a minute and re-run the scenario, or run with `--debug` to see the polling cadence.
+
+### Production bug surfaced by these scenarios
+
+While running `list_indices_shape` against a real sandbox app, we discovered the v4 SDK's typed `list_indices()` raises `pydantic.ValidationError` because the Algolia API regularly omits fields (`lastBuildTimeS`, `numberOfPendingTasks`, `pendingTask`) that the SDK's `FetchedIndex` model declares as required. The production `_get_all_indices` helper in `enterprise_catalog/apps/api/tasks.py` was rewritten to use `list_indices_with_http_info()` and parse the raw JSON body directly, sidestepping the strict deserialization. The integration scenario takes the same path and this is one reason to keep it green.
+
+### Pytest collection
+
+`scripts/` is excluded from pytest discovery in both `pytest.ini` and `pytest.local.ini` (`norecursedirs = .* docs requirements scripts ...`) so the runner's `test_*.py` filenames don't get collected as unit tests.

--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from operator import itemgetter
 
-from algoliasearch.exceptions import AlgoliaException
+from algoliasearch.http.exceptions import AlgoliaException
 from celery import shared_task, states
 from celery.exceptions import Ignore
 from celery_utils.logged_task import LoggedTask
@@ -677,10 +677,19 @@ def _is_tmp_index(index):
 
 def _get_all_indices(client):
     """
-    Returns a list of indices from the Algolia client.
+    Returns a list of indices from the Algolia client as plain dicts
+    (camelCase keys, e.g. ``updatedAt``) so downstream helpers can keep using
+    dict-style access regardless of the underlying SDK version.
+
+    Uses ``list_indices_with_http_info`` and parses the raw JSON body rather
+    than relying on the v4 SDK's strict ``FetchedIndex`` Pydantic model: in
+    practice the real Algolia API omits fields (``lastBuildTimeS``,
+    ``numberOfPendingTasks``, ``pendingTask``) that the SDK declares as
+    required, which makes the typed deserialization raise ``ValidationError``.
     """
-    indices = client.list_indices().get('items', [])
-    return indices
+    response = client.list_indices_with_http_info()
+    payload = json.loads(response.raw_data)
+    return payload.get('items', [])
 
 
 def _retrieve_inactive_tmp_indices(client, min_days_ago, max_days_ago):
@@ -712,7 +721,7 @@ def _delete_indices(client, indices, dry_run=True):
     for index_name in indices:
         try:
             logger.info('Deleting index: %s', index_name)
-            client.init_index(index_name).delete()
+            client.delete_index(index_name)
             logger.info('Deleted index: %s', index_name)
         except Exception as exep:
             logger.exception(

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -9,7 +9,7 @@ from operator import itemgetter
 from unittest import mock
 
 import ddt
-from algoliasearch.exceptions import AlgoliaException
+from algoliasearch.http.exceptions import AlgoliaException
 from celery import states
 from django.test import TestCase, override_settings
 from django_celery_results.models import TaskResult
@@ -51,6 +51,17 @@ from enterprise_catalog.apps.catalog.utils import localized_utcnow
 # An object that represents the output of some hard work done by a task.
 COMPUTED_PRECIOUS_OBJECT = object()
 SORTED_QUERY_UUID_LIST = sorted([uuid.uuid4(), uuid.uuid4()])
+
+
+def _mock_list_indices_response(item_dicts):
+    """
+    Build a fake ApiResponse for the v4 Algolia client's
+    ``list_indices_with_http_info``. The production code reads ``raw_data`` and
+    parses it as JSON, so we encode the supplied dicts that way.
+    """
+    response = mock.MagicMock()
+    response.raw_data = json.dumps({'items': list(item_dicts)})
+    return response
 
 
 @tasks.expiring_task_semaphore()
@@ -1367,40 +1378,30 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             {'key': 'course-v1:edX+testX+4', 'foo': 'bar'},
         ]
 
-    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')
-    def test_delete_indices_exception_handling(self, mock_search_client):
+    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClientSync')
+    def test_delete_indices_exception_handling(self, mock_search_client):  # pylint: disable=unused-argument
         """
         Test that exceptions during index deletion are properly caught and re-raised.
         """
-        # Setup mock data
         index_name = 'enterprise_catalog_tmp_test'
         mock_indices = [index_name]
 
-        # Configure mock
         mock_client = mock.MagicMock()
-        mock_index = mock.MagicMock()
-        mock_index.delete.side_effect = Exception("Test exception")
-        mock_client.init_index.return_value = mock_index
-        mock_search_client.create.return_value = mock_client
+        mock_client.delete_index.side_effect = Exception("Test exception")
 
-        # Create a mock task instance
         mock_task_id = uuid.uuid4()
         bound_task_object = mock.MagicMock()
         bound_task_object.request.id = mock_task_id
 
-        # Test that the exception is re-raised
         with self.assertRaises(Exception):
             with self.assertLogs(level='ERROR') as log_context:
                 tasks._delete_indices(mock_client, mock_indices, dry_run=False)  # pylint: disable=protected-access
 
-        # Verify the exception was logged
         self.assertTrue(any('Test exception' in msg for msg in log_context.output))
-
-        # Verify the client was initialized with the correct index
-        mock_client.init_index.assert_called_once_with(index_name)
+        mock_client.delete_index.assert_called_once_with(index_name)
 
     # Test remove_old_temporary_catalog_indices_task
-    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')
+    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClientSync')
     def test_remove_old_temporary_catalog_indices(self, mock_search_client):
         """
         Test that temporary indices between 10 and 60 days old get deleted.
@@ -1408,8 +1409,12 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
         # Setup mock data
         now = datetime.now()
         index_name = 'enterprise_catalog_new'
-        # Mock django conf settings.ALGOLIA['INDEX_NAME'] to be 'enterprise_catalog_new'
-        with self.settings(ALGOLIA={'INDEX_NAME': index_name}):
+        # Mock django conf settings.ALGOLIA to provide credentials and index name.
+        with self.settings(ALGOLIA={
+            'INDEX_NAME': index_name,
+            'APPLICATION_ID': 'fake-app-id',
+            'API_KEY': 'fake-api-key',
+        }):
 
             mock_indices = {
                 'items': [
@@ -1463,12 +1468,12 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 ]
             }
 
-            # Configure mock
             mock_client = mock.MagicMock()
-            mock_client.list_indices.return_value = mock_indices
-            mock_search_client.create.return_value = mock_client
+            mock_client.list_indices_with_http_info.return_value = _mock_list_indices_response(
+                mock_indices['items']
+            )
+            mock_search_client.return_value = mock_client
 
-            # Create a mock task instance (similar to other tests in the file)
             mock_task_id = uuid.uuid4()
             bound_task_object = mock.MagicMock()
             bound_task_object.request.id = mock_task_id
@@ -1476,12 +1481,10 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             bound_task_object.request.kwargs = {}
 
             with self.assertLogs(level='INFO'):
-                # Call the task with the bound task object
                 tasks.remove_old_temporary_catalog_indices_task(
                     bound_task_object, min_days_ago=10, max_days_ago=60, dry_run=False
                 )
 
-                # Verify the correct indices were identified
                 expected_indices_to_delete = [
                     f'{index_name}_tmp_1',
                     f'{index_name}_tmp_2',
@@ -1489,12 +1492,10 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                     f'{index_name}_tmp_7'
                 ]
 
-                # Verify SearchClient was created with correct credentials
-                mock_search_client.create.assert_called_once()
+                mock_search_client.assert_called_once()
 
-                # Test that mock_search_client.init_index was called with the index names to be deleted and none other
-                mock_client.init_index.assert_has_calls(
-                    [mock.call(index_name) for index_name in expected_indices_to_delete],
+                mock_client.delete_index.assert_has_calls(
+                    [mock.call(idx) for idx in expected_indices_to_delete],
                     any_order=True
                 )
 
@@ -1503,42 +1504,41 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                     if index['name'] not in expected_indices_to_delete
                 ]
 
-                # Test that mock_search_client.init_index has no calls for indices that should not be deleted
-                for call in mock_client.init_index.call_args_list:
-                    index_name = call[0][0]
-                    assert index_name not in indexes_not_to_delete, f"Unexpected call to delete index: {index_name}"
+                for call in mock_client.delete_index.call_args_list:
+                    deleted_name = call[0][0]
+                    assert deleted_name not in indexes_not_to_delete, (
+                        f"Unexpected call to delete index: {deleted_name}"
+                    )
 
-                assert mock_client.init_index.called
-
-                assert mock_client.init_index.return_value.delete.call_count == len(expected_indices_to_delete)
+                assert mock_client.delete_index.call_count == len(expected_indices_to_delete)
 
     # Test remove_old_temporary_catalog_indices_task
-    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')
+    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClientSync')
     def test_remove_old_temporary_catalog_indices_should_not_delete_on_dry_run(self, mock_search_client):
         """
         Test that temporary indices between 10 and 60 days old get deleted.
         """
-        # Setup mock data
         now = datetime.now()
         index_name = 'enterprise_catalog_new'
-        # Mock django conf settings.ALGOLIA['INDEX_NAME'] to be 'enterprise_catalog_new'
-        with self.settings(ALGOLIA={'INDEX_NAME': index_name}):
-            mock_indices = {
-                'items': [
-                    {
-                        'name': f'{index_name}_tmp_1',
-                        'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
-                        'entries': 0
-                    }
-                ]
-            }
+        with self.settings(ALGOLIA={
+            'INDEX_NAME': index_name,
+            'APPLICATION_ID': 'fake-app-id',
+            'API_KEY': 'fake-api-key',
+        }):
+            mock_indices = [
+                {
+                    'name': f'{index_name}_tmp_1',
+                    'updatedAt': (now - timedelta(days=30)).strftime('%Y-%m-%dT%H:%M:%S.%fZ'),
+                    'entries': 0
+                }
+            ]
 
-            # Configure mock
             mock_client = mock.MagicMock()
-            mock_client.list_indices.return_value = mock_indices
-            mock_search_client.create.return_value = mock_client
+            mock_client.list_indices_with_http_info.return_value = _mock_list_indices_response(
+                mock_indices
+            )
+            mock_search_client.return_value = mock_client
 
-            # Create a mock task instance (similar to other tests in the file)
             mock_task_id = uuid.uuid4()
             bound_task_object = mock.MagicMock()
             bound_task_object.request.id = mock_task_id
@@ -1546,7 +1546,6 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
             bound_task_object.request.kwargs = {}
 
             with self.assertLogs(level='INFO') as log_context:
-                # Call the task with the bound task object
                 tasks.remove_old_temporary_catalog_indices_task(
                     bound_task_object, min_days_ago=10, max_days_ago=60
                 )
@@ -1554,11 +1553,9 @@ class IndexEnterpriseCatalogCoursesInAlgoliaTaskTests(TestCase):
                 log_message = [msg for msg in log_context.output if 'Index names to delete' in msg][0]
                 self.assertIn(f'{index_name}_tmp_1', log_message)
 
-                # Verify SearchClient was created with correct credentials
-                mock_search_client.create.assert_called_once()
+                mock_search_client.assert_called_once()
 
-                assert not mock_client.init_index.called
-                assert not mock_client.init_index.return_value.delete.called
+                assert not mock_client.delete_index.called
 
     @mock.patch('enterprise_catalog.apps.api.tasks.new_search_client_or_error')
     def test_remove_old_temporary_catalog_indices_task_client_exception(self, mock_client_or_error):

--- a/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_enterprise_customer_views.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from unittest import mock
 
 import pytz
-from algoliasearch.exceptions import AlgoliaException
+from algoliasearch.http.exceptions import AlgoliaException
 from django.test import override_settings
 from rest_framework import status
 
@@ -525,10 +525,14 @@ class EnterpriseCustomerViewSetTests(BaseEnterpriseCustomerViewSetTests):
         self.assertEqual(response.data, expected_error_response)
 
     @mock.patch(
-        "algoliasearch.search_client.SearchClient.generate_secured_api_key",
+        "algoliasearch.search.client.SearchClientSync.generate_secured_api_key",
         side_effect=AlgoliaException("Mocked exception"),
     )
-    @override_settings(ALGOLIA={'SEARCH_API_KEY': 'fake-search-api-search'})
+    @override_settings(ALGOLIA={
+        'SEARCH_API_KEY': 'fake-search-api-search',
+        'APPLICATION_ID': 'fake-app-id',
+        'API_KEY': 'fake-api-key',
+    })
     def test_secured_algolia_api_key_algolia_exception(self, mock_generate_key):  # pylint: disable=unused-argument
         """
         Test that the secured Algolia API key is not generated if an AlgoliaException occurs.

--- a/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_customer.py
@@ -1,7 +1,7 @@
 import logging
 import uuid
 
-from algoliasearch.exceptions import AlgoliaException
+from algoliasearch.http.exceptions import AlgoliaException
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.decorators import method_decorator
 from drf_spectacular.utils import OpenApiExample, extend_schema

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -5,8 +5,8 @@ Algolia api client code.
 import logging
 from datetime import timedelta
 
-from algoliasearch.exceptions import AlgoliaException
-from algoliasearch.search_client import SearchClient
+from algoliasearch.http.exceptions import AlgoliaException
+from algoliasearch.search.client import SearchClientSync
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -16,6 +16,34 @@ from enterprise_catalog.apps.catalog.utils import localized_utcnow
 logger = logging.getLogger(__name__)
 
 
+class _AlgoliaIndexProxy:
+    """
+    Thin compatibility proxy that mimics the v3 ``index.search`` /
+    ``index.search_for_facet_values`` shape on top of the v4 client.
+
+    v4 collapsed per-index objects into client methods that take ``index_name``
+    as a parameter and return Pydantic models. Several callsites in this repo
+    (CSV/workbook exports, AI curation, academy facet lookups) still expect the
+    v3 dict-shaped responses, so this proxy preserves that interface.
+    """
+
+    def __init__(self, client, index_name):
+        self._client = client
+        self._index_name = index_name
+
+    def search(self, query, request_options=None):
+        params = dict(request_options or {})
+        params['query'] = query
+        response = self._client.search_single_index(self._index_name, search_params=params)
+        return response.to_dict()
+
+    def search_for_facet_values(self, facet_name, query, request_options=None):
+        body = dict(request_options or {})
+        body.setdefault('facetQuery', query)
+        response = self._client.search_for_facet_values(self._index_name, facet_name, body)
+        return response.to_dict()
+
+
 class AlgoliaSearchClient:
     """
     Object builds an API client to make calls to an Algolia index.
@@ -23,8 +51,17 @@ class AlgoliaSearchClient:
 
     def __init__(self):
         self._client = None
-        self.algolia_index = None
-        self.replica_index = None
+
+    @property
+    def algolia_index(self):
+        """
+        Compatibility shim for callers that still use the v3-style
+        ``algolia_client.algolia_index.search(...)`` pattern. Returns ``None``
+        if the client has not been initialized via ``init_index()``.
+        """
+        if not self._client or not self.algolia_index_name:
+            return None
+        return _AlgoliaIndexProxy(self._client, self.algolia_index_name)
 
     @property
     def algolia_application_id(self):
@@ -48,10 +85,12 @@ class AlgoliaSearchClient:
 
     def init_index(self):
         """
-        Initializes an index within Algolia. Initializing an index will create it if it doesn't exist.
+        Initializes the Algolia client. In v4 of the Python SDK there is no
+        per-index object; the client is constructed once and operations take
+        the index name as a parameter.
         """
         if not self.algolia_index_name or not self.algolia_replica_index_name:
-            logger.error('Could not initialize Algolia index due to missing index name.')
+            logger.error('Could not initialize Algolia client due to missing index name.')
             return
 
         if not self.algolia_application_id or not self.algolia_api_key:
@@ -62,28 +101,7 @@ class AlgoliaSearchClient:
             )
             return
 
-        # Create SearchClient
-        self._client = SearchClient.create(self.algolia_application_id, self.algolia_api_key)
-
-        # Initialize Algolia indices
-        if self.algolia_index_name:
-            try:
-                self.algolia_index = self._client.init_index(self.algolia_index_name)
-            except AlgoliaException as exc:
-                logger.exception(
-                    'Could not initialize %s index in Algolia due to an exception.',
-                    self.algolia_index_name,
-                )
-                raise exc
-        if self.algolia_replica_index_name:
-            try:
-                self.replica_index = self._client.init_index(self.algolia_replica_index_name)
-            except AlgoliaException as exc:
-                logger.exception(
-                    'Could not initialize %s index in Algolia due to an exception.',
-                    self.algolia_replica_index_name,
-                )
-                raise exc
+        self._client = SearchClientSync(self.algolia_application_id, self.algolia_api_key)
 
     def set_index_settings(self, index_settings, primary_index=True):
         """
@@ -93,34 +111,34 @@ class AlgoliaSearchClient:
         Algolia dashboard but ensures consistent settings (configuration as code).
 
         Arguments:
-            settings (dict): A dictionary of Algolia settings.
+            index_settings (dict): A dictionary of Algolia settings.
+            primary_index (bool): If True, settings target the primary index;
+                otherwise the replica index.
         """
-        if not self.algolia_index:
-            logger.error('Algolia index does not exist. Did you initialize it?')
+        if not self._client:
+            logger.error('Algolia client does not exist. Did you initialize it?')
             return
 
+        index_name = self.algolia_index_name if primary_index else self.algolia_replica_index_name
         try:
-            if primary_index:
-                self.algolia_index.set_settings(index_settings)
-            else:
-                self.replica_index.set_settings(index_settings)
+            self._client.set_settings(index_name, index_settings)
         except AlgoliaException as exc:
             logger.exception(
                 'Unable to set settings for Algolia\'s %s index due to an exception.',
-                self.algolia_index_name,
+                index_name,
             )
             raise exc
 
     def index_exists(self):
         """
-        Returns whether the index exists in Algolia.
+        Returns whether the primary and replica indices both exist in Algolia.
         """
-        if not self.algolia_index or not self.replica_index:
-            logger.error('Algolia index does not exist. Did you initialize it?')
+        if not self._client:
+            logger.error('Algolia client does not exist. Did you initialize it?')
             return False
 
-        primary_exists = self.algolia_index.exists()
-        replica_exists = self.replica_index.exists()
+        primary_exists = self._client.index_exists(self.algolia_index_name)
+        replica_exists = self._client.index_exists(self.algolia_replica_index_name)
         if not primary_exists:
             logger.warning(
                 'Index with name %s does not exist in Algolia.',
@@ -139,21 +157,19 @@ class AlgoliaSearchClient:
         Clears all objects from the index and replaces them with a new set of objects. The records are
         replaced in the index without any downtime due to an atomic reindex.
 
-        See https://www.algolia.com/doc/api-reference/api-methods/replace-all-objects/ for more detials.
+        See https://www.algolia.com/doc/api-reference/api-methods/replace-all-objects/ for more details.
 
         Arguments:
-            algolia_objects (list): List of objects to include in the Algolia index
+            algolia_objects (list): List of objects to include in the Algolia index.
         """
         if not self.index_exists():
-            # index must exist to continue, nothing left to do
             return
 
-        # The 'safe' field makes the client wait for asynchronous indexing operations to complete
-        use_safe = getattr(settings, 'USE_REPLACE_ALL_OBJECTS_SAFE', True)
+        # v4 of the Algolia client manages the copy/reindex/swap sequencing
+        # internally and no longer accepts the v3 `safe` flag. The legacy
+        # USE_REPLACE_ALL_OBJECTS_SAFE setting is intentionally ignored.
         try:
-            self.algolia_index.replace_all_objects(algolia_objects, {
-                'safe': use_safe,
-            })
+            self._client.replace_all_objects(self.algolia_index_name, list(algolia_objects))
             logger.info('The %s Algolia index was successfully indexed.', self.algolia_index_name)
         except AlgoliaException as exc:
             logger.exception(
@@ -168,15 +184,21 @@ class AlgoliaSearchClient:
         """
         objects = []
         if not self.index_exists():
-            # index must exist to continue, nothing left to do
             return objects
+
+        def _collect(response):
+            for hit in response.hits:
+                objects.append(hit.object_id)
+
         try:
-            index_browse_iterator = self.algolia_index.browse_objects({
-                "attributesToRetrieve": ["objectID"],
-                "filters": f"aggregation_key:'{aggregation_key}'",
-            })
-            for hit in index_browse_iterator:
-                objects.append(hit['objectID'])
+            self._client.browse_objects(
+                self.algolia_index_name,
+                aggregator=_collect,
+                browse_params={
+                    'attributesToRetrieve': ['objectID'],
+                    'filters': f"aggregation_key:'{aggregation_key}'",
+                },
+            )
         except AlgoliaException as exc:
             logger.exception(
                 'Could not retrieve objects associated with aggregation key %s due to an exception.',
@@ -190,11 +212,10 @@ class AlgoliaSearchClient:
         Removes objects from the Algolia index.
         """
         if not self.index_exists():
-            # index must exist to continue, nothing left to do
             return
 
         try:
-            self.algolia_index.delete_objects(object_ids)
+            self._client.delete_objects(self.algolia_index_name, object_ids)
             logger.info(
                 'The following objects were successfully removed from the %s Algolia index: %s',
                 self.algolia_index_name,
@@ -229,6 +250,14 @@ class AlgoliaSearchClient:
                 'Cannot generate secured Algolia API key without the ALGOLIA.SEARCH_API_KEY in settings.'
             )
 
+        if not self._client:
+            if not self.algolia_application_id or not self.algolia_api_key:
+                raise ImproperlyConfigured(
+                    'Cannot generate secured Algolia API key without '
+                    'ALGOLIA.APPLICATION_ID and ALGOLIA.API_KEY in settings.'
+                )
+            self._client = SearchClientSync(self.algolia_application_id, self.algolia_api_key)
+
         expiration_time = getattr(settings, 'SECURED_ALGOLIA_API_KEY_EXPIRATION', 3600)  # Default to 1 hour
         valid_until_dt = localized_utcnow() + timedelta(seconds=expiration_time)
         valid_until_unix = int(valid_until_dt.timestamp())
@@ -252,10 +281,10 @@ class AlgoliaSearchClient:
         if indices:
             restrictions |= {'restrictIndices': indices}
 
-        # Generate secured api key
+        # Generate secured api key. In v4 this is an instance method on the client.
         logger.info('[AlgoliaSearchClient.generate_secured_api_key] restrictions: %s', restrictions)
         try:
-            secured_api_key = SearchClient.generate_secured_api_key(
+            secured_api_key = self._client.generate_secured_api_key(
                 self.algolia_search_api_key,
                 restrictions,
             )

--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -3,7 +3,7 @@ import datetime
 import logging
 import time
 
-from algoliasearch.search_client import SearchClient
+from algoliasearch.search.client import SearchClientSync
 from dateutil import parser
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
@@ -397,16 +397,13 @@ def new_search_client_or_error():
     """
     Returns a new Algolia search client that is not initialized to any specific index.
     """
-    client = SearchClient.create(
-        settings.ALGOLIA.get('APPLICATION_ID', None),
-        settings.ALGOLIA.get('API_KEY', None)
-    )
-    if not client:
+    app_id = settings.ALGOLIA.get('APPLICATION_ID', None)
+    api_key = settings.ALGOLIA.get('API_KEY', None)
+    if not app_id or not api_key:
         raise TypeError(
-            'Failed to create Algolia search client.'
-            f'The client should be an Algolia search client, but was {client}.'
+            'Failed to create Algolia search client: missing APPLICATION_ID or API_KEY.'
         )
-    return client
+    return SearchClientSync(app_id, api_key)
 
 
 def configure_algolia_index(algolia_client):

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -1874,24 +1874,22 @@ class AlgoliaUtilsTests(TestCase):
         transformed_advertised_course_run = _get_course_run(searchable_course, advertised_course_run)
         assert transformed_advertised_course_run == expected_course_run
 
-    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClient')
+    @mock.patch('enterprise_catalog.apps.catalog.algolia_utils.SearchClientSync')
     def test_new_search_client_or_error(self, mock_search_client):
         """
         Test that new_search_client_or_error returns a valid search client or raises an error.
         """
         mock_client = mock.MagicMock()
-        # Test successful client creation
-        mock_search_client.create.return_value = mock_client
-        client = utils.new_search_client_or_error()
+        mock_search_client.return_value = mock_client
 
-        assert client is mock_client
-        assert mock_search_client.create.call_count == 1
+        with self.settings(ALGOLIA={'APPLICATION_ID': 'app', 'API_KEY': 'key'}):
+            client = utils.new_search_client_or_error()
+            assert client is mock_client
+            assert mock_search_client.call_count == 1
 
-        # Test error case when client creation fails
-        mock_search_client.create.return_value = None
-        with self.assertRaises(TypeError) as context:
-            utils.new_search_client_or_error()
+        # Test error case when settings are missing
+        with self.settings(ALGOLIA={}):
+            with self.assertRaises(TypeError) as context:
+                utils.new_search_client_or_error()
 
-        # Verify the error message
         self.assertIn('Failed to create Algolia search client', str(context.exception))
-        self.assertIn('should be an Algolia search client', str(context.exception))

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,7 +9,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = enterprise_catalog.settings.test
 addopts = --cov enterprise_catalog --cov-report term-missing --cov-report xml
-norecursedirs = .* docs requirements
+norecursedirs = .* docs requirements scripts
 
 # Filter depr warnings coming from packages that we can't control.
 filterwarnings =

--- a/pytest.local.ini
+++ b/pytest.local.ini
@@ -16,7 +16,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = enterprise_catalog.settings.test
 addopts = --cov-report term-missing --cov-report xml -W ignore
-norecursedirs = .* docs requirements site-packages
+norecursedirs = .* docs requirements scripts site-packages
 
 # Filter depr warnings coming from packages that we can't control.
 filterwarnings =

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,13 @@
 #
 #    make upgrade
 #
-algoliasearch==3.0.0
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.13.5
+    # via algoliasearch
+aiosignal==1.4.0
+    # via aiohttp
+algoliasearch==4.39.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -22,8 +28,12 @@ asgiref==3.11.1
     # via
     #   django
     #   django-cors-headers
+    #   social-auth-app-django
+async-timeout==5.0.1
+    # via algoliasearch
 attrs==26.1.0
     # via
+    #   aiohttp
     #   jsonschema
     #   referencing
 backoff==1.10.0
@@ -36,7 +46,7 @@ celery==5.6.3
     #   -r requirements/base.in
     #   django-celery-results
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   httpcore
     #   httpx
@@ -47,7 +57,7 @@ cffi==2.0.0
     #   pynacl
 charset-normalizer==3.4.7
     # via requests
-click==8.3.2
+click==8.3.3
     # via
     #   celery
     #   click-didyoumean
@@ -63,8 +73,10 @@ click-repl==0.3.0
     # via celery
 code-annotations==3.0.0
     # via edx-toggles
-cryptography==46.0.7
-    # via pyjwt
+cryptography==47.0.0
+    # via
+    #   pyjwt
+    #   social-auth-core
 defusedxml==0.7.1
     # via
     #   djangorestframework-xml
@@ -129,7 +141,7 @@ django-model-utils==5.0.0
     #   -r requirements/base.in
     #   edx-celeryutils
     #   edx-rbac
-django-modeltranslation==0.20.2
+django-modeltranslation==0.20.3
     # via -r requirements/base.in
 django-simple-history==3.11.0
     # via
@@ -185,17 +197,22 @@ edx-toggles==6.0.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
+frozenlist==1.8.0
+    # via
+    #   aiohttp
+    #   aiosignal
 h11==0.16.0
     # via httpcore
 httpcore==1.0.9
     # via httpx
 httpx==0.28.1
     # via openai
-idna==3.11
+idna==3.13
     # via
     #   anyio
     #   httpx
     #   requests
+    #   yarl
 inflection==0.5.1
     # via drf-spectacular
 jinja2==3.1.6
@@ -216,6 +233,10 @@ markupsafe==3.0.3
     # via jinja2
 monotonic==1.6
     # via analytics-python
+multidict==6.7.1
+    # via
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.8
     # via -r requirements/base.in
 numpy==2.4.4
@@ -230,19 +251,25 @@ openai==1.13.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
-packaging==26.0
+packaging==26.2
     # via kombu
 ply==3.11
     # via djangoql
 prompt-toolkit==3.0.52
     # via click-repl
+propcache==0.4.1
+    # via
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via edx-django-utils
 pycparser==3.0
     # via cffi
-pydantic==2.12.5
-    # via openai
-pydantic-core==2.41.5
+pydantic==2.13.3
+    # via
+    #   algoliasearch
+    #   openai
+pydantic-core==2.46.3
     # via pydantic
 pyjwt[crypto]==2.12.1
     # via
@@ -253,12 +280,13 @@ pyjwt[crypto]==2.12.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/base.in
-pymongo==4.16.0
+pymongo==4.17.0
     # via edx-opaque-keys
 pynacl==1.6.2
     # via edx-django-utils
 python-dateutil==2.9.0.post0
     # via
+    #   algoliasearch
     #   analytics-python
     #   celery
 python-slugify==8.0.4
@@ -300,7 +328,7 @@ scipy==1.17.1
     # via scikit-learn
 semantic-version==2.10.0
     # via edx-drf-extensions
-simplejson==3.20.2
+simplejson==4.1.1
     # via -r requirements/base.in
 six==1.17.0
     # via
@@ -311,11 +339,11 @@ six==1.17.0
     #   python-dateutil
 sniffio==1.3.1
     # via openai
-social-auth-app-django==5.7.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==4.8.5
+social-auth-core==4.9.0
     # via
     #   edx-auth-backends
     #   social-auth-app-django
@@ -336,6 +364,7 @@ tqdm==4.67.3
     # via openai
 typing-extensions==4.15.0
     # via
+    #   aiosignal
     #   anyio
     #   django-modeltranslation
     #   edx-opaque-keys
@@ -346,14 +375,16 @@ typing-extensions==4.15.0
     #   typing-inspection
 typing-inspection==0.4.2
     # via pydantic
-tzdata==2026.1
+tzdata==2026.2
     # via kombu
 tzlocal==5.3.1
     # via celery
 uritemplate==4.2.0
     # via drf-spectacular
 urllib3==2.6.3
-    # via requests
+    # via
+    #   algoliasearch
+    #   requests
 vine==5.1.0
     # via
     #   amqp
@@ -363,7 +394,9 @@ wcwidth==0.6.0
     # via prompt-toolkit
 xlsxwriter==3.2.9
     # via -r requirements/base.in
-zipp==3.23.0
+yarl==1.23.0
+    # via aiohttp
+zipp==3.23.1
     # via -r requirements/base.in
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,5 +30,5 @@ diff-cover==4.0.0
 # To avoid any breaking changes
 openai<=1.13.3
 
-# algoliasearch 4.0 is not backwards compatible with 3.0
-algoliasearch<4
+# Stay on major version 4 of algolia client
+algoliasearch>=4,<5

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,22 @@
 #
 #    make upgrade
 #
-algoliasearch==3.0.0
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   algoliasearch
+aiosignal==1.4.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+algoliasearch==4.39.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
@@ -35,16 +50,23 @@ asgiref==3.11.1
     #   -r requirements/test.txt
     #   django
     #   django-cors-headers
+    #   social-auth-app-django
 astroid==4.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+async-timeout==5.0.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   algoliasearch
 attrs==26.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   aiohttp
     #   jsonschema
     #   referencing
 backoff==1.10.0
@@ -57,11 +79,11 @@ billiard==4.2.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-build==1.4.2
+build==1.4.4
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-cachetools==7.0.5
+cachetools==7.0.6
     # via
     #   -r requirements/test.txt
     #   tox
@@ -72,7 +94,7 @@ celery==5.6.3
     #   -r requirements/test.txt
     #   django-celery-results
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -90,7 +112,7 @@ charset-normalizer==3.4.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-click==8.3.2
+click==8.3.3
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -138,11 +160,12 @@ coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwt
+    #   social-auth-core
 ddt==1.7.2
     # via
     #   -r requirements/dev.in
@@ -255,7 +278,7 @@ django-model-utils==5.0.0
     #   -r requirements/test.txt
     #   edx-celeryutils
     #   edx-rbac
-django-modeltranslation==0.20.2
+django-modeltranslation==0.20.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -329,7 +352,7 @@ edx-drf-extensions==10.6.0
     #   edx-rbac
 edx-i18n-tools==2.0.0
     # via -r requirements/dev.in
-edx-lint==6.0.0
+edx-lint==6.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -353,16 +376,22 @@ edx-toggles==6.0.0
     #   edx-auth-backends
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==40.13.0
+faker==40.15.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   -r requirements/test.txt
     #   python-discovery
     #   tox
     #   virtualenv
+frozenlist==1.8.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   aiosignal
 gunicorn==25.3.0
     # via -r requirements/dev.in
 h11==0.16.0
@@ -380,13 +409,14 @@ httpx==0.28.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openai
-idna==3.11
+idna==3.13
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   anyio
     #   httpx
     #   requests
+    #   yarl
 inflect==7.5.0
     # via
     #   -r requirements/dev.in
@@ -443,7 +473,7 @@ kombu==5.6.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-lxml[html-clean]==6.0.2
+lxml[html-clean]==6.1.0
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -464,8 +494,14 @@ monotonic==1.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
-more-itertools==11.0.1
+more-itertools==11.0.2
     # via inflect
+multidict==6.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.8
     # via
     #   -r requirements/quality.txt
@@ -487,7 +523,7 @@ openai==1.13.3
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -503,7 +539,7 @@ path==16.16.0
     # via edx-i18n-tools
 pip-tools==7.5.3
     # via -r requirements/pip-tools.txt
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -530,6 +566,12 @@ prompt-toolkit==3.0.52
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   click-repl
+propcache==0.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via
     #   -r requirements/quality.txt
@@ -542,12 +584,13 @@ pycparser==3.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
-pydantic==2.12.5
+pydantic==2.13.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   algoliasearch
     #   openai
-pydantic-core==2.41.5
+pydantic-core==2.46.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -596,7 +639,7 @@ pymemcache==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -628,6 +671,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   algoliasearch
     #   analytics-python
     #   celery
 python-discovery==1.2.2
@@ -714,7 +758,7 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.20.2
+simplejson==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -737,12 +781,12 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==5.7.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.8.5
+social-auth-core==4.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -784,8 +828,9 @@ tomlkit==0.14.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   edx-lint
     #   pylint
-tox==4.52.0
+tox==4.53.0
     # via -r requirements/test.txt
 tqdm==4.67.3
     # via
@@ -798,6 +843,7 @@ typing-extensions==4.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   aiosignal
     #   anyio
     #   django-modeltranslation
     #   edx-opaque-keys
@@ -812,7 +858,7 @@ typing-inspection==0.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pydantic
-tzdata==2026.1
+tzdata==2026.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -831,6 +877,7 @@ urllib3==2.6.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   algoliasearch
     #   requests
     #   responses
 vine==5.1.0
@@ -840,7 +887,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.2.0
+virtualenv==21.3.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -849,7 +896,7 @@ wcwidth==0.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   prompt-toolkit
-wheel==0.46.3
+wheel==0.47.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
@@ -857,7 +904,12 @@ xlsxwriter==3.2.9
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-zipp==3.23.0
+yarl==1.23.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+zipp==3.23.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,9 +6,21 @@
 #
 accessible-pygments==0.0.5
     # via pydata-sphinx-theme
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/test.txt
+    #   algoliasearch
+aiosignal==1.4.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
 alabaster==1.0.0
     # via sphinx
-algoliasearch==3.0.0
+algoliasearch==4.39.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
@@ -32,14 +44,20 @@ asgiref==3.11.1
     #   -r requirements/test.txt
     #   django
     #   django-cors-headers
+    #   social-auth-app-django
 astroid==4.0.4
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+async-timeout==5.0.1
+    # via
+    #   -r requirements/test.txt
+    #   algoliasearch
 attrs==26.1.0
     # via
     #   -r requirements/test.txt
+    #   aiohttp
     #   jsonschema
     #   referencing
 babel==2.18.0
@@ -56,7 +74,7 @@ billiard==4.2.4
     # via
     #   -r requirements/test.txt
     #   celery
-cachetools==7.0.5
+cachetools==7.0.6
     # via
     #   -r requirements/test.txt
     #   tox
@@ -66,7 +84,7 @@ celery==5.6.3
     #   -r requirements/test.txt
     #   django-celery-results
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/test.txt
     #   httpcore
@@ -81,7 +99,7 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/test.txt
     #   requests
-click==8.3.2
+click==8.3.3
     # via
     #   -r requirements/test.txt
     #   celery
@@ -121,10 +139,11 @@ coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -r requirements/test.txt
     #   pyjwt
+    #   social-auth-core
 ddt==1.7.2
     # via -r requirements/test.txt
 defusedxml==0.7.1
@@ -206,7 +225,7 @@ django-model-utils==5.0.0
     #   -r requirements/test.txt
     #   edx-celeryutils
     #   edx-rbac
-django-modeltranslation==0.20.2
+django-modeltranslation==0.20.3
     # via -r requirements/test.txt
 django-simple-history==3.11.0
     # via
@@ -266,7 +285,7 @@ edx-drf-extensions==10.6.0
     # via
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==6.0.0
+edx-lint==6.1.0
     # via -r requirements/test.txt
 edx-opaque-keys==4.0.0
     # via
@@ -282,16 +301,21 @@ edx-toggles==6.0.0
     #   edx-auth-backends
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==40.13.0
+faker==40.15.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   -r requirements/test.txt
     #   python-discovery
     #   tox
     #   virtualenv
+frozenlist==1.8.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   aiosignal
 h11==0.16.0
     # via
     #   -r requirements/test.txt
@@ -304,12 +328,13 @@ httpx==0.28.1
     # via
     #   -r requirements/test.txt
     #   openai
-idna==3.11
+idna==3.13
     # via
     #   -r requirements/test.txt
     #   anyio
     #   httpx
     #   requests
+    #   yarl
 imagesize==2.0.0
     # via sphinx
 inflection==0.5.1
@@ -363,9 +388,14 @@ monotonic==1.6
     # via
     #   -r requirements/test.txt
     #   analytics-python
+multidict==6.7.1
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.8
     # via -r requirements/test.txt
-nh3==0.3.4
+nh3==0.3.5
     # via readme-renderer
 numpy==2.4.4
     # via
@@ -381,7 +411,7 @@ openai==1.13.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -389,7 +419,7 @@ packaging==26.0
     #   pytest
     #   sphinx
     #   tox
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -410,6 +440,11 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/test.txt
     #   click-repl
+propcache==0.4.1
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via
     #   -r requirements/test.txt
@@ -418,11 +453,12 @@ pycparser==3.0
     # via
     #   -r requirements/test.txt
     #   cffi
-pydantic==2.12.5
+pydantic==2.13.3
     # via
     #   -r requirements/test.txt
+    #   algoliasearch
     #   openai
-pydantic-core==2.41.5
+pydantic-core==2.46.3
     # via
     #   -r requirements/test.txt
     #   pydantic
@@ -467,7 +503,7 @@ pylint-plugin-utils==0.9.0
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/test.txt
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -491,6 +527,7 @@ pytest-django==4.12.0
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/test.txt
+    #   algoliasearch
     #   analytics-python
     #   celery
 python-discovery==1.2.2
@@ -562,7 +599,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.20.2
+simplejson==4.1.1
     # via -r requirements/test.txt
 six==1.17.0
     # via
@@ -579,11 +616,11 @@ sniffio==1.3.1
     #   openai
 snowballstemmer==3.0.1
     # via sphinx
-social-auth-app-django==5.7.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.8.5
+social-auth-core==4.9.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -639,8 +676,9 @@ tomli-w==1.2.0
 tomlkit==0.14.0
     # via
     #   -r requirements/test.txt
+    #   edx-lint
     #   pylint
-tox==4.52.0
+tox==4.53.0
     # via -r requirements/test.txt
 tqdm==4.67.3
     # via
@@ -649,6 +687,7 @@ tqdm==4.67.3
 typing-extensions==4.15.0
     # via
     #   -r requirements/test.txt
+    #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   django-modeltranslation
@@ -663,7 +702,7 @@ typing-inspection==0.4.2
     # via
     #   -r requirements/test.txt
     #   pydantic
-tzdata==2026.1
+tzdata==2026.2
     # via
     #   -r requirements/test.txt
     #   kombu
@@ -678,6 +717,7 @@ uritemplate==4.2.0
 urllib3==2.6.3
     # via
     #   -r requirements/test.txt
+    #   algoliasearch
     #   requests
     #   responses
 vine==5.1.0
@@ -686,7 +726,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.2.0
+virtualenv==21.3.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -696,7 +736,11 @@ wcwidth==0.6.0
     #   prompt-toolkit
 xlsxwriter==3.2.9
     # via -r requirements/test.txt
-zipp==3.23.0
+yarl==1.23.0
+    # via
+    #   -r requirements/test.txt
+    #   aiohttp
+zipp==3.23.1
     # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-build==1.4.2
+build==1.4.4
     # via pip-tools
-click==8.3.2
+click==8.3.3
     # via pip-tools
-packaging==26.0
+packaging==26.2
     # via
     #   build
     #   wheel
@@ -18,7 +18,7 @@ pyproject-hooks==1.2.0
     # via
     #   build
     #   pip-tools
-wheel==0.46.3
+wheel==0.47.0
     # via pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,13 @@
 #
 #    make upgrade
 #
-packaging==26.0
+packaging==26.2
     # via wheel
-wheel==0.46.3
+wheel==0.47.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.0.1
+pip==26.1
     # via -r requirements/pip.in
 setuptools==82.0.1
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,7 +4,19 @@
 #
 #    make upgrade
 #
-algoliasearch==3.0.0
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
+aiosignal==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+algoliasearch==4.39.0
     # via -r requirements/base.txt
 amqp==5.3.1
     # via
@@ -26,9 +38,15 @@ asgiref==3.11.1
     #   -r requirements/base.txt
     #   django
     #   django-cors-headers
+    #   social-auth-app-django
+async-timeout==5.0.1
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
 attrs==26.1.0
     # via
     #   -r requirements/base.txt
+    #   aiohttp
     #   jsonschema
     #   referencing
 backoff==1.10.0
@@ -44,7 +62,7 @@ celery==5.6.3
     #   -r requirements/base.txt
     #   django-celery-results
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/base.txt
     #   httpcore
@@ -59,7 +77,7 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.3.2
+click==8.3.3
     # via
     #   -r requirements/base.txt
     #   celery
@@ -84,10 +102,11 @@ code-annotations==3.0.0
     # via
     #   -r requirements/base.txt
     #   edx-toggles
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
+    #   social-auth-core
 defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
@@ -155,7 +174,7 @@ django-model-utils==5.0.0
     #   -r requirements/base.txt
     #   edx-celeryutils
     #   edx-rbac
-django-modeltranslation==0.20.2
+django-modeltranslation==0.20.3
     # via -r requirements/base.txt
 django-simple-history==3.11.0
     # via -r requirements/base.txt
@@ -216,9 +235,14 @@ edx-toggles==6.0.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-gevent==25.9.1
+frozenlist==1.8.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   aiosignal
+gevent==26.4.0
     # via -r requirements/production.in
-greenlet==3.4.0
+greenlet==3.5.0
     # via gevent
 gunicorn==25.3.0
     # via -r requirements/production.in
@@ -234,12 +258,13 @@ httpx==0.28.1
     # via
     #   -r requirements/base.txt
     #   openai
-idna==3.11
+idna==3.13
     # via
     #   -r requirements/base.txt
     #   anyio
     #   httpx
     #   requests
+    #   yarl
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
@@ -278,6 +303,11 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
+multidict==6.7.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.8
     # via -r requirements/base.txt
 numpy==2.4.4
@@ -292,7 +322,7 @@ oauthlib==3.3.1
     #   social-auth-core
 openai==1.13.3
     # via -r requirements/base.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/base.txt
     #   gunicorn
@@ -305,6 +335,11 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/base.txt
     #   click-repl
+propcache==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via
     #   -r requirements/base.txt
@@ -313,11 +348,12 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pydantic==2.12.5
+pydantic==2.13.3
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   openai
-pydantic-core==2.41.5
+pydantic-core==2.46.3
     # via
     #   -r requirements/base.txt
     #   pydantic
@@ -331,7 +367,7 @@ pyjwt[crypto]==2.12.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -342,6 +378,7 @@ pynacl==1.6.2
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   analytics-python
     #   celery
 python-memcached==1.62
@@ -400,7 +437,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.20.2
+simplejson==4.1.1
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -414,11 +451,11 @@ sniffio==1.3.1
     # via
     #   -r requirements/base.txt
     #   openai
-social-auth-app-django==5.7.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.8.5
+social-auth-core==4.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -452,6 +489,7 @@ tqdm==4.67.3
 typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
+    #   aiosignal
     #   anyio
     #   django-modeltranslation
     #   edx-opaque-keys
@@ -464,7 +502,7 @@ typing-inspection==0.4.2
     # via
     #   -r requirements/base.txt
     #   pydantic
-tzdata==2026.1
+tzdata==2026.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -479,6 +517,7 @@ uritemplate==4.2.0
 urllib3==2.6.3
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   requests
 vine==5.1.0
     # via
@@ -492,11 +531,15 @@ wcwidth==0.6.0
     #   prompt-toolkit
 xlsxwriter==3.2.9
     # via -r requirements/base.txt
-zipp==3.23.0
+yarl==1.23.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+zipp==3.23.1
     # via -r requirements/base.txt
-zope-event==6.1
+zope-event==6.2
     # via gevent
-zope-interface==8.2
+zope-interface==8.4
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,19 @@
 #
 #    make upgrade
 #
-algoliasearch==3.0.0
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
+aiosignal==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+algoliasearch==4.39.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -28,13 +40,19 @@ asgiref==3.11.1
     #   -r requirements/base.txt
     #   django
     #   django-cors-headers
+    #   social-auth-app-django
 astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
+async-timeout==5.0.1
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
 attrs==26.1.0
     # via
     #   -r requirements/base.txt
+    #   aiohttp
     #   jsonschema
     #   referencing
 backoff==1.10.0
@@ -51,7 +69,7 @@ celery==5.6.3
     #   -r requirements/base.txt
     #   django-celery-results
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/base.txt
     #   httpcore
@@ -66,7 +84,7 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.3.2
+click==8.3.3
     # via
     #   -r requirements/base.txt
     #   celery
@@ -96,10 +114,11 @@ code-annotations==3.0.0
     #   -r requirements/base.txt
     #   edx-lint
     #   edx-toggles
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
+    #   social-auth-core
 defusedxml==0.7.1
     # via
     #   -r requirements/base.txt
@@ -171,7 +190,7 @@ django-model-utils==5.0.0
     #   -r requirements/base.txt
     #   edx-celeryutils
     #   edx-rbac
-django-modeltranslation==0.20.2
+django-modeltranslation==0.20.3
     # via -r requirements/base.txt
 django-simple-history==3.11.0
     # via
@@ -222,7 +241,7 @@ edx-drf-extensions==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==6.0.0
+edx-lint==6.1.0
     # via -r requirements/quality.in
 edx-opaque-keys==4.0.0
     # via
@@ -236,6 +255,11 @@ edx-toggles==6.0.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
+frozenlist==1.8.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   aiosignal
 h11==0.16.0
     # via
     #   -r requirements/base.txt
@@ -248,12 +272,13 @@ httpx==0.28.1
     # via
     #   -r requirements/base.txt
     #   openai
-idna==3.11
+idna==3.13
     # via
     #   -r requirements/base.txt
     #   anyio
     #   httpx
     #   requests
+    #   yarl
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
@@ -298,6 +323,11 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
+multidict==6.7.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.8
     # via -r requirements/base.txt
 numpy==2.4.4
@@ -314,11 +344,11 @@ openai==1.13.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/base.txt
     #   kombu
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via pylint
 ply==3.11
     # via
@@ -328,6 +358,11 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/base.txt
     #   click-repl
+propcache==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via
     #   -r requirements/base.txt
@@ -338,11 +373,12 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pydantic==2.12.5
+pydantic==2.13.3
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   openai
-pydantic-core==2.41.5
+pydantic-core==2.46.3
     # via
     #   -r requirements/base.txt
     #   pydantic
@@ -372,7 +408,7 @@ pylint-plugin-utils==0.9.0
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -383,6 +419,7 @@ pynacl==1.6.2
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   analytics-python
     #   celery
 python-slugify==8.0.4
@@ -438,7 +475,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.20.2
+simplejson==4.1.1
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -455,11 +492,11 @@ sniffio==1.3.1
     #   openai
 snowballstemmer==3.0.1
     # via pydocstyle
-social-auth-app-django==5.7.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.8.5
+social-auth-core==4.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -487,7 +524,9 @@ threadpoolctl==3.6.0
     #   -r requirements/base.txt
     #   scikit-learn
 tomlkit==0.14.0
-    # via pylint
+    # via
+    #   edx-lint
+    #   pylint
 tqdm==4.67.3
     # via
     #   -r requirements/base.txt
@@ -495,6 +534,7 @@ tqdm==4.67.3
 typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
+    #   aiosignal
     #   anyio
     #   django-modeltranslation
     #   edx-opaque-keys
@@ -507,7 +547,7 @@ typing-inspection==0.4.2
     # via
     #   -r requirements/base.txt
     #   pydantic
-tzdata==2026.1
+tzdata==2026.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -522,6 +562,7 @@ uritemplate==4.2.0
 urllib3==2.6.3
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   requests
 vine==5.1.0
     # via
@@ -535,7 +576,11 @@ wcwidth==0.6.0
     #   prompt-toolkit
 xlsxwriter==3.2.9
     # via -r requirements/base.txt
-zipp==3.23.0
+yarl==1.23.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+zipp==3.23.1
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,19 @@
 #
 #    make upgrade
 #
-algoliasearch==3.0.0
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
+aiosignal==1.4.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+algoliasearch==4.39.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
@@ -28,13 +40,19 @@ asgiref==3.11.1
     #   -r requirements/base.txt
     #   django
     #   django-cors-headers
+    #   social-auth-app-django
 astroid==4.0.4
     # via
     #   pylint
     #   pylint-celery
+async-timeout==5.0.1
+    # via
+    #   -r requirements/base.txt
+    #   algoliasearch
 attrs==26.1.0
     # via
     #   -r requirements/base.txt
+    #   aiohttp
     #   jsonschema
     #   referencing
 backoff==1.10.0
@@ -45,7 +63,7 @@ billiard==4.2.4
     # via
     #   -r requirements/base.txt
     #   celery
-cachetools==7.0.5
+cachetools==7.0.6
     # via tox
 celery==5.6.3
     # via
@@ -53,7 +71,7 @@ celery==5.6.3
     #   -r requirements/base.txt
     #   django-celery-results
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/base.txt
     #   httpcore
@@ -68,7 +86,7 @@ charset-normalizer==3.4.7
     # via
     #   -r requirements/base.txt
     #   requests
-click==8.3.2
+click==8.3.3
     # via
     #   -r requirements/base.txt
     #   celery
@@ -105,10 +123,11 @@ coverage[toml]==7.13.5
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
+    #   social-auth-core
 ddt==1.7.2
     # via -r requirements/test.in
 defusedxml==0.7.1
@@ -185,7 +204,7 @@ django-model-utils==5.0.0
     #   -r requirements/base.txt
     #   edx-celeryutils
     #   edx-rbac
-django-modeltranslation==0.20.2
+django-modeltranslation==0.20.3
     # via -r requirements/base.txt
 django-simple-history==3.11.0
     # via
@@ -236,7 +255,7 @@ edx-drf-extensions==10.6.0
     # via
     #   -r requirements/base.txt
     #   edx-rbac
-edx-lint==6.0.0
+edx-lint==6.1.0
     # via -r requirements/test.in
 edx-opaque-keys==4.0.0
     # via
@@ -252,13 +271,18 @@ edx-toggles==6.0.0
     #   edx-auth-backends
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==40.13.0
+faker==40.15.0
     # via factory-boy
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   python-discovery
     #   tox
     #   virtualenv
+frozenlist==1.8.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   aiosignal
 h11==0.16.0
     # via
     #   -r requirements/base.txt
@@ -271,12 +295,13 @@ httpx==0.28.1
     # via
     #   -r requirements/base.txt
     #   openai
-idna==3.11
+idna==3.13
     # via
     #   -r requirements/base.txt
     #   anyio
     #   httpx
     #   requests
+    #   yarl
 inflection==0.5.1
     # via
     #   -r requirements/base.txt
@@ -321,6 +346,11 @@ monotonic==1.6
     # via
     #   -r requirements/base.txt
     #   analytics-python
+multidict==6.7.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.8
     # via -r requirements/base.txt
 numpy==2.4.4
@@ -337,14 +367,14 @@ openai==1.13.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/base.txt
     #   kombu
     #   pyproject-api
     #   pytest
     #   tox
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   pylint
     #   python-discovery
@@ -363,6 +393,11 @@ prompt-toolkit==3.0.52
     # via
     #   -r requirements/base.txt
     #   click-repl
+propcache==0.4.1
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via
     #   -r requirements/base.txt
@@ -371,11 +406,12 @@ pycparser==3.0
     # via
     #   -r requirements/base.txt
     #   cffi
-pydantic==2.12.5
+pydantic==2.13.3
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   openai
-pydantic-core==2.41.5
+pydantic-core==2.46.3
     # via
     #   -r requirements/base.txt
     #   pydantic
@@ -405,7 +441,7 @@ pylint-plugin-utils==0.9.0
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/base.txt
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -426,6 +462,7 @@ pytest-django==4.12.0
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   analytics-python
     #   celery
 python-discovery==1.2.2
@@ -489,7 +526,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simplejson==3.20.2
+simplejson==4.1.1
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -504,11 +541,11 @@ sniffio==1.3.1
     # via
     #   -r requirements/base.txt
     #   openai
-social-auth-app-django==5.7.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==4.8.5
+social-auth-core==4.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -538,8 +575,10 @@ threadpoolctl==3.6.0
 tomli-w==1.2.0
     # via tox
 tomlkit==0.14.0
-    # via pylint
-tox==4.52.0
+    # via
+    #   edx-lint
+    #   pylint
+tox==4.53.0
     # via -r requirements/test.in
 tqdm==4.67.3
     # via
@@ -548,6 +587,7 @@ tqdm==4.67.3
 typing-extensions==4.15.0
     # via
     #   -r requirements/base.txt
+    #   aiosignal
     #   anyio
     #   django-modeltranslation
     #   edx-opaque-keys
@@ -560,7 +600,7 @@ typing-inspection==0.4.2
     # via
     #   -r requirements/base.txt
     #   pydantic
-tzdata==2026.1
+tzdata==2026.2
     # via
     #   -r requirements/base.txt
     #   kombu
@@ -575,6 +615,7 @@ uritemplate==4.2.0
 urllib3==2.6.3
     # via
     #   -r requirements/base.txt
+    #   algoliasearch
     #   requests
     #   responses
 vine==5.1.0
@@ -583,7 +624,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.2.0
+virtualenv==21.3.0
     # via tox
 wcwidth==0.6.0
     # via
@@ -591,7 +632,11 @@ wcwidth==0.6.0
     #   prompt-toolkit
 xlsxwriter==3.2.9
     # via -r requirements/base.txt
-zipp==3.23.0
+yarl==1.23.0
+    # via
+    #   -r requirements/base.txt
+    #   aiohttp
+zipp==3.23.1
     # via -r requirements/base.txt
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -4,7 +4,22 @@
 #
 #    make upgrade
 #
-algoliasearch==3.0.0
+aiohappyeyeballs==2.6.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+aiohttp==3.13.5
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   algoliasearch
+aiosignal==1.4.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+algoliasearch==4.39.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
@@ -35,16 +50,23 @@ asgiref==3.11.1
     #   -r requirements/test.txt
     #   django
     #   django-cors-headers
+    #   social-auth-app-django
 astroid==4.0.4
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
+async-timeout==5.0.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   algoliasearch
 attrs==26.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   aiohttp
     #   jsonschema
     #   referencing
 backoff==1.10.0
@@ -57,7 +79,7 @@ billiard==4.2.4
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   celery
-cachetools==7.0.5
+cachetools==7.0.6
     # via
     #   -r requirements/test.txt
     #   tox
@@ -68,7 +90,7 @@ celery==5.6.3
     #   -r requirements/test.txt
     #   django-celery-results
     #   edx-celeryutils
-certifi==2026.2.25
+certifi==2026.4.22
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -86,7 +108,7 @@ charset-normalizer==3.4.7
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   requests
-click==8.3.2
+click==8.3.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -132,11 +154,12 @@ coverage[toml]==7.13.5
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==46.0.7
+cryptography==47.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pyjwt
+    #   social-auth-core
 ddt==1.7.2
     # via -r requirements/test.txt
 defusedxml==0.7.1
@@ -239,7 +262,7 @@ django-model-utils==5.0.0
     #   -r requirements/test.txt
     #   edx-celeryutils
     #   edx-rbac
-django-modeltranslation==0.20.2
+django-modeltranslation==0.20.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -311,7 +334,7 @@ edx-drf-extensions==10.6.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-rbac
-edx-lint==6.0.0
+edx-lint==6.1.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -335,16 +358,22 @@ edx-toggles==6.0.0
     #   edx-auth-backends
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==40.13.0
+faker==40.15.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.25.2
+filelock==3.29.0
     # via
     #   -r requirements/test.txt
     #   python-discovery
     #   tox
     #   virtualenv
+frozenlist==1.8.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   aiosignal
 h11==0.16.0
     # via
     #   -r requirements/quality.txt
@@ -360,13 +389,14 @@ httpx==0.28.1
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   openai
-idna==3.11
+idna==3.13
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   anyio
     #   httpx
     #   requests
+    #   yarl
 inflection==0.5.1
     # via
     #   -r requirements/quality.txt
@@ -430,6 +460,12 @@ monotonic==1.6
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   analytics-python
+multidict==6.7.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 mysqlclient==2.2.8
     # via
     #   -r requirements/quality.txt
@@ -451,7 +487,7 @@ openai==1.13.3
     #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-packaging==26.0
+packaging==26.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -459,7 +495,7 @@ packaging==26.0
     #   pyproject-api
     #   pytest
     #   tox
-platformdirs==4.9.4
+platformdirs==4.9.6
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -483,6 +519,12 @@ prompt-toolkit==3.0.52
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   click-repl
+propcache==0.4.1
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+    #   yarl
 psutil==7.2.2
     # via
     #   -r requirements/quality.txt
@@ -495,12 +537,13 @@ pycparser==3.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   cffi
-pydantic==2.12.5
+pydantic==2.13.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   algoliasearch
     #   openai
-pydantic-core==2.41.5
+pydantic-core==2.46.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -548,7 +591,7 @@ pymemcache==4.0.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-pymongo==4.16.0
+pymongo==4.17.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -575,6 +618,7 @@ python-dateutil==2.9.0.post0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   algoliasearch
     #   analytics-python
     #   celery
 python-discovery==1.2.2
@@ -656,7 +700,7 @@ semantic-version==2.10.0
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-simplejson==3.20.2
+simplejson==4.1.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -679,12 +723,12 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==5.7.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==4.8.5
+social-auth-core==4.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -725,8 +769,9 @@ tomlkit==0.14.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   edx-lint
     #   pylint
-tox==4.52.0
+tox==4.53.0
     # via -r requirements/test.txt
 tqdm==4.67.3
     # via
@@ -737,6 +782,7 @@ typing-extensions==4.15.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   aiosignal
     #   anyio
     #   django-modeltranslation
     #   edx-opaque-keys
@@ -750,7 +796,7 @@ typing-inspection==0.4.2
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   pydantic
-tzdata==2026.1
+tzdata==2026.2
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
@@ -769,6 +815,7 @@ urllib3==2.6.3
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
+    #   algoliasearch
     #   requests
     #   responses
 vine==5.1.0
@@ -778,7 +825,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==21.2.0
+virtualenv==21.3.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -791,7 +838,12 @@ xlsxwriter==3.2.9
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
-zipp==3.23.0
+yarl==1.23.0
+    # via
+    #   -r requirements/quality.txt
+    #   -r requirements/test.txt
+    #   aiohttp
+zipp==3.23.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/scripts/.env.example
+++ b/scripts/.env.example
@@ -1,0 +1,35 @@
+# Algolia Integration Test Configuration
+#
+# Copy to scripts/.env and fill in your sandbox credentials.
+# NEVER commit scripts/.env to version control.
+
+# =============================================================================
+# REQUIRED — Algolia sandbox credentials
+# =============================================================================
+
+# Algolia application id (sandbox app, not production).
+ALGOLIA_APPLICATION_ID=your_sandbox_app_id
+
+# Admin API key for that app. The integration tests write to and delete from
+# the sandbox index, so the key must have write privileges.
+ALGOLIA_ADMIN_API_KEY=your_admin_api_key
+
+# Sandbox index names to operate on. The tests will overwrite the contents of
+# these indices on each run via replace_all_objects, so do NOT point them at a
+# production index. The runner refuses to start if the index name contains
+# "prod" as a guardrail.
+ALGOLIA_INDEX_NAME=enterprise_catalog_sandbox
+ALGOLIA_REPLICA_INDEX_NAME=enterprise_catalog_sandbox_replica
+
+# =============================================================================
+# OPTIONAL
+# =============================================================================
+
+# Search-only API key. Required ONLY for the generate_secured_api_key scenario.
+# Leave unset to skip that scenario.
+# ALGOLIA_SEARCH_API_KEY=your_search_only_api_key
+
+# aggregation_key value used when seeding sample records. Defaults to
+# 'integration-test-aggregation-key'. Override only if you need to avoid
+# colliding with another test run on the same sandbox index.
+# SAMPLE_AGGREGATION_KEY=integration-test-aggregation-key

--- a/scripts/algolia_integration/__init__.py
+++ b/scripts/algolia_integration/__init__.py
@@ -1,0 +1,11 @@
+"""
+Algolia sandbox integration test package.
+
+Exercises the project's ``AlgoliaSearchClient`` wrapper against a real Algolia
+sandbox application. Designed to run inside the ``enterprise.catalog.app``
+container so the wrapper imports cleanly. See ``scripts/.env.example`` for the
+required environment variables and ``docs/how_to/algolia_integration_tests_pattern.md``
+for the structural pattern this is modeled on.
+"""
+
+__version__ = '0.1.0'

--- a/scripts/algolia_integration/client.py
+++ b/scripts/algolia_integration/client.py
@@ -1,0 +1,72 @@
+"""
+Bootstrap Django and construct an initialized ``AlgoliaSearchClient`` for the
+integration tests. Also exposes a raw ``SearchClientSync`` for the few
+scenarios (search-after-replace, secured-key search) that need to act as an
+unprivileged consumer of the index.
+"""
+import logging
+import os
+
+from .config import Config
+
+
+logger = logging.getLogger(__name__)
+
+
+def bootstrap_django(config: Config) -> None:
+    """
+    Configure Django and apply the integration-test ALGOLIA settings.
+
+    Sets ``DJANGO_SETTINGS_MODULE`` to the test settings module if it is not
+    already set, calls ``django.setup()``, then overwrites ``settings.ALGOLIA``
+    with the credentials from ``config``. Subsequent imports of the project's
+    wrapper will read these values.
+    """
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'enterprise_catalog.settings.test')
+
+    import django  # noqa: PLC0415  (deferred so DJANGO_SETTINGS_MODULE wins)
+    django.setup()
+
+    from django.conf import settings  # noqa: PLC0415
+
+    settings.ALGOLIA = {
+        'APPLICATION_ID': config.algolia_application_id,
+        'API_KEY': config.algolia_admin_api_key,
+        'SEARCH_API_KEY': config.algolia_search_api_key,
+        'INDEX_NAME': config.algolia_index_name,
+        'REPLICA_INDEX_NAME': config.algolia_replica_index_name,
+    }
+    logger.debug(
+        "Django bootstrapped; ALGOLIA settings applied for app id %s",
+        config.algolia_application_id,
+    )
+
+
+def make_wrapper_client():
+    """
+    Return an initialized project ``AlgoliaSearchClient``.
+
+    Must be called after ``bootstrap_django``.
+    """
+    from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient  # noqa: PLC0415
+
+    client = AlgoliaSearchClient()
+    client.init_index()
+    if client._client is None:  # pylint: disable=protected-access
+        raise RuntimeError(
+            "AlgoliaSearchClient.init_index() did not initialize a client. "
+            "Check ALGOLIA settings (APPLICATION_ID, API_KEY, INDEX_NAME, REPLICA_INDEX_NAME)."
+        )
+    return client
+
+
+def make_raw_search_client(config: Config, api_key: str = None):
+    """
+    Return a fresh ``SearchClientSync`` for low-level operations.
+
+    Defaults to the admin API key. Pass ``api_key`` to construct a client
+    scoped to a different key (e.g. a secured search key).
+    """
+    from algoliasearch.search.client import SearchClientSync  # noqa: PLC0415
+
+    return SearchClientSync(config.algolia_application_id, api_key or config.algolia_admin_api_key)

--- a/scripts/algolia_integration/config.py
+++ b/scripts/algolia_integration/config.py
@@ -1,0 +1,122 @@
+"""
+Configuration for Algolia integration tests.
+
+Loads credentials and the sandbox index names from environment variables (or a
+``.env`` file). Real values must never be committed to the repo.
+"""
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+try:
+    from dotenv import load_dotenv
+except ImportError as exc:
+    raise Exception(
+        "dotenv package unavailable. Install scripts/requirements.txt:\n"
+        "    pip install -r scripts/requirements.txt"
+    ) from exc
+
+
+REQUIRED_VARS = (
+    'ALGOLIA_APPLICATION_ID',
+    'ALGOLIA_ADMIN_API_KEY',
+    'ALGOLIA_INDEX_NAME',
+    'ALGOLIA_REPLICA_INDEX_NAME',
+)
+
+
+@dataclass
+class Config:
+    """
+    Configuration loaded from env vars / ``.env``.
+
+    The integration tests target a stable sandbox index whose name is supplied
+    via ``ALGOLIA_INDEX_NAME``. Tests overwrite the index contents on each run
+    (``replace_all_objects``), so the index can be reused safely across runs as
+    long as it is not pointed at production data.
+    """
+    algolia_application_id: str
+    algolia_admin_api_key: str
+    algolia_index_name: str
+    algolia_replica_index_name: str
+
+    # Optional: required only by the generate_secured_api_key scenario.
+    algolia_search_api_key: Optional[str] = None
+
+    # Optional: enterprise UUID used to seed sample records' aggregation_key.
+    # Defaults to a fixed UUID-like string so runs are reproducible.
+    sample_aggregation_key: str = 'integration-test-aggregation-key'
+
+    @classmethod
+    def from_env(cls, env_file: Optional[Path] = None) -> 'Config':
+        """
+        Load configuration from environment variables.
+
+        Args:
+            env_file: Optional path to a ``.env`` file. Defaults to ``scripts/.env``
+                if present, then ``./.env``.
+
+        Raises:
+            ValueError: If required environment variables are missing.
+            FileNotFoundError: If ``env_file`` is given but does not exist.
+        """
+        if env_file:
+            if not env_file.exists():
+                raise FileNotFoundError(f"Environment file not found: {env_file}")
+            load_dotenv(env_file)
+        else:
+            for candidate in (Path('scripts/.env'), Path('.env')):
+                if candidate.exists():
+                    load_dotenv(candidate)
+                    break
+
+        missing = [var for var in REQUIRED_VARS if not os.getenv(var)]
+        if missing:
+            raise ValueError(
+                f"Missing required environment variables: {', '.join(missing)}\n"
+                f"Set them in your shell or in scripts/.env. "
+                f"See scripts/.env.example for reference."
+            )
+
+        return cls(
+            algolia_application_id=os.environ['ALGOLIA_APPLICATION_ID'],
+            algolia_admin_api_key=os.environ['ALGOLIA_ADMIN_API_KEY'],
+            algolia_index_name=os.environ['ALGOLIA_INDEX_NAME'],
+            algolia_replica_index_name=os.environ['ALGOLIA_REPLICA_INDEX_NAME'],
+            algolia_search_api_key=os.getenv('ALGOLIA_SEARCH_API_KEY'),
+            sample_aggregation_key=os.getenv(
+                'SAMPLE_AGGREGATION_KEY',
+                'integration-test-aggregation-key',
+            ),
+        )
+
+    def validate(self) -> None:
+        """
+        Validate basic shape of configured values.
+        """
+        if 'prod' in self.algolia_index_name.lower():
+            raise ValueError(
+                f"Refusing to run against an index whose name contains 'prod': "
+                f"{self.algolia_index_name}"
+            )
+        if self.algolia_index_name == self.algolia_replica_index_name:
+            raise ValueError(
+                "ALGOLIA_INDEX_NAME and ALGOLIA_REPLICA_INDEX_NAME must differ."
+            )
+
+    def mask_secrets(self) -> dict:
+        """
+        Return a dict safe for printing — credential fields show only presence, never value.
+        """
+        def present(val: Optional[str]) -> str:
+            return '<set>' if val else '<not set>'
+
+        return {
+            'algolia_application_id': present(self.algolia_application_id),
+            'algolia_admin_api_key': present(self.algolia_admin_api_key),
+            'algolia_search_api_key': present(self.algolia_search_api_key),
+            'algolia_index_name': self.algolia_index_name,
+            'algolia_replica_index_name': self.algolia_replica_index_name,
+            'sample_aggregation_key': self.sample_aggregation_key,
+        }

--- a/scripts/algolia_integration/test_scenarios.py
+++ b/scripts/algolia_integration/test_scenarios.py
@@ -1,0 +1,445 @@
+"""
+Integration test scenarios for the project's ``AlgoliaSearchClient`` wrapper
+running against a real Algolia sandbox application.
+
+Each scenario is a callable ``(wrapper, config) -> {'status': ..., 'data': ...}``.
+Failures raise ``AssertionError`` (caught by the runner). Scenarios that depend
+on prior state declare it via ``depends_on``.
+"""
+import logging
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List, Optional
+
+from .client import make_raw_search_client
+from .config import Config
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TestScenario:
+    """One named integration test."""
+    name: str
+    description: str
+    run: Callable[[Any, Config], Dict[str, Any]]
+    depends_on: Optional[List[str]] = None
+    skip_on_error: bool = False
+    # When False, the scenario is skipped by --all but can still be invoked
+    # explicitly via --test <name>. Useful for known-flaky or expensive
+    # scenarios we want to keep around for ad-hoc debugging.
+    enabled: bool = True
+
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+def _sample_records(aggregation_key: str) -> List[Dict[str, Any]]:
+    """
+    Build a small fixed dataset stamped with the configured aggregation_key.
+
+    Five records is enough to exercise replace/browse/delete without making
+    runs slow.
+    """
+    titles = [
+        'Intro to Integration Testing',
+        'Algolia Sandbox Smoke Test',
+        'Enterprise Catalog v4 Migration',
+        'Browse Aggregator Verification',
+        'Secured API Key Restrictions',
+    ]
+    records = []
+    for idx, title in enumerate(titles):
+        records.append({
+            'objectID': f'integration-test-{idx}',
+            'title': title,
+            'aggregation_key': aggregation_key,
+            'content_type': 'course',
+            'enterprise_catalog_query_uuids': ['00000000-0000-0000-0000-000000000001'],
+        })
+    return records
+
+
+def _wait_for_indexing_settle(seconds: float = 2.0) -> None:
+    """
+    Brief sleep so newly-indexed records are visible to subsequent searches.
+
+    The v4 ``replace_all_objects`` helper waits for its own tasks, but the
+    eventual-consistency window between index commit and search availability
+    is real on Algolia, so we add a small buffer.
+    """
+    time.sleep(seconds)
+
+
+def _poll_until(predicate: Callable[[], bool], timeout: float, interval: float = 2.0) -> bool:
+    """
+    Poll ``predicate`` until it returns truthy or ``timeout`` seconds elapse.
+
+    Sandbox apps with lots of queued tasks can take longer than the SDK's
+    default ``wait_for_task`` retry budget. This lets a scenario keep checking
+    on its own clock instead of failing instantly.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval)
+    return predicate()
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+def test_init_and_index_exists(wrapper, config: Config) -> Dict[str, Any]:
+    """The wrapper can talk to Algolia and the sandbox indices both exist."""
+    logger.info("Confirming primary + replica indices exist in Algolia")
+    exists = wrapper.index_exists()
+    assert exists, (
+        f"index_exists() returned False. Confirm both '{config.algolia_index_name}' "
+        f"and '{config.algolia_replica_index_name}' exist in your sandbox app."
+    )
+    return {'status': 'PASS', 'data': {'index_exists': True}}
+
+
+def test_set_index_settings(wrapper, config: Config) -> Dict[str, Any]:  # pylint: disable=unused-argument
+    """``set_settings`` works for both primary and replica indices."""
+    logger.info("Pushing minimal settings to primary + replica")
+    primary_settings = {
+        'searchableAttributes': ['title', 'aggregation_key'],
+        'attributesForFaceting': [
+            'filterOnly(aggregation_key)',
+            'filterOnly(enterprise_catalog_query_uuids)',
+        ],
+    }
+    wrapper.set_index_settings(primary_settings, primary_index=True)
+    # Virtual replicas only allow a small whitelist of overrides; customRanking
+    # is one of them.
+    wrapper.set_index_settings({'customRanking': ['desc(title)']}, primary_index=False)
+    return {'status': 'PASS', 'data': {'primary_settings_applied': True}}
+
+
+def test_seed_sample_records(wrapper, config: Config) -> Dict[str, Any]:  # pylint: disable=unused-argument
+    """
+    Seed the sandbox index with sample records via the SDK's ``save_objects``
+    helper so the browse/delete scenarios have data to work with.
+
+    This intentionally does NOT use the project wrapper's ``replace_all_objects``
+    path — that's exercised by the standalone ``replace_all_objects_and_search``
+    scenario, which currently runs into the SDK's wait_for_task retry budget on
+    busy sandbox apps.
+    """
+    raw = make_raw_search_client(config)
+    records = _sample_records(config.sample_aggregation_key)
+    logger.info("Seeding %d records via save_objects (no client-side task wait)", len(records))
+    # We deliberately do NOT pass wait_for_tasks=True: on busy sandbox apps the
+    # SDK's wait_for_task helper hits its 50-retry budget even when the record
+    # write itself succeeds quickly. Verifying via search-side polling below
+    # is more reliable.
+    raw.save_objects(config.algolia_index_name, records)
+
+    expected_object_ids = {rec['objectID'] for rec in records}
+
+    def _all_visible() -> bool:
+        # Use get_objects (direct objectID lookup) rather than search.
+        # search depends on searchableAttributes / attributesForFaceting having
+        # propagated, which lags writes on busy sandbox apps. get_objects is
+        # the most direct check that a record is in the index.
+        response = raw.get_objects({
+            'requests': [
+                {'indexName': config.algolia_index_name, 'objectID': object_id}
+                for object_id in expected_object_ids
+            ],
+        })
+        results = response.to_dict().get('results', [])
+        ids = {r['objectID'] for r in results if r and r.get('objectID')}
+        return expected_object_ids.issubset(ids)
+
+    # Busy sandbox apps can take 2+ minutes for a write to be visible to
+    # search; budget accordingly.
+    settled = _poll_until(_all_visible, timeout=300.0, interval=5.0)
+    assert settled, f"Sample records not visible after 300s: expected {expected_object_ids}"
+    return {'status': 'PASS', 'data': {'seeded_count': len(expected_object_ids)}}
+
+
+def test_replace_all_objects_and_search(wrapper, config: Config) -> Dict[str, Any]:
+    """Push records, then search via the SDK to confirm they're queryable.
+
+    The SDK's ``replace_all_objects`` helper has a fixed internal retry budget
+    when waiting for the underlying copy/index/swap tasks. Busy sandbox apps
+    can blow past that budget even when the operation eventually completes,
+    so we tolerate the retry-exhaustion error and verify success by searching.
+    """
+    records = _sample_records(config.sample_aggregation_key)
+    expected_object_ids = {rec['objectID'] for rec in records}
+    logger.info("Calling wrapper.replace_all_objects with %d records", len(records))
+
+    try:
+        wrapper.replace_all_objects(records)
+    except Exception as exc:  # pylint: disable=broad-except
+        # The SDK's wait_for_task may have given up — the swap can still
+        # complete server-side. Don't fail yet; verify via search.
+        logger.warning("replace_all_objects raised (will verify via search): %s", exc)
+
+    raw = make_raw_search_client(config)
+
+    def _all_records_visible() -> bool:
+        response = raw.search_single_index(
+            config.algolia_index_name,
+            search_params={
+                'query': '',
+                'hitsPerPage': 100,
+                'filters': f"aggregation_key:'{config.sample_aggregation_key}'",
+            },
+        )
+        hits = response.to_dict().get('hits', [])
+        ids = {hit['objectID'] for hit in hits if hit.get('objectID', '').startswith('integration-test-')}
+        return expected_object_ids.issubset(ids)
+
+    settled = _poll_until(_all_records_visible, timeout=120.0, interval=3.0)
+    assert settled, (
+        f"Expected objectIDs {expected_object_ids} not all visible after 120s; "
+        f"replace_all_objects did not complete server-side."
+    )
+    return {'status': 'PASS', 'data': {'indexed_count': len(expected_object_ids)}}
+
+
+def test_browse_by_aggregation_key(wrapper, config: Config) -> Dict[str, Any]:
+    """``get_all_objects_associated_with_aggregation_key`` returns every objectID."""
+    logger.info("Browsing by aggregation_key=%r", config.sample_aggregation_key)
+    object_ids = wrapper.get_all_objects_associated_with_aggregation_key(
+        config.sample_aggregation_key,
+    )
+    expected = {f'integration-test-{i}' for i in range(5)}
+    actual = set(object_ids)
+    assert expected.issubset(actual), (
+        f"Browse missed objects. Expected superset of {expected}, got {actual}"
+    )
+    return {'status': 'PASS', 'data': {'browsed_object_ids': sorted(actual)}}
+
+
+def test_delete_objects(wrapper, config: Config) -> Dict[str, Any]:
+    """``remove_objects`` deletes the requested objectIDs."""
+    to_delete_set = {'integration-test-3', 'integration-test-4'}
+    logger.info("Deleting objects %s", sorted(to_delete_set))
+    wrapper.remove_objects(list(to_delete_set))
+
+    raw = make_raw_search_client(config)
+
+    def _deleted_gone() -> bool:
+        # Direct objectID lookup: get_objects returns null entries for missing IDs.
+        response = raw.get_objects({
+            'requests': [
+                {'indexName': config.algolia_index_name, 'objectID': oid}
+                for oid in to_delete_set
+            ],
+        })
+        results = response.to_dict().get('results', [])
+        # When an object is missing, the SDK returns None / empty for that slot.
+        return all(not r or not r.get('objectID') for r in results)
+
+    settled = _poll_until(_deleted_gone, timeout=180.0, interval=3.0)
+    assert settled, f"Deleted objectIDs still present after 180s: {to_delete_set}"
+
+    expected_remaining = {'integration-test-0', 'integration-test-1', 'integration-test-2'}
+    remaining = set(wrapper.get_all_objects_associated_with_aggregation_key(
+        config.sample_aggregation_key,
+    ))
+    assert expected_remaining.issubset(remaining), (
+        f"Expected {expected_remaining} to remain, got {remaining}"
+    )
+    return {
+        'status': 'PASS',
+        'data': {'deleted': sorted(to_delete_set), 'remaining': sorted(remaining)},
+    }
+
+
+def test_list_indices_shape(wrapper, config: Config) -> Dict[str, Any]:  # pylint: disable=unused-argument
+    """``list_indices_with_http_info`` returns parseable JSON with the expected keys.
+
+    We bypass the SDK's typed ``list_indices()`` because the v4 ``FetchedIndex``
+    Pydantic model declares fields (``lastBuildTimeS``, ``numberOfPendingTasks``,
+    ``pendingTask``) as required, which the real Algolia API regularly omits.
+    The production ``_get_all_indices`` task also takes the raw-bytes path.
+    """
+    import json as _json  # local import keeps top of file clean
+    raw = make_raw_search_client(config)
+    response = raw.list_indices_with_http_info()
+
+    assert hasattr(response, 'raw_data'), "ApiResponse missing raw_data attribute"
+    payload = _json.loads(response.raw_data)
+    assert 'items' in payload, f"list_indices payload missing 'items': {payload.keys()}"
+
+    names = []
+    for item in payload['items']:
+        assert 'name' in item, f"Item missing 'name': {item.keys()}"
+        assert 'updatedAt' in item, f"Item missing camelCase 'updatedAt': {item.keys()}"
+        names.append(item['name'])
+
+    assert config.algolia_index_name in names, (
+        f"Expected sandbox index {config.algolia_index_name} in list, got {names[:10]}..."
+    )
+    return {'status': 'PASS', 'data': {'index_count': len(names)}}
+
+
+def test_create_and_delete_temporary_index(wrapper, config: Config) -> Dict[str, Any]:  # pylint: disable=unused-argument
+    """Exercise ``delete_index`` against a tmp index this scenario creates."""
+    raw = make_raw_search_client(config)
+    tmp_index_name = f'{config.algolia_index_name}_tmp_{int(time.time())}'
+    logger.info("Creating tmp index %s", tmp_index_name)
+
+    raw.save_objects(
+        tmp_index_name,
+        [{'objectID': 'tmp-record', 'flag': 'integration-test'}],
+        wait_for_tasks=True,
+    )
+
+    appeared = _poll_until(lambda: raw.index_exists(tmp_index_name), timeout=60.0, interval=3.0)
+    assert appeared, f"Tmp index {tmp_index_name} not visible after save"
+
+    logger.info("Deleting tmp index %s", tmp_index_name)
+    raw.delete_index(tmp_index_name)
+
+    gone = _poll_until(lambda: not raw.index_exists(tmp_index_name), timeout=60.0, interval=3.0)
+    assert gone, f"Tmp index {tmp_index_name} still exists after delete_index + 60s"
+    return {'status': 'PASS', 'data': {'tmp_index_name': tmp_index_name}}
+
+
+def test_generate_secured_api_key(wrapper, config: Config) -> Dict[str, Any]:
+    """Generate a restricted search key and use it to do a scoped search."""
+    if not config.algolia_search_api_key:
+        return {
+            'status': 'SKIP',
+            'data': {'reason': 'ALGOLIA_SEARCH_API_KEY not set'},
+        }
+
+    catalog_query_uuid = '00000000-0000-0000-0000-000000000001'
+    logger.info("Generating secured key for catalog_query_uuid=%s", catalog_query_uuid)
+    result = wrapper.generate_secured_api_key(
+        user_id='integration-test-user',
+        enterprise_catalog_query_uuids=[catalog_query_uuid],
+    )
+    assert 'secured_api_key' in result, f"Result missing secured_api_key: {result}"
+    assert 'valid_until' in result, f"Result missing valid_until: {result}"
+    secured_key = result['secured_api_key']
+    assert isinstance(secured_key, str) and len(secured_key) > 20, (
+        f"Secured key looks malformed: {secured_key!r}"
+    )
+
+    secured_client = make_raw_search_client(config, api_key=secured_key)
+
+    def _has_hits() -> bool:
+        response = secured_client.search_single_index(
+            config.algolia_index_name,
+            search_params={'query': '', 'hitsPerPage': 50},
+        )
+        return bool(response.to_dict().get('hits'))
+
+    # The settings push that adds enterprise_catalog_query_uuids to
+    # attributesForFaceting can lag, so the secured-key search may return zero
+    # hits initially. Poll until we see results.
+    if not _poll_until(_has_hits, timeout=120.0, interval=4.0):
+        return {
+            'status': 'SKIP',
+            'data': {
+                'reason': (
+                    'Secured key generated, but no hits visible after 120s. '
+                    'attributesForFaceting may not have propagated yet — re-run the '
+                    'scenario in a few minutes to verify restriction enforcement.'
+                ),
+                'valid_until': result['valid_until'],
+            },
+        }
+
+    response = secured_client.search_single_index(
+        config.algolia_index_name,
+        search_params={'query': '', 'hitsPerPage': 50},
+    )
+    hits = response.to_dict().get('hits', [])
+    for hit in hits:
+        uuids = hit.get('enterprise_catalog_query_uuids') or []
+        assert catalog_query_uuid in uuids, (
+            f"Secured key returned a hit not matching the restriction filter: {hit}"
+        )
+    return {
+        'status': 'PASS',
+        'data': {
+            'valid_until': result['valid_until'],
+            'restricted_hit_count': len(hits),
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+TEST_SCENARIOS: List[TestScenario] = [
+    TestScenario(
+        name='init_and_index_exists',
+        description='Wrapper can connect to Algolia and both sandbox indices exist',
+        run=test_init_and_index_exists,
+    ),
+    TestScenario(
+        name='set_index_settings',
+        description='set_settings works for both primary and replica indices',
+        run=test_set_index_settings,
+        depends_on=['init_and_index_exists'],
+    ),
+    TestScenario(
+        name='seed_sample_records',
+        description='Seed sample records via save_objects so browse/delete have data',
+        run=test_seed_sample_records,
+        depends_on=['set_index_settings'],
+    ),
+    TestScenario(
+        name='replace_all_objects_and_search',
+        description='replace_all_objects writes records that are queryable via search '
+                    '(opt-in: --test replace_all_objects_and_search; flaky on busy sandbox apps)',
+        run=test_replace_all_objects_and_search,
+        depends_on=['set_index_settings'],
+        enabled=False,
+    ),
+    TestScenario(
+        name='browse_by_aggregation_key',
+        description='browse_objects aggregator returns every object for an aggregation_key',
+        run=test_browse_by_aggregation_key,
+        depends_on=['seed_sample_records'],
+    ),
+    TestScenario(
+        name='delete_objects',
+        description='remove_objects deletes the requested objectIDs',
+        run=test_delete_objects,
+        depends_on=['browse_by_aggregation_key'],
+    ),
+    TestScenario(
+        name='list_indices_shape',
+        description='list_indices returns Pydantic models that round-trip to camelCase dicts',
+        run=test_list_indices_shape,
+        depends_on=['init_and_index_exists'],
+    ),
+    TestScenario(
+        name='create_and_delete_temporary_index',
+        description='delete_index removes a tmp index created by save_objects',
+        run=test_create_and_delete_temporary_index,
+        depends_on=['init_and_index_exists'],
+        skip_on_error=True,
+    ),
+    TestScenario(
+        name='generate_secured_api_key',
+        description='Secured API key is generated and enforces its restrictions',
+        run=test_generate_secured_api_key,
+        depends_on=['seed_sample_records'],
+        skip_on_error=True,
+    ),
+]
+
+
+def get_scenario_by_name(name: str) -> Optional[TestScenario]:
+    return next((s for s in TEST_SCENARIOS if s.name == name), None)
+
+
+def list_scenario_names(include_disabled: bool = False) -> List[str]:
+    return [s.name for s in TEST_SCENARIOS if include_disabled or s.enabled]

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,0 +1,7 @@
+# Extra dependencies for scripts/test_algolia_integration.py.
+#
+# algoliasearch is already pinned in the project's base requirements (we don't
+# want to fight that here). Inside the container these are already available;
+# install this only if you want to run the runner from a host venv.
+
+python-dotenv>=0.20.0

--- a/scripts/test_algolia_integration.py
+++ b/scripts/test_algolia_integration.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""
+Integration tests for the project's AlgoliaSearchClient wrapper against an
+Algolia sandbox application.
+
+Designed to run inside the enterprise.catalog.app container so the project's
+Django + algolia_utils imports resolve cleanly.
+
+Usage:
+    # Inside the container (recommended path)
+    docker exec -e DJANGO_SETTINGS_MODULE=enterprise_catalog.settings.test \\
+      enterprise.catalog.app python scripts/test_algolia_integration.py --all
+
+    # List available scenarios without running them
+    docker exec enterprise.catalog.app python scripts/test_algolia_integration.py --list
+
+    # Run a single scenario
+    docker exec enterprise.catalog.app python scripts/test_algolia_integration.py \\
+      --test browse_by_aggregation_key
+
+Configuration is read from scripts/.env (or the path passed via --env). See
+scripts/.env.example for the required variables.
+"""
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, List, Set
+
+# Make both the project root (so ``enterprise_catalog`` imports) and the
+# scripts/ directory (so ``algolia_integration`` imports) discoverable.
+_SCRIPT_DIR = Path(__file__).parent
+_PROJECT_ROOT = _SCRIPT_DIR.parent
+sys.path.insert(0, str(_PROJECT_ROOT))
+sys.path.insert(0, str(_SCRIPT_DIR))
+
+from algolia_integration.client import bootstrap_django, make_wrapper_client  # noqa: E402
+from algolia_integration.config import Config  # noqa: E402
+from algolia_integration.test_scenarios import (  # noqa: E402
+    TEST_SCENARIOS,
+    get_scenario_by_name,
+    list_scenario_names,
+)
+
+
+class Colors:
+    HEADER = '\033[95m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    CYAN = '\033[96m'
+    BOLD = '\033[1m'
+    ENDC = '\033[0m'
+
+
+def setup_logging(verbose: bool, debug: bool) -> None:
+    if debug:
+        level = logging.DEBUG
+    elif verbose:
+        level = logging.INFO
+    else:
+        level = logging.WARNING
+    logging.basicConfig(
+        level=level,
+        format='%(asctime)s [%(levelname)s] %(name)s: %(message)s',
+        datefmt='%H:%M:%S',
+    )
+
+
+def print_header(text: str) -> None:
+    print(f"\n{Colors.BOLD}{Colors.HEADER}{text}{Colors.ENDC}")
+    print('=' * len(text))
+
+
+def print_success(text: str) -> None:
+    print(f"{Colors.GREEN}\u2713 {text}{Colors.ENDC}")
+
+
+def print_error(text: str) -> None:
+    print(f"{Colors.RED}\u2717 {text}{Colors.ENDC}")
+
+
+def print_warning(text: str) -> None:
+    print(f"{Colors.YELLOW}\u26a0 {text}{Colors.ENDC}")
+
+
+def print_info(text: str) -> None:
+    print(f"{Colors.CYAN}\u2139 {text}{Colors.ENDC}")
+
+
+def resolve_dependencies(test_names: List[str]) -> List[str]:
+    """Topologically sort the requested test names by their depends_on chains."""
+    resolved: List[str] = []
+    seen: Set[str] = set()
+
+    def resolve(name: str, path: Set[str]) -> None:
+        if name in path:
+            raise ValueError(f"Circular dependency: {' -> '.join(path)} -> {name}")
+        if name in seen:
+            return
+        scenario = get_scenario_by_name(name)
+        if not scenario:
+            raise ValueError(f"Unknown scenario: {name}")
+        if scenario.depends_on:
+            for dep in scenario.depends_on:
+                resolve(dep, path | {name})
+        if name not in seen:
+            resolved.append(name)
+            seen.add(name)
+
+    for name in test_names:
+        resolve(name, set())
+    return resolved
+
+
+def run_scenario(scenario, wrapper, config, verbose: bool) -> Dict:
+    print(f"\n{Colors.BOLD}\u25b6 Running: {scenario.name}{Colors.ENDC}")
+    print(f"  {scenario.description}")
+    try:
+        result = scenario.run(wrapper, config)
+    except AssertionError as exc:
+        print_error(f"{scenario.name}: ASSERTION FAILED")
+        print(f"  {exc}")
+        return {'status': 'FAIL', 'error': str(exc), 'error_type': 'assertion'}
+    except Exception as exc:  # pylint: disable=broad-except
+        print_error(f"{scenario.name}: {type(exc).__name__}")
+        print(f"  {exc}")
+        return {'status': 'FAIL', 'error': str(exc), 'error_type': type(exc).__name__}
+
+    if result.get('status') == 'PASS':
+        print_success(f"{scenario.name}: PASSED")
+    elif result.get('status') == 'SKIP':
+        print_warning(f"{scenario.name}: SKIPPED ({result.get('data', {}).get('reason', '')})")
+    else:
+        print_error(f"{scenario.name}: {result.get('status')}")
+
+    if verbose and 'data' in result:
+        print(f"\n{Colors.CYAN}  Result data:{Colors.ENDC}")
+        print(f"  {json.dumps(result['data'], indent=2, default=str)}")
+
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Algolia sandbox integration tests',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('--env', type=Path, default=None,
+                        help='Path to .env file (default: scripts/.env then ./.env)')
+    parser.add_argument('--test', action='append', dest='tests',
+                        help='Run a specific scenario by name (repeatable)')
+    parser.add_argument('--all', action='store_true', help='Run all scenarios')
+    parser.add_argument('--list', action='store_true', help='List scenarios and exit')
+    parser.add_argument('--verbose', '-v', action='store_true', help='Verbose output')
+    parser.add_argument('--debug', action='store_true', help='Debug logging')
+    parser.add_argument('--stop-on-fail', action='store_true',
+                        help='Stop after the first failed scenario')
+    args = parser.parse_args()
+
+    setup_logging(args.verbose, args.debug)
+
+    if args.list:
+        print_header('Available Scenarios')
+        for scenario in TEST_SCENARIOS:
+            deps = f' (depends on: {", ".join(scenario.depends_on)})' if scenario.depends_on else ''
+            disabled = '' if scenario.enabled else f' {Colors.YELLOW}[opt-in]{Colors.ENDC}'
+            print(f"  \u2022 {Colors.BOLD}{scenario.name}{Colors.ENDC}{deps}{disabled}")
+            print(f"    {scenario.description}")
+        return 0
+
+    if args.tests:
+        invalid = [name for name in args.tests if not get_scenario_by_name(name)]
+        if invalid:
+            print_error(f"Unknown scenario(s): {', '.join(invalid)}")
+            print_info('Use --list to see available scenarios')
+            return 1
+        names = args.tests
+    elif args.all:
+        names = list_scenario_names()
+    else:
+        parser.print_help()
+        return 1
+
+    try:
+        names = resolve_dependencies(names)
+    except ValueError as exc:
+        print_error(f"Dependency error: {exc}")
+        return 1
+
+    print_header('Configuration')
+    try:
+        config = Config.from_env(args.env)
+        config.validate()
+        print_success('Configuration loaded')
+        if args.verbose:
+            print('\nConfiguration (secrets masked):')
+            for key, value in config.mask_secrets().items():
+                print(f"  {key}: {value}")
+    except FileNotFoundError as exc:
+        print_error(f"Env file not found: {exc}")
+        print_info('See scripts/.env.example')
+        return 1
+    except ValueError as exc:
+        print_error(f"Configuration error: {exc}")
+        return 1
+
+    print_header('Bootstrapping Django + AlgoliaSearchClient')
+    try:
+        bootstrap_django(config)
+        wrapper = make_wrapper_client()
+        print_success('Wrapper initialized')
+    except Exception as exc:  # pylint: disable=broad-except
+        print_error(f"Bootstrap failed: {type(exc).__name__}: {exc}")
+        if args.debug:
+            raise
+        return 1
+
+    print_header('Running Scenarios')
+    print(f"Will run {len(names)} scenario(s)")
+
+    results: Dict[str, Dict] = {}
+    skipped: List[str] = []
+
+    for name in names:
+        scenario = get_scenario_by_name(name)
+        if scenario.depends_on:
+            failed = [d for d in scenario.depends_on
+                      if results.get(d, {}).get('status') != 'PASS']
+            if failed:
+                print_warning(f"Skipping {name}; dependencies failed: {', '.join(failed)}")
+                skipped.append(name)
+                continue
+        result = run_scenario(scenario, wrapper, config, args.verbose)
+        results[name] = result
+        if args.stop_on_fail and result.get('status') == 'FAIL':
+            print_warning('Stopping due to --stop-on-fail')
+            break
+
+    print_header('Summary')
+    passed = sum(1 for r in results.values() if r.get('status') == 'PASS')
+    skipped_in_run = sum(1 for r in results.values() if r.get('status') == 'SKIP')
+    failed = sum(1 for r in results.values() if r.get('status') == 'FAIL')
+    total = len(results)
+    print(f"\nResults: {passed}/{total} passed, {skipped_in_run} skipped, {failed} failed")
+
+    if failed:
+        print(f"\n{Colors.RED}Failed:{Colors.ENDC}")
+        for name, result in results.items():
+            if result.get('status') == 'FAIL':
+                print(f"  \u2022 {name}: {result.get('error_type', 'unknown')}")
+                if args.verbose:
+                    print(f"    {result.get('error', '')}")
+
+    if skipped:
+        print(f"\n{Colors.YELLOW}Skipped (unmet deps):{Colors.ENDC}")
+        for name in skipped:
+            print(f"  \u2022 {name}")
+
+    if failed:
+        return 1
+    return 0
+
+
+if __name__ == '__main__':
+    try:
+        sys.exit(main())
+    except KeyboardInterrupt:
+        print_warning('\nInterrupted')
+        sys.exit(130)


### PR DESCRIPTION
ENT-11656

v3 is no longer supported. Migrate to algoliasearch 4.39.0 and absorb the breaking SDK changes inside the AlgoliaSearchClient wrapper so existing call sites keep their interface. SearchClientSync replaces SearchClient. create; client methods now take index_name as a parameter; replace_all_objects sequences atomically without the v3 safe= flag; generate_secured_api_key is an instance method; AlgoliaException moved to algoliasearch.http.exceptions. A small _AlgoliaIndexProxy preserves the v3-style
algolia_client.algolia_index.search() / .search_for_facet_values() pattern for the CSV/workbook/AI-curation/academy callsites.

Production fix surfaced by sandbox testing: the v4 SDK's typed list_indices() raises pydantic.ValidationError on real Algolia responses because FetchedIndex declares lastBuildTimeS, numberOfPendingTasks, and pendingTask as required, which the API regularly omits. Switched _get_all_indices to list_indices_with_http_info() + json.loads to bypass the strict deserialization.

Adds scripts/algolia_integration/ runner modeled on enterprise-access billing_integration: env-driven config, project-wrapper client, and eight scenarios covering set_settings / replace_all_objects / browse / delete / list_indices / delete_index / generate_secured_api_key. See docs/how_to/algolia_integration_tests_pattern.md for usage.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
