### PR TITLE
refactor: name function accurately

### DIFF
--- a/docs/algolia-reindexing/tech-spec.md
+++ b/docs/algolia-reindexing/tech-spec.md
@@ -303,7 +303,7 @@ We determine what needs reindexing differently per content type:
 | Component | Purpose |
 |-----------|---------|
 | `ContentMetadataIndexingState` model | Tracks per-record indexing state, failure history |
-| `AlgoliaSearchClient` batch methods | `save_objects_batch()`, `delete_objects_batch()`, `get_object_ids_by_prefix()`, `get_content_keys_for_catalog_query()` |
+| `AlgoliaSearchClient` batch methods | `save_objects_batch()`, `delete_objects_batch()`, `get_object_ids_by_prefix()`, `get_aggregation_keys_for_catalog_query()` |
 | Content-type batch tasks | `index_courses_batch_in_algolia`, `index_programs_batch_in_algolia`, `index_pathways_batch_in_algolia` |
 | Dispatcher tasks | `dispatch_algolia_indexing` (all stale), `dispatch_algolia_indexing_for_catalog_query` (single catalog) |
 | Management command | `incremental_reindex_algolia` — manual runs, testing against v2 index |
@@ -487,17 +487,22 @@ When content is *removed* from a catalog's membership, that content's Algolia re
 def dispatch_algolia_indexing_for_catalog_query(catalog_query_id):
     catalog_query = CatalogQuery.objects.get(id=catalog_query_id)
 
-    # Query Algolia for records with this catalog_query's facets
-    algolia_content_keys = algolia_client.get_content_keys_for_catalog_query(catalog_query_id)
+    # Query Algolia for aggregation_keys ("{content_type}:{content_key}") currently
+    # indexed under this catalog query's facet.
+    algolia_aggregation_keys = algolia_client.get_aggregation_keys_for_catalog_query(catalog_query_id)
 
-    # Query database for current membership
-    db_content_keys = set(catalog_query.content_metadata.values_list('content_key', flat=True))
+    # Query database for current membership; convert to aggregation_keys so the
+    # set diff is apples-to-apples.
+    db_aggregation_keys = {
+        f'{cm.content_type}:{cm.content_key}'
+        for cm in catalog_query.content_metadata.all()
+    }
 
-    # Content removed from membership needs reindexing to update facets
-    removed_keys = algolia_content_keys - db_content_keys
-    all_keys_to_index = db_content_keys | removed_keys
+    # Content removed from membership needs reindexing to update facets.
+    removed_aggregation_keys = algolia_aggregation_keys - db_aggregation_keys
+    all_aggregation_keys_to_index = db_aggregation_keys | removed_aggregation_keys
 
-    # Batch and dispatch...
+    # Group by content_type, batch, and dispatch...
 ```
 
 **Why this works**: When we reindex a removed course, we generate fresh Algolia objects based on its *current* membership (which no longer includes the old catalog). The Algolia `save_objects_batch()` replaces the record, removing the stale catalog facet.
@@ -656,7 +661,7 @@ Instead of updating each frontend's `ALGOLIA_INDEX_NAME` env var and deploying s
 - Add `save_objects_batch(objects, index_name=None)` method
 - Add `delete_objects_batch(object_ids, index_name=None)` method
 - Add `get_object_ids_by_prefix(prefix, index_name=None)` method for shard discovery
-- Add `get_content_keys_for_catalog_query(catalog_query_id, index_name=None)` method for membership removal detection
+- Add `get_aggregation_keys_for_catalog_query(catalog_query_id, index_name=None)` method for membership removal detection
 - Add `_get_index(index_name=None)` helper to support custom index names
 
 **File Changes**:
@@ -669,7 +674,7 @@ Instead of updating each frontend's `ALGOLIA_INDEX_NAME` env var and deploying s
 - [ ] `save_objects_batch()` upserts objects without affecting other records
 - [ ] `delete_objects_batch()` removes specified objects by ID
 - [ ] `get_object_ids_by_prefix()` returns all object IDs matching a content key prefix
-- [ ] `get_content_keys_for_catalog_query()` returns content keys currently indexed with the given catalog query's facets (uses Algolia's browse/search API with facet filter)
+- [ ] `get_aggregation_keys_for_catalog_query()` returns content keys currently indexed with the given catalog query's facets (uses Algolia's browse/search API with facet filter)
 - [ ] All methods support optional `index_name` param for targeting v2 index
 - [ ] All methods have appropriate error handling and logging
 

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -234,23 +234,31 @@ class AlgoliaSearchClient:
             raise exc
         return object_ids
 
-    def get_content_keys_for_catalog_query(self, catalog_query_uuid, index_name=None):
+    def get_aggregation_keys_for_catalog_query(self, catalog_query_uuid, index_name=None):
         """
-        Return the set of content keys currently indexed with the given catalog query's facet.
+        Return the set of ``aggregation_key`` values currently indexed with the given
+        catalog query's facet.
 
-        Used by the per-catalog dispatcher to detect membership removals: any content key
-        present in Algolia under this catalog query but no longer in the database
-        membership needs to be reindexed so its facets reflect the removal.
+        Each returned value is a ``"{content_type}:{content_key}"`` string (e.g.
+        ``"course:edX+DemoX"``); shards belonging to the same content collapse to a
+        single entry because they share the same ``aggregation_key``. Callers that
+        want bare ``content_key``s (or just the ``content_type``) should split the
+        returned strings on ``:``.
+
+        Used by the per-catalog dispatcher to detect membership removals: any
+        aggregation_key present in Algolia under this catalog query but no longer
+        in the database membership needs to be reindexed so its facets reflect the
+        removal.
 
         Arguments:
             catalog_query_uuid (str|UUID): The CatalogQuery uuid to filter by.
             index_name (str): Optional index name; defaults to the primary index.
 
         Returns:
-            set: aggregation_keys (content keys) currently indexed under this catalog query.
+            set[str]: aggregation_keys currently indexed under this catalog query.
         """
         index = self._get_index(index_name)
-        content_keys = set()
+        aggregation_keys = set()
         try:
             # browse_objects returns an ObjectIterator that auto-paginates via cursor;
             # safe for catalog queries with 10k+ records.
@@ -263,15 +271,15 @@ class AlgoliaSearchClient:
             for hit in iterator:
                 aggregation_key = hit.get('aggregation_key')
                 if aggregation_key:
-                    content_keys.add(aggregation_key)
+                    aggregation_keys.add(aggregation_key)
         except AlgoliaException as exc:
             logger.exception(
-                'Could not list content keys for catalog query %s in the %s Algolia index due to an exception.',
+                'Could not list aggregation keys for catalog query %s in the %s Algolia index due to an exception.',
                 catalog_query_uuid,
                 index_name or self.algolia_index_name,
             )
             raise exc
-        return content_keys
+        return aggregation_keys
 
     def replace_all_objects(self, algolia_objects):  # pragma: no cover
         """

--- a/enterprise_catalog/apps/api_client/tests/test_algolia.py
+++ b/enterprise_catalog/apps/api_client/tests/test_algolia.py
@@ -15,7 +15,7 @@ from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 class TestAlgoliaSearchClientBatchMethods(TestCase):
     """
     Tests for ``save_objects_batch``, ``delete_objects_batch``,
-    ``get_object_ids_for_aggregation_key``, ``get_content_keys_for_catalog_query``,
+    ``get_object_ids_for_aggregation_key``, ``get_aggregation_keys_for_catalog_query``,
     and the ``_get_index`` helper.
     """
     # pylint: disable=protected-access
@@ -230,59 +230,59 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
         client.algolia_index.browse_objects.side_effect = AlgoliaException('boom')
 
         with self.assertRaises(AlgoliaException):
-            client.get_object_ids_for_aggregation_key('course-abc')
+            client.get_object_ids_for_aggregation_key('course:edx-abc')
 
-    def test_get_content_keys_for_catalog_query_dedupes_across_shards(self):
+    def test_get_aggregation_keys_for_catalog_query_dedupes_across_shards(self):
         """
         Multiple shards of the same content yield a single aggregation_key in the result.
         """
         client = self._build_client()
         client.algolia_index.browse_objects.return_value = iter([
-            {'aggregation_key': 'course-abc'},
-            {'aggregation_key': 'course-abc'},  # second shard, same content key
-            {'aggregation_key': 'course-def'},
+            {'aggregation_key': 'course:edx-abc'},
+            {'aggregation_key': 'course:edx-abc'},  # second shard, same content key
+            {'aggregation_key': 'course:edx-def'},
         ])
 
-        result = client.get_content_keys_for_catalog_query('cq-uuid-1')
+        result = client.get_aggregation_keys_for_catalog_query('cq-uuid-1')
 
-        self.assertEqual(result, {'course-abc', 'course-def'})
+        self.assertEqual(result, {'course:edx-abc', 'course:edx-def'})
         client.algolia_index.browse_objects.assert_called_once_with({
             'attributesToRetrieve': ['aggregation_key'],
             'facetFilters': ['enterprise_catalog_query_uuids:cq-uuid-1'],
         })
 
-    def test_get_content_keys_for_catalog_query_skips_missing_aggregation_key(self):
+    def test_get_aggregation_keys_for_catalog_query_skips_missing_aggregation_key(self):
         """
         Records without ``aggregation_key`` are ignored rather than added as None.
         """
         client = self._build_client()
         client.algolia_index.browse_objects.return_value = iter([
-            {'aggregation_key': 'course-abc'},
+            {'aggregation_key': 'course:edx-abc'},
             {},
             {'aggregation_key': None},
         ])
 
-        result = client.get_content_keys_for_catalog_query('cq-uuid-1')
-        self.assertEqual(result, {'course-abc'})
+        result = client.get_aggregation_keys_for_catalog_query('cq-uuid-1')
+        self.assertEqual(result, {'course:edx-abc'})
 
-    def test_get_content_keys_for_catalog_query_targets_alternate_index(self):
+    def test_get_aggregation_keys_for_catalog_query_targets_alternate_index(self):
         """
         Browses the alternate index when ``index_name`` is provided.
         """
         client = self._build_client()
         alt_index = mock.MagicMock(name='alt_index')
-        alt_index.browse_objects.return_value = iter([{'aggregation_key': 'course-abc'}])
+        alt_index.browse_objects.return_value = iter([{'aggregation_key': 'course:edx-abc'}])
         client._client.init_index.return_value = alt_index
 
-        result = client.get_content_keys_for_catalog_query(
+        result = client.get_aggregation_keys_for_catalog_query(
             'cq-uuid-1', index_name=self.ALT_INDEX_NAME,
         )
 
-        self.assertEqual(result, {'course-abc'})
+        self.assertEqual(result, {'course:edx-abc'})
         alt_index.browse_objects.assert_called_once()
         client.algolia_index.browse_objects.assert_not_called()
 
-    def test_get_content_keys_for_catalog_query_reraises_algolia_exception(self):
+    def test_get_aggregation_keys_for_catalog_query_reraises_algolia_exception(self):
         """
         Algolia errors are re-raised.
         """
@@ -290,15 +290,15 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
         client.algolia_index.browse_objects.side_effect = AlgoliaException('boom')
 
         with self.assertRaises(AlgoliaException):
-            client.get_content_keys_for_catalog_query('cq-uuid-1')
+            client.get_aggregation_keys_for_catalog_query('cq-uuid-1')
 
-    def test_get_content_keys_for_catalog_query_raises_when_index_unavailable(self):
+    def test_get_aggregation_keys_for_catalog_query_raises_when_index_unavailable(self):
         """
         With no initialized index, raises ImproperlyConfigured.
         """
         client = AlgoliaSearchClient()
         with self.assertRaises(ImproperlyConfigured):
-            client.get_content_keys_for_catalog_query('cq-uuid-1')
+            client.get_aggregation_keys_for_catalog_query('cq-uuid-1')
 
     def test_get_object_ids_for_aggregation_key_raises_when_index_unavailable(self):
         """
@@ -306,4 +306,4 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
         """
         client = AlgoliaSearchClient()
         with self.assertRaises(ImproperlyConfigured):
-            client.get_object_ids_for_aggregation_key('course-abc')
+            client.get_object_ids_for_aggregation_key('course:edx-abc')

--- a/scripts/algolia_batch_smoke.py
+++ b/scripts/algolia_batch_smoke.py
@@ -2,7 +2,7 @@
 Smoke test for the new AlgoliaSearchClient batch methods.
 
 Exercises ``save_objects_batch``, ``get_object_ids_for_aggregation_key``,
-``get_content_keys_for_catalog_query``, and ``delete_objects_batch`` against
+``get_aggregation_keys_for_catalog_query``, and ``delete_objects_batch`` against
 a sandbox Algolia index. Reads sandbox credentials from ``scripts/.env``.
 
 Usage (from the project root, inside the app container)::
@@ -20,7 +20,7 @@ via every new method, and deletes them. Safe to re-run — each invocation uses
 a fresh aggregation_key and cleans up after itself.
 
 Assumes the sandbox index has ``enterprise_catalog_query_uuids`` declared as
-an attribute for faceting (required for the ``get_content_keys_for_catalog_query``
+an attribute for faceting (required for the ``get_aggregation_keys_for_catalog_query``
 scenario). If you've been running the existing legacy reindex against this
 sandbox, that's already configured.
 """
@@ -134,8 +134,8 @@ try:
     print(f'    -> {len(found_ids)} objectIDs returned')
 
     found_keys = _step(
-        'get_content_keys_for_catalog_query',
-        lambda: client.get_content_keys_for_catalog_query(CATALOG_QUERY_UUID),
+        'get_aggregation_keys_for_catalog_query',
+        lambda: client.get_aggregation_keys_for_catalog_query(CATALOG_QUERY_UUID),
     )
     assert AGGREGATION_KEY in found_keys, \
         f'{AGGREGATION_KEY} not in {sorted(found_keys)}'


### PR DESCRIPTION
Rename function to reflect what's actually iterated over and returned (aggregation_keys and not content_keys).
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
