### PR TITLE
feat(highlights): increase max highlight sets from 16 to 26

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_curation_views.py
@@ -7,6 +7,7 @@ import uuid
 from unittest import mock
 
 import ddt
+from django.conf import settings
 from django.core.cache import cache as django_cache
 from faker import Faker
 from rest_framework import status
@@ -19,7 +20,6 @@ from enterprise_catalog.apps.api.v1.tests.mixins import (
 )
 from enterprise_catalog.apps.api.v1.views.curation.highlights import (
     CONTENT_PER_HIGHLIGHTSET_LIMIT,
-    HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT,
     HighlightSetPartialUpdateSerializer,
 )
 from enterprise_catalog.apps.catalog.constants import COURSE, PROGRAM
@@ -809,7 +809,7 @@ class HighlightSetViewSetTests(CurationAPITestBase):
             'is_published': True,
         }
         # Create so many HighlightSet objects such that the final count is just at the limit, but not exceeding it.
-        for _ in range(HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT - 1):
+        for _ in range(settings.HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT - 1):
             response = self.client.post(url, post_data)
             assert response.status_code == status.HTTP_201_CREATED
         # Create one more HighlightSet that should trigger an error.

--- a/enterprise_catalog/apps/api/v1/views/curation/highlights.py
+++ b/enterprise_catalog/apps/api/v1/views/curation/highlights.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Mapping
 from uuid import UUID
 
+from django.conf import settings
 from django.db import transaction
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_page
@@ -56,7 +57,6 @@ from enterprise_catalog.apps.curation.models import (
 
 REQUEST_CACHE_NAMESPACE = 'CURATION_REQUEST_CACHE'
 CONTENT_PER_HIGHLIGHTSET_LIMIT = 24
-HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT = 16
 logger = logging.getLogger(__name__)
 
 
@@ -624,13 +624,14 @@ class HighlightSetViewSet(HighlightSetBaseViewSet, viewsets.ModelViewSet):
 
         # Validate that creating this HighlightSet would not cause the maximum number of highlight sets per enterprise
         # customer to be exceeded.
-        existing_highlightset_count = len(HighlightSet.objects.filter(enterprise_curation=curation_config))
-        if existing_highlightset_count == HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT:
+        existing_highlightset_count = HighlightSet.objects.filter(enterprise_curation=curation_config).count()
+        highlightsets_limit = settings.HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT
+        if existing_highlightset_count >= highlightsets_limit:
             return Response(
                 {
                     'Error': (
                         'Request exceeds the backend maximum highlight set per enterprise customer '
-                        f'({HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT}).'
+                        f'({highlightsets_limit}).'
                     ),
                 },
                 status=status.HTTP_403_FORBIDDEN

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -463,6 +463,15 @@ SHOULD_INDEX_COURSES_WITH_RESTRICTED_RUNS = False
 # Whether to enable v2 of the APIs that surface restricted course (+ runs) content
 ENABLE_V2_API = False
 
+# Maximum number of HighlightSets allowed per enterprise customer.
+# Overridable via env var; falls back to 26 if the value is missing, non-integer, or non-positive.
+_HIGHLIGHTSETS_LIMIT_DEFAULT = 26
+try:
+    _parsed = int(os.environ.get('HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT', _HIGHLIGHTSETS_LIMIT_DEFAULT))
+    HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT = _parsed if _parsed > 0 else _HIGHLIGHTSETS_LIMIT_DEFAULT
+except ValueError:
+    HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT = _HIGHLIGHTSETS_LIMIT_DEFAULT
+
 # Set up system-to-feature roles mapping for edx-rbac
 SYSTEM_TO_FEATURE_ROLE_MAPPING = {
     # The enterprise catalog admin role is for users who need to perform state altering requests on catalogs

--- a/enterprise_catalog/settings/test.py
+++ b/enterprise_catalog/settings/test.py
@@ -35,6 +35,9 @@ CELERY_RESULT_BACKEND = f'file://{results_dir.name}'
 # test runtimes compared with the more secure PBKDF2-based hasher used in production.
 PASSWORD_HASHERS = ['django.contrib.auth.hashers.MD5PasswordHasher']
 
+# Use a small limit to keep test_create_too_many_sets fast.
+HIGHLIGHTSETS_PER_ENTERPRISE_LIMIT = 3
+
 # Disable API throttling by default in tests; individual tests can re-enable
 # specific rates via ``override_settings``. DRF treats a ``None`` rate as no limit.
 REST_FRAMEWORK = {


### PR DESCRIPTION
- Increase limit from 16 to 26 highlight sets per enterprise
- Align environment variable naming with existing conventions
- JIRA: [ENT-11143](https://2u-internal.atlassian.net/browse/ENT-11143)