### PR TITLE
feat: bulk Algolia save/delete with per-record fallback

### DIFF
--- a/docs/algolia-reindexing/tech-spec.md
+++ b/docs/algolia-reindexing/tech-spec.md
@@ -712,6 +712,18 @@ Instead of updating each frontend's `ALGOLIA_INDEX_NAME` env var and deploying s
 - Tasks fire-and-forget the Algolia writes: the `IndexingResponse` from
   `save_objects` / `delete_objects` is discarded and `.wait()` is not
   called. See ADR 0012 in this repo.
+- Bulk Algolia writes with per-record fallback. `_index_content_batch`
+  splits work across three passes: (1) per-record planning with no
+  Algolia writes (just diff math against `state.algolia_object_ids`),
+  (2) one bulk `save_objects_batch` and one bulk `delete_objects_batch`
+  call across the entire task batch, falling back to per-record retries
+  on `AlgoliaException` to isolate which content_keys actually failed,
+  (3) per-record state-row updates keyed off the per-record failure
+  sets. The client chunks each bulk call at
+  `ALGOLIA_INDEXING_CHUNK_SIZE` (default 100) to bound the blast
+  radius of a partial failure; Algolia upserts/deletes are idempotent,
+  so chunks the SDK already flushed before a failure are safely
+  re-written by the per-record fallback.
 
 **File Changes**:
 | File | Change |

--- a/docs/decisions/0012-incremental-indexing-state-authority-and-outcome-contract.rst
+++ b/docs/decisions/0012-incremental-indexing-state-authority-and-outcome-contract.rst
@@ -29,7 +29,7 @@ Decision
 --------
 
 **The state row is the system of record for shard ownership; Algolia browse
-is a fallback.** ``_process_content_key`` reads
+is a fallback.** ``_resolve_indexing_decision`` reads
 ``state.algolia_object_ids`` first to compute orphan diffs and to drive the
 REMOVE path; it falls back to
 ``AlgoliaSearchClient.get_object_ids_for_aggregation_key`` only when the
@@ -40,7 +40,7 @@ correctness during the transition window when legacy shards may exist
 without a corresponding state row.
 
 **``_index_content_batch`` resolves each ``content_key`` to exactly one of
-four outcomes**, formalized as ``BatchOutcome`` (a ``StrEnum``) with these
+four outcomes**, formalized as ``RecordOutcome`` (a ``StrEnum``) with these
 semantics:
 
 * **INDEXED** — content is indexable per the partition functions AND the
@@ -58,7 +58,7 @@ semantics:
   ``mark_as_failed(reason)`` is called best-effort. The batch continues
   processing the remaining records.
 
-Counters and the per-key failure list roll up into a ``BatchResults``
+Counters and the per-key failure list roll up into a ``BatchSummary``
 dataclass; task wrappers convert it via ``dataclasses.asdict()`` so the
 on-the-wire Celery payload stays JSON-serializable.
 
@@ -74,7 +74,7 @@ Consequences
   reindex job is decommissioned and we're confident no shards exist
   without a corresponding state row. Until then, the cost is one search
   op per first-time-indexed content.
-* The ``BatchOutcome`` set and its state-row effects are a public contract
+* The ``RecordOutcome`` set and its state-row effects are a public contract
   for the Phase 4 dispatcher and any downstream tooling. Adding a fifth
   outcome or changing what an existing one does to the state row is an
   ADR-worthy change.

--- a/docs/decisions/0012-incremental-indexing-state-authority-and-outcome-contract.rst
+++ b/docs/decisions/0012-incremental-indexing-state-authority-and-outcome-contract.rst
@@ -41,7 +41,10 @@ without a corresponding state row.
 
 **``_index_content_batch`` resolves each ``content_key`` to exactly one of
 four outcomes**, formalized as ``RecordOutcome`` (a ``StrEnum``) with these
-semantics:
+semantics. Each ``IndexingDecision`` carries both a ``desired_outcome`` (set
+during pass 1, immutable) and an ``outcome`` (mutable, mirrors
+``desired_outcome`` until pass 2's per-record fallback flips it to FAILED on
+write failure). Pass 3 dispatches on ``outcome``:
 
 * **INDEXED** — content is indexable per the partition functions AND the
   legacy generator emits ≥1 shard. New objects are upserted, orphans

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -10,7 +10,7 @@ from algoliasearch.search_client import SearchClient
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from enterprise_catalog.apps.catalog.utils import localized_utcnow
+from enterprise_catalog.apps.catalog.utils import batch, localized_utcnow
 
 
 logger = logging.getLogger(__name__)
@@ -159,45 +159,67 @@ class AlgoliaSearchClient:
             )
         return self._client.init_index(index_name)
 
-    def save_objects_batch(self, algolia_objects, index_name=None):
+    def save_objects_batch(self, algolia_objects, index_name=None, chunk_size=None):
         """
         Upsert a batch of objects into the given index without affecting other records.
         This intentionally does *not* wait for the asynchronous Algolia index job to complete.
         See ADR 0012 for details.
 
+        Chunking: the input list is split into ``chunk_size``-sized HTTP requests
+        (defaulting to ``settings.ALGOLIA_INDEXING_CHUNK_SIZE``). The Algolia SDK
+        also auto-chunks at 1000; we chunk smaller to limit blast radius on
+        failure. If a chunk raises ``AlgoliaException``, earlier chunks have
+        already been accepted by Algolia — Algolia upserts by ``objectID``, so a
+        retry of the full input is idempotent (callers running through the
+        per-record fallback path rely on this).
+
         Arguments:
             algolia_objects (list): Objects to save. Each must include an ``objectID``.
             index_name (str): Optional index name; defaults to the primary index.
+            chunk_size (int): Optional override for the per-request chunk size.
         """
+        if not algolia_objects:
+            return None
         index = self._get_index(index_name)
+        effective_chunk_size = chunk_size or getattr(settings, 'ALGOLIA_INDEXING_CHUNK_SIZE', 100)
         try:
-            return index.save_objects(algolia_objects)
+            for chunk in batch(list(algolia_objects), batch_size=effective_chunk_size):
+                index.save_objects(chunk)
         except AlgoliaException as exc:
             logger.exception(
                 'Could not save objects batch in the %s Algolia index due to an exception.',
                 index_name or self.algolia_index_name,
             )
             raise exc
+        return None
 
-    def delete_objects_batch(self, object_ids, index_name=None):
+    def delete_objects_batch(self, object_ids, index_name=None, chunk_size=None):
         """
         Delete a batch of objects by objectID from the given index.
+
+        Chunking: same behavior as ``save_objects_batch`` — split into
+        ``chunk_size``-sized HTTP requests, raising on the first chunk to fail.
+        Deletes are idempotent so retrying the full list is safe.
 
         Arguments:
             object_ids (list): Algolia objectIDs to delete.
             index_name (str): Optional index name; defaults to the primary index.
+            chunk_size (int): Optional override for the per-request chunk size.
         """
         if not object_ids:
             return None
         index = self._get_index(index_name)
+        effective_chunk_size = chunk_size or getattr(settings, 'ALGOLIA_INDEXING_CHUNK_SIZE', 100)
         try:
-            return index.delete_objects(object_ids)
+            for chunk in batch(list(object_ids), batch_size=effective_chunk_size):
+                index.delete_objects(chunk)
         except AlgoliaException as exc:
             logger.exception(
                 'Could not delete objects batch from the %s Algolia index due to an exception.',
                 index_name or self.algolia_index_name,
             )
             raise exc
+        return None
 
     def get_object_ids_for_aggregation_key(self, aggregation_key, index_name=None):
         """

--- a/enterprise_catalog/apps/api_client/tests/test_algolia.py
+++ b/enterprise_catalog/apps/api_client/tests/test_algolia.py
@@ -98,6 +98,49 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
 
         client.algolia_index.save_objects.assert_called_once_with(objects)
 
+    def test_save_objects_batch_chunks_into_multiple_calls(self):
+        """
+        With ``chunk_size`` smaller than the input length, the call is split
+        across multiple ``save_objects`` invocations on the index — each one
+        independently raises on its own failure, which is the property that
+        makes the bulk-with-fallback path in the search tasks work.
+        """
+        client = self._build_client()
+        objects = [{'objectID': f'shard-{i}'} for i in range(5)]
+
+        client.save_objects_batch(objects, chunk_size=2)
+
+        self.assertEqual(client.algolia_index.save_objects.call_count, 3)
+        chunks = [call.args[0] for call in client.algolia_index.save_objects.call_args_list]
+        # All input objects accounted for, in order, across 2-2-1 chunks.
+        self.assertEqual(
+            [obj['objectID'] for chunk in chunks for obj in chunk],
+            [obj['objectID'] for obj in objects],
+        )
+        self.assertEqual([len(chunk) for chunk in chunks], [2, 2, 1])
+
+    def test_save_objects_batch_noop_when_no_objects(self):
+        """
+        Empty input returns early without calling Algolia.
+        """
+        client = self._build_client()
+        client.save_objects_batch([])
+        client.algolia_index.save_objects.assert_not_called()
+
+    def test_save_objects_batch_uses_setting_default_chunk_size(self):
+        """
+        ``chunk_size=None`` (the default) reads from the Django setting; the
+        request fits in one chunk at the configured size.
+        """
+        client = self._build_client()
+        objects = [{'objectID': f'shard-{i}'} for i in range(50)]
+
+        with self.settings(ALGOLIA_INDEXING_CHUNK_SIZE=100):
+            client.save_objects_batch(objects)
+
+        client.algolia_index.save_objects.assert_called_once()
+        self.assertEqual(len(client.algolia_index.save_objects.call_args.args[0]), 50)
+
     def test_save_objects_batch_targets_alternate_index(self):
         """
         With ``index_name`` set, ``save_objects_batch`` writes to that index instead.
@@ -143,6 +186,21 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
 
         client.algolia_index.delete_objects.assert_called_once_with(ids)
 
+    def test_delete_objects_batch_chunks_into_multiple_calls(self):
+        """
+        With ``chunk_size`` smaller than the input length, the call is split
+        across multiple ``delete_objects`` invocations.
+        """
+        client = self._build_client()
+        ids = [f'shard-{i}' for i in range(5)]
+
+        client.delete_objects_batch(ids, chunk_size=2)
+
+        self.assertEqual(client.algolia_index.delete_objects.call_count, 3)
+        chunks = [call.args[0] for call in client.algolia_index.delete_objects.call_args_list]
+        self.assertEqual([oid for chunk in chunks for oid in chunk], ids)
+        self.assertEqual([len(chunk) for chunk in chunks], [2, 2, 1])
+
     def test_delete_objects_batch_targets_alternate_index(self):
         """
         With ``index_name`` set, ``delete_objects_batch`` deletes from that index.
@@ -163,8 +221,7 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
         Empty/None object_ids returns early without calling Algolia.
         """
         client = self._build_client()
-        result = client.delete_objects_batch(ids)
-        self.assertIsNone(result)
+        client.delete_objects_batch(ids)
         client.algolia_index.delete_objects.assert_not_called()
 
     def test_delete_objects_batch_reraises_algolia_exception(self):

--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -8,6 +8,17 @@ shards, and updates the per-record ``ContentMetadataIndexingState``.
 
 Design notes worth keeping in mind:
 
+* **Three-pass + bulk-with-fallback.** ``_index_content_batch`` first resolves
+  every record into an ``IndexingDecision`` (no Algolia writes; the only
+  Algolia I/O is the per-record browse fallback in ``_existing_shard_ids``),
+  then issues one bulk ``save_objects_batch`` and one bulk
+  ``delete_objects_batch`` for the entire task batch. If a bulk call raises
+  ``AlgoliaException``, we fall back to per-record save/delete to isolate
+  which content_keys actually failed; per-record fallback failures mutate
+  ``decision.outcome`` to FAILED in place. Algolia upserts and deletes by
+  ``objectID``, so the per-record retries are idempotent against any chunks
+  the SDK already flushed before the bulk call raised. The final pass
+  applies state-row updates by dispatching on ``decision.outcome``.
 * **Algolia save operations precede DB writes.**
   If the DB write fails after a successful  Algolia save, the next stragglers run sees ``last_indexed_at`` not advanced
   and re-indexes — idempotent, just one wasted Algolia upsert.
@@ -15,8 +26,10 @@ Design notes worth keeping in mind:
   which task will eventually write/publish the updated index record on the Algolia index.
   See ADR 0012.
 * **Per-record failures don't fail the whole batch.** Each content_key is
-  wrapped in its own try/except; failures are recorded via ``mark_as_failed``
-  and the loop continues.
+  isolated either at resolution time (try/except inside
+  ``_resolve_indexing_decision``) or at fallback time (try/except per record
+  inside ``_per_record_save_fallback`` / ``_per_record_delete_fallback``);
+  failures are recorded via ``mark_as_failed`` and the loop continues.
 * **Orphaned shards** are detected by querying Algolia for the content_key's
   current shards and diffing against the new shard set. The legacy
   ``replace_all_objects`` flow relied on full-index replacement; we don't have
@@ -31,6 +44,7 @@ from collections import defaultdict
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
 
+from algoliasearch.exceptions import AlgoliaException
 from celery import shared_task
 from celery_utils.logged_task import LoggedTask
 from django.db import IntegrityError
@@ -38,6 +52,7 @@ from django.db.utils import OperationalError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
 from enterprise_catalog.apps.api.tasks import _get_algolia_products_for_batch
+from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.catalog.algolia_utils import (
     get_initialized_algolia_client,
 )
@@ -48,6 +63,7 @@ from enterprise_catalog.apps.catalog.constants import (
 )
 from enterprise_catalog.apps.catalog.models import ContentMetadata
 from enterprise_catalog.apps.search.indexing_mappings import (
+    IndexingMappings,
     get_indexing_mappings,
 )
 from enterprise_catalog.apps.search.models import ContentMetadataIndexingState
@@ -59,14 +75,16 @@ logger = logging.getLogger(__name__)
 UNREADY_TASK_RETRY_COUNTDOWN_SECONDS = 60 * 5
 
 
-class BatchOutcome(StrEnum):
+class RecordOutcome(StrEnum):
     """
-    The resolution of a single content_key inside a batch indexing task.
+    The outcome of indexing a single content record inside a batch indexing
+    task.
 
-    ``_process_content_key`` returns one of INDEXED / SKIPPED / REMOVED.
-    FAILED is recorded by ``_index_content_batch`` when an exception bubbles
-    out of the per-record block. The string values match the ``BatchResults``
-    counter attribute names so we can dispatch increments via ``setattr``.
+    ``_resolve_indexing_decision`` produces one of INDEXED / SKIPPED / REMOVED
+    / FAILED in pass 1; FAILED can also arrive in pass 2 if a per-record
+    fallback save/delete itself raises (the fallback mutates the decision's
+    outcome). The string values match the ``BatchSummary`` counter attribute
+    names so ``increment(outcome)`` can dispatch via ``setattr``.
     """
     INDEXED = 'indexed'
     SKIPPED = 'skipped'
@@ -75,7 +93,7 @@ class BatchOutcome(StrEnum):
 
 
 @dataclass
-class BatchResults:
+class BatchSummary:
     """
     Counts of per-record outcomes from a single batch indexing task, plus
     the ``content_type`` and the list of content_keys that hit per-record
@@ -85,7 +103,7 @@ class BatchResults:
     convert it to a plain dict via ``dataclasses.asdict()`` so the on-the-wire
     shape (over Celery / JSON) stays stable for downstream consumers.
 
-    Counter attribute names match ``BatchOutcome`` member values 1:1, which
+    Counter attribute names match ``RecordOutcome`` member values 1:1, which
     lets ``increment(outcome)`` use ``setattr``/``getattr`` without a switch.
     """
     content_type: str
@@ -96,7 +114,7 @@ class BatchResults:
     failed_keys: list = field(default_factory=list)
 
     def increment(self, outcome):
-        """Bump the counter that matches ``outcome`` (a ``BatchOutcome``)."""
+        """Bump the counter that matches ``outcome`` (a ``RecordOutcome``)."""
         setattr(self, outcome, getattr(self, outcome) + 1)
 
     def record_failure(self, content_key):
@@ -155,24 +173,121 @@ def index_pathways_batch_in_algolia(self, content_keys, index_name=None, force=F
     return asdict(_index_content_batch(content_keys, LEARNER_PATHWAY, index_name=index_name, force=force))
 
 
+@dataclass
+class IndexingDecision:
+    """
+    The resolved indexing decision for one content record in a batch indexing
+    task.
+
+    Built by ``_resolve_indexing_decision`` in pass 1 (with at most one
+    per-record Algolia browse — see ``_existing_shard_ids``), consumed by
+    ``_execute_saves`` / ``_execute_deletes`` in pass 2, then applied to the
+    state row + counters in pass 3 by ``_finalize_decision``.
+
+    A decision is mutable in exactly one way: if a per-record fallback in
+    pass 2 raises, the fallback sets ``outcome = RecordOutcome.FAILED`` and
+    populates ``failure_reason`` on this same instance. That makes
+    ``decision.outcome`` the single source of truth in pass 3 — no separate
+    failure-set parameters need to be threaded through.
+
+    Always construct via the ``skipped`` / ``removed`` / ``indexed`` /
+    ``failed`` classmethods rather than the raw constructor; each enforces
+    the field invariants for its outcome.
+
+    Invariants by outcome:
+
+    * INDEXED — ``new_objects`` non-empty, ``new_object_ids`` matches their
+      ``objectID`` (in order), ``ids_to_delete`` is the set of orphans (may
+      be empty).
+    * REMOVED — ``new_objects`` and ``new_object_ids`` empty; ``ids_to_delete``
+      is the set of shards Algolia is hosting for this content (may be
+      empty).
+    * SKIPPED — nothing to do; all lists empty.
+    * FAILED — planning failed, OR a per-record fallback in pass 2 raised.
+      ``content`` and ``state`` may be ``None`` (e.g. when ``ContentMetadata``
+      is missing); ``failure_reason`` carries the exception.
+    """
+    content_key: str
+    outcome: RecordOutcome
+    content: ContentMetadata = None
+    state: ContentMetadataIndexingState = None
+    new_objects: list = field(default_factory=list)
+    new_object_ids: list = field(default_factory=list)
+    ids_to_delete: list = field(default_factory=list)
+    failure_reason: Exception = None
+
+    @classmethod
+    def skipped(cls, *, content_key, content, state):
+        """``state.last_indexed_at`` is current and ``force=False``."""
+        return cls(
+            content_key=content_key, outcome=RecordOutcome.SKIPPED,
+            content=content, state=state,
+        )
+
+    @classmethod
+    def removed(cls, *, content_key, content, state, ids_to_delete):
+        """
+        Either the content is no longer indexable, or it's indexable but the
+        legacy generator emitted zero shards (memberships dropped).
+        ``ids_to_delete`` is whatever Algolia is currently hosting for it.
+        """
+        return cls(
+            content_key=content_key, outcome=RecordOutcome.REMOVED,
+            content=content, state=state, ids_to_delete=list(ids_to_delete),
+        )
+
+    @classmethod
+    def indexed(cls, *, content_key, content, state, new_objects, new_object_ids, ids_to_delete):
+        """
+        New objects to upsert (non-empty) plus any orphan shard IDs that the
+        previous run wrote but this run no longer needs.
+        """
+        return cls(
+            content_key=content_key, outcome=RecordOutcome.INDEXED,
+            content=content, state=state,
+            new_objects=new_objects, new_object_ids=new_object_ids,
+            ids_to_delete=list(ids_to_delete),
+        )
+
+    @classmethod
+    def failed(cls, *, content_key, content=None, state=None, failure_reason):
+        """
+        Pass 1 couldn't produce a real plan (e.g. missing ``ContentMetadata``)
+        or pass 2's per-record fallback raised. Pass 3 will best-effort stamp
+        the state row via ``mark_as_failed`` if both ``content`` and ``state``
+        are available.
+        """
+        return cls(
+            content_key=content_key, outcome=RecordOutcome.FAILED,
+            content=content, state=state, failure_reason=failure_reason,
+        )
+
+
 def _index_content_batch(content_keys, content_type, index_name=None, force=False):
     """
-    Drive the per-record indexing loop for a batch of content_keys.
+    Drive the per-record indexing loop for a batch of content_keys via three
+    coordinated passes:
 
-    Each content_key resolves to one of three outcomes:
+    1. **Resolve** (no Algolia writes; one per-record read fallback): each
+       content_key resolves to an ``IndexingDecision`` carrying one of four
+       outcomes — INDEXED / SKIPPED / REMOVED / FAILED — plus the new objects
+       and shard IDs needed for the writes. The only Algolia I/O here is
+       ``_existing_shard_ids``'s per-record browse fallback for records the
+       state row hasn't seen yet.
+    2. **Execute** (bulk-with-fallback): one ``save_objects_batch`` call across
+       every INDEXED decision's objects, then one ``delete_objects_batch`` for
+       every orphan + REMOVED shard. If either bulk call raises, we fall back
+       to per-record retries; per-record failures mutate the decision's
+       outcome to FAILED in place.
+    3. **Finalize** (state row updates): each decision's final outcome drives
+       the state-row stamp (``mark_as_indexed``, ``mark_as_removed``,
+       ``mark_as_failed``) and the counter increment.
 
-    * **REMOVE** — content is no longer indexable; existing Algolia shards are
-      deleted and the state row is marked ``removed_from_index_at``.
-    * **SKIP** — already indexed at the current ContentMetadata version
-      (``state.last_indexed_at >= content.modified``) and ``force=False``.
-    * **INDEX** — new objects are upserted, orphaned shards deleted, and the
-      state row is marked ``last_indexed_at``.
-
-    Returns a ``BatchResults`` with counts and the list of content_keys that
+    Returns a ``BatchSummary`` with counts and the list of content_keys that
     hit per-record failures. Task wrappers convert it to a dict via
     ``asdict()`` for Celery transport.
     """
-    results = BatchResults(content_type=content_type)
+    results = BatchSummary(content_type=content_type)
     if not content_keys:
         logger.info('No content_keys passed to index_%s_batch; returning empty result.', content_type)
         return results
@@ -186,13 +301,72 @@ def _index_content_batch(content_keys, content_type, index_name=None, force=Fals
         )
     }
 
-    # Generate all Algolia objects for the batch in one call. Filter the
-    # output by aggregation_key so we only act on shards belonging to keys
-    # in this batch — the legacy generator may "pull in" related content
-    # (e.g. courses inside a requested program) which we leave for that
-    # content's own batch to write. The legacy generator emits
-    # ``aggregation_key`` as ``"{content_type}:{content_key}"`` (e.g.
-    # ``"course:edX+DemoX"``), so we build the prefixed form here.
+    objects_by_content_key = _build_objects_by_content_key(
+        content_keys=content_keys, content_type=content_type, mappings=mappings,
+    )
+
+    algolia_client = get_initialized_algolia_client()
+
+    # --- Pass 1: resolve each content_key into an IndexingDecision ---------
+    decisions: list[IndexingDecision] = [
+        _resolve_indexing_decision(
+            content_key=content_key,
+            content=content_by_key.get(content_key),
+            content_type=content_type,
+            new_objects=objects_by_content_key.get(content_key, []),
+            indexable_keys=mappings.all_indexable_content_keys,
+            algolia_client=algolia_client,
+            index_name=index_name,
+            force=force,
+        )
+        for content_key in content_keys
+    ]
+
+    # --- Pass 2: bulk Algolia ops with per-record fallback ------------------
+    # Per-record fallbacks mutate decision.outcome to FAILED on retry failure,
+    # so pass 3 only needs to look at decision.outcome.
+    _execute_saves(decisions, algolia_client, index_name)
+    _execute_deletes(decisions, algolia_client, index_name)
+
+    # --- Pass 3: finalize state rows + counters -----------------------------
+    for decision in decisions:
+        try:
+            _finalize_decision(decision, results)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.exception(
+                'Finalize step raised for content_key=%s', decision.content_key,
+            )
+            if decision.content is not None:
+                _safely_mark_failed(decision.content, exc)
+            results.record_failure(decision.content_key)
+
+    logger.info(
+        'index_%s_batch complete: indexed=%d skipped=%d removed=%d failed=%d',
+        content_type,
+        results.indexed,
+        results.skipped,
+        results.removed,
+        results.failed,
+    )
+    return results
+
+
+def _build_objects_by_content_key(
+    content_keys: list[str],
+    content_type: str,
+    mappings: IndexingMappings,
+) -> dict[str, list[dict]]:
+    """
+    Generate Algolia objects for the batch in one call to the legacy generator
+    and bucket them by content_key.
+
+    Filter the generator output by aggregation_key so we only act on shards
+    belonging to keys in this batch — the generator may "pull in" related
+    content (e.g. courses inside a requested program) which we leave for that
+    content's own batch to write. The generator emits ``aggregation_key`` as
+    ``"{content_type}:{content_key}"``, so we build the same prefixed form
+    here.
+    """
     objects_by_content_key = defaultdict(list)
     legacy_objects = _get_algolia_products_for_batch(
         batch_num=0,
@@ -213,46 +387,7 @@ def _index_content_batch(content_keys, content_type, index_name=None, force=Fals
         agg_key = obj.get('aggregation_key')
         if agg_key in aggregation_key_to_content_key:
             objects_by_content_key[aggregation_key_to_content_key[agg_key]].append(obj)
-
-    algolia_client = get_initialized_algolia_client()
-
-    for content_key in content_keys:
-        content = content_by_key.get(content_key)
-        if content is None:
-            logger.warning(
-                'ContentMetadata not found for content_key=%s (content_type=%s); marking as failed.',
-                content_key, content_type,
-            )
-            results.record_failure(content_key)
-            continue
-
-        try:
-            outcome = _process_content_key(
-                content,
-                content_type=content_type,
-                new_objects=objects_by_content_key.get(content_key, []),
-                indexable_keys=mappings.all_indexable_content_keys,
-                algolia_client=algolia_client,
-                index_name=index_name,
-                force=force,
-            )
-            results.increment(outcome)
-        except Exception as exc:  # pylint: disable=broad-except
-            logger.exception(
-                'Per-record indexing failed for content_key=%s', content_key,
-            )
-            _safely_mark_failed(content, exc)
-            results.record_failure(content_key)
-
-    logger.info(
-        'index_%s_batch complete: indexed=%d skipped=%d removed=%d failed=%d',
-        content_type,
-        results.indexed,
-        results.skipped,
-        results.removed,
-        results.failed,
-    )
-    return results
+    return objects_by_content_key
 
 
 def _aggregation_key_for(content_type, content_key):
@@ -265,70 +400,216 @@ def _aggregation_key_for(content_type, content_key):
     return f'{content_type}:{content_key}'
 
 
-def _process_content_key(
-    content, content_type, new_objects, indexable_keys, algolia_client, index_name, force,
-):
+def _existing_shard_ids(state, aggregation_key, algolia_client, index_name):
     """
-    Resolve a single content_key to one of ``BatchOutcome.REMOVED``,
-    ``BatchOutcome.SKIPPED``, or ``BatchOutcome.INDEXED``. The caller increments
-    the matching counter in the batch results dict.
+    Return the Algolia shard objectIDs Algolia is hosting for a content
+    record.
 
-    ``BatchOutcome.FAILED`` is never returned from here — exceptions raised
-    inside this function bubble up to ``_index_content_batch``, which records
-    the failure separately.
+    Prefer the state row's tracked IDs — it's the system of record for what
+    the previous run wrote, and trusting it eliminates one Algolia search op
+    per non-SKIP record. Fall back to a per-record Algolia browse only when
+    the row has no recorded IDs (first-time index, row reset, or shards
+    inherited from a legacy reindex). Until the legacy reindexer is retired,
+    this fallback is the only way to detect orphans on first contact.
     """
-    state, _ = ContentMetadataIndexingState.get_or_create_for_content(content)
-    content_key = content.content_key
-    aggregation_key = _aggregation_key_for(content_type, content_key)
-
-    if content_key not in indexable_keys:
-        # If the state row tracks shards, delete those. Otherwise (first time
-        # we've seen this record, or state row missing the IDs from a legacy
-        # reindex), fall back to querying Algolia by aggregation_key so we
-        # don't leave orphans behind.
-        ids_to_remove = state.algolia_object_ids or algolia_client.get_object_ids_for_aggregation_key(
-            aggregation_key, index_name=index_name,
-        )
-        if ids_to_remove:
-            algolia_client.delete_objects_batch(ids_to_remove, index_name=index_name)
-        state.mark_as_removed()
-        return BatchOutcome.REMOVED
-
-    if not force and state.last_indexed_at and state.last_indexed_at >= content.modified:
-        return BatchOutcome.SKIPPED
-
-    new_object_ids = [obj['objectID'] for obj in new_objects]
-    # Prefer the state row's tracked shard IDs over a browse round-trip — the
-    # state row is the system of record for what we wrote on the previous run,
-    # and trusting it eliminates one Algolia search op per non-SKIP record.
-    # Fall back to a browse only when state is empty (first index for this
-    # content, row was reset, etc.) so we still detect orphans in that case.
-    existing_object_ids = state.algolia_object_ids or algolia_client.get_object_ids_for_aggregation_key(
+    if state.algolia_object_ids:
+        return state.algolia_object_ids
+    return algolia_client.get_object_ids_for_aggregation_key(
         aggregation_key, index_name=index_name,
     )
 
-    if not new_objects:
-        # Indexable per the partition fn, but the legacy generator emitted
-        # zero shards (e.g. catalog memberships were dropped without
-        # ``ContentMetadata.modified`` advancing). Treat as REMOVED so the
-        # row reflects reality and the next run can resurrect it cleanly
-        # when memberships return.
+
+def _resolve_indexing_decision(
+    content_key: str,
+    content: ContentMetadata | None,
+    content_type: str,
+    new_objects: list[dict],
+    indexable_keys: set[str],
+    algolia_client: AlgoliaSearchClient,
+    index_name: str | None,
+    force: bool,
+) -> IndexingDecision:
+    """
+    Decide whether this content should be indexed, skipped, removed, or
+    marked failed, and return that plan. No Algolia writes happen here;
+    later passes act on it. A single Algolia read may occur the first
+    time we see a record, to discover existing shards that need cleanup.
+
+    ``content=None`` means the upstream DB lookup turned up no
+    ``ContentMetadata`` row for this key — that's resolved here as FAILED,
+    not in the caller.
+    """
+    if content is None:
         logger.warning(
-            'Indexable %s %r produced zero Algolia objects; treating as REMOVED.',
-            content_type, content_key,
+            'ContentMetadata not found for content_key=%s (content_type=%s); marking as failed.',
+            content_key, content_type,
         )
-        if existing_object_ids:
-            algolia_client.delete_objects_batch(existing_object_ids, index_name=index_name)
-        state.mark_as_removed()
-        return BatchOutcome.REMOVED
+        return IndexingDecision.failed(
+            content_key=content_key,
+            failure_reason=ValueError(
+                f'ContentMetadata not found for content_key={content_key}',
+            ),
+        )
 
-    orphan_ids = set(existing_object_ids) - set(new_object_ids)
-    algolia_client.save_objects_batch(new_objects, index_name=index_name)
-    if orphan_ids:
-        algolia_client.delete_objects_batch(list(orphan_ids), index_name=index_name)
+    try:
+        state, _ = ContentMetadataIndexingState.get_or_create_for_content(content)
+        aggregation_key = _aggregation_key_for(content_type, content_key)
 
-    state.mark_as_indexed(algolia_object_ids=new_object_ids)
-    return BatchOutcome.INDEXED
+        if content_key not in indexable_keys:
+            return IndexingDecision.removed(
+                content_key=content_key, content=content, state=state,
+                ids_to_delete=_existing_shard_ids(
+                    state, aggregation_key, algolia_client, index_name,
+                ),
+            )
+
+        if not force and state.last_indexed_at and state.last_indexed_at >= content.modified:
+            return IndexingDecision.skipped(
+                content_key=content_key, content=content, state=state,
+            )
+
+        if not new_objects:
+            # Indexable per the partition fn, but the legacy generator emitted
+            # zero shards (e.g. catalog memberships dropped without
+            # ``ContentMetadata.modified`` advancing). Treat as REMOVED so
+            # the row reflects reality and the next run can resurrect it
+            # cleanly when memberships return.
+            logger.warning(
+                'Indexable %s %r produced zero Algolia objects; treating as REMOVED.',
+                content_type, content_key,
+            )
+            return IndexingDecision.removed(
+                content_key=content_key, content=content, state=state,
+                ids_to_delete=_existing_shard_ids(
+                    state, aggregation_key, algolia_client, index_name,
+                ),
+            )
+
+        new_object_ids = [obj['objectID'] for obj in new_objects]
+        orphan_ids = list(
+            set(_existing_shard_ids(state, aggregation_key, algolia_client, index_name))
+            - set(new_object_ids)
+        )
+        return IndexingDecision.indexed(
+            content_key=content_key, content=content, state=state,
+            new_objects=new_objects,
+            new_object_ids=new_object_ids,
+            ids_to_delete=orphan_ids,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.exception(
+            'Resolving indexing decision failed for content_key=%s', content_key,
+        )
+        return IndexingDecision.failed(
+            content_key=content_key, content=content, failure_reason=exc,
+        )
+
+
+def _execute_saves(decisions, algolia_client, index_name):
+    """
+    Issue one bulk ``save_objects_batch`` for every INDEXED decision's
+    objects. On ``AlgoliaException``, fall back to per-record save —
+    per-record failures mutate the decision's outcome to FAILED in place.
+    """
+    indexed_decisions = [
+        d for d in decisions
+        if d.outcome == RecordOutcome.INDEXED
+    ]
+    if not indexed_decisions:
+        return
+
+    all_objects = [obj for decision in indexed_decisions for obj in decision.new_objects]
+    try:
+        algolia_client.save_objects_batch(all_objects, index_name=index_name)
+    except AlgoliaException:
+        logger.exception(
+            'Bulk save_objects_batch raised for %d records; falling back to per-record saves.',
+            len(indexed_decisions),
+        )
+        _per_record_save_fallback(indexed_decisions, algolia_client, index_name)
+
+
+def _per_record_save_fallback(decisions, algolia_client, index_name):
+    """
+    Retry each decision's save individually. On per-record failure, mutate
+    the decision's outcome to FAILED so pass 3 dispatches via the FAILED
+    branch.
+    """
+    for decision in decisions:
+        try:
+            algolia_client.save_objects_batch(decision.new_objects, index_name=index_name)
+        except AlgoliaException as exc:
+            logger.exception(
+                'Per-record save fallback failed for content_key=%s', decision.content_key,
+            )
+            decision.outcome = RecordOutcome.FAILED
+            decision.failure_reason = exc
+
+
+def _execute_deletes(decisions, algolia_client, index_name):
+    """
+    Issue one bulk ``delete_objects_batch`` for every orphan + REMOVED shard
+    across the batch. Decisions whose save fallback failed have already been
+    mutated to FAILED, so the outcome filter excludes them — their old shards
+    stay in place as the partial-failure fallback.
+
+    On ``AlgoliaException``, fall back to per-record deletes; per-record
+    failures mutate the decision's outcome to FAILED in place.
+    """
+    delete_decisions = [
+        decision for decision in decisions
+        if decision.outcome in (RecordOutcome.INDEXED, RecordOutcome.REMOVED)
+        and decision.ids_to_delete
+    ]
+    if not delete_decisions:
+        return
+
+    all_ids = [obj_id for decision in delete_decisions for obj_id in decision.ids_to_delete]
+    try:
+        algolia_client.delete_objects_batch(all_ids, index_name=index_name)
+    except AlgoliaException:
+        logger.exception(
+            'Bulk delete_objects_batch raised for %d records; falling back to per-record deletes.',
+            len(delete_decisions),
+        )
+        _per_record_delete_fallback(delete_decisions, algolia_client, index_name)
+
+
+def _per_record_delete_fallback(decisions, algolia_client, index_name):
+    """
+    Retry each decision's delete individually. On per-record failure, mutate
+    the decision's outcome to FAILED.
+    """
+    for decision in decisions:
+        try:
+            algolia_client.delete_objects_batch(decision.ids_to_delete, index_name=index_name)
+        except AlgoliaException as exc:
+            logger.exception(
+                'Per-record delete fallback failed for content_key=%s', decision.content_key,
+            )
+            decision.outcome = RecordOutcome.FAILED
+            decision.failure_reason = exc
+
+
+def _finalize_decision(decision, results):
+    """
+    Apply the decision's final outcome to the state row and bump the matching
+    counter. ``decision.outcome`` already accounts for any per-record fallback
+    failures (the fallback paths mutate it to FAILED), so this is a pure
+    dispatch on the outcome.
+    """
+    if decision.outcome == RecordOutcome.FAILED:
+        if decision.content is not None:
+            _safely_mark_failed(decision.content, decision.failure_reason)
+        results.record_failure(decision.content_key)
+    elif decision.outcome == RecordOutcome.SKIPPED:
+        results.increment(RecordOutcome.SKIPPED)
+    elif decision.outcome == RecordOutcome.REMOVED:
+        decision.state.mark_as_removed()
+        results.increment(RecordOutcome.REMOVED)
+    elif decision.outcome == RecordOutcome.INDEXED:
+        decision.state.mark_as_indexed(algolia_object_ids=decision.new_object_ids)
+        results.increment(RecordOutcome.INDEXED)
 
 
 def _safely_mark_failed(content, exc):

--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -184,17 +184,23 @@ class IndexingDecision:
     ``_execute_saves`` / ``_execute_deletes`` in pass 2, then applied to the
     state row + counters in pass 3 by ``_finalize_decision``.
 
-    A decision is mutable in exactly one way: if a per-record fallback in
-    pass 2 raises, the fallback sets ``outcome = RecordOutcome.FAILED`` and
-    populates ``failure_reason`` on this same instance. That makes
-    ``decision.outcome`` the single source of truth in pass 3 — no separate
-    failure-set parameters need to be threaded through.
+    Each decision carries two outcome fields:
+
+    * ``desired_outcome`` (immutable) — what pass 1's resolution determined
+      *should* happen for this record (INDEXED / SKIPPED / REMOVED / FAILED).
+    * ``outcome`` (mutable, mirrors ``desired_outcome`` until pass 2 runs) —
+      what *actually* happened after the Algolia writes. The per-record
+      fallback paths set ``outcome = FAILED`` and populate ``failure_reason``
+      when a save or delete retry raises. Pass 3 dispatches on ``outcome``.
+
+    The split keeps pass 1's plan auditable after pass 2 has rewritten the
+    fate of some records.
 
     Always construct via the ``skipped`` / ``removed`` / ``indexed`` /
     ``failed`` classmethods rather than the raw constructor; each enforces
-    the field invariants for its outcome.
+    the field invariants for its desired outcome.
 
-    Invariants by outcome:
+    Invariants by desired_outcome:
 
     * INDEXED — ``new_objects`` non-empty, ``new_object_ids`` matches their
       ``objectID`` (in order), ``ids_to_delete`` is the set of orphans (may
@@ -203,12 +209,13 @@ class IndexingDecision:
       is the set of shards Algolia is hosting for this content (may be
       empty).
     * SKIPPED — nothing to do; all lists empty.
-    * FAILED — planning failed, OR a per-record fallback in pass 2 raised.
-      ``content`` and ``state`` may be ``None`` (e.g. when ``ContentMetadata``
-      is missing); ``failure_reason`` carries the exception.
+    * FAILED — planning failed (e.g. missing ``ContentMetadata``).
+      ``content`` and ``state`` may be ``None``; ``failure_reason`` carries
+      the exception.
     """
     content_key: str
-    outcome: RecordOutcome
+    desired_outcome: RecordOutcome
+    outcome: RecordOutcome = None
     content: ContentMetadata = None
     state: ContentMetadataIndexingState = None
     new_objects: list = field(default_factory=list)
@@ -216,11 +223,16 @@ class IndexingDecision:
     ids_to_delete: list = field(default_factory=list)
     failure_reason: Exception = None
 
+    def __post_init__(self):
+        # ``outcome`` mirrors ``desired_outcome`` until pass 2 overrides it.
+        if self.outcome is None:
+            self.outcome = self.desired_outcome
+
     @classmethod
     def skipped(cls, *, content_key, content, state):
         """``state.last_indexed_at`` is current and ``force=False``."""
         return cls(
-            content_key=content_key, outcome=RecordOutcome.SKIPPED,
+            content_key=content_key, desired_outcome=RecordOutcome.SKIPPED,
             content=content, state=state,
         )
 
@@ -232,7 +244,7 @@ class IndexingDecision:
         ``ids_to_delete`` is whatever Algolia is currently hosting for it.
         """
         return cls(
-            content_key=content_key, outcome=RecordOutcome.REMOVED,
+            content_key=content_key, desired_outcome=RecordOutcome.REMOVED,
             content=content, state=state, ids_to_delete=list(ids_to_delete),
         )
 
@@ -243,7 +255,7 @@ class IndexingDecision:
         previous run wrote but this run no longer needs.
         """
         return cls(
-            content_key=content_key, outcome=RecordOutcome.INDEXED,
+            content_key=content_key, desired_outcome=RecordOutcome.INDEXED,
             content=content, state=state,
             new_objects=new_objects, new_object_ids=new_object_ids,
             ids_to_delete=list(ids_to_delete),
@@ -252,13 +264,12 @@ class IndexingDecision:
     @classmethod
     def failed(cls, *, content_key, content=None, state=None, failure_reason):
         """
-        Pass 1 couldn't produce a real plan (e.g. missing ``ContentMetadata``)
-        or pass 2's per-record fallback raised. Pass 3 will best-effort stamp
-        the state row via ``mark_as_failed`` if both ``content`` and ``state``
-        are available.
+        Pass 1 couldn't produce a real plan (e.g. missing ``ContentMetadata``).
+        Pass 3 will best-effort stamp the state row via ``mark_as_failed`` if
+        ``content`` is available.
         """
         return cls(
-            content_key=content_key, outcome=RecordOutcome.FAILED,
+            content_key=content_key, desired_outcome=RecordOutcome.FAILED,
             content=content, state=state, failure_reason=failure_reason,
         )
 
@@ -275,11 +286,11 @@ def _index_content_batch(content_keys, content_type, index_name=None, force=Fals
        ``_existing_shard_ids``'s per-record browse fallback for records the
        state row hasn't seen yet.
     2. **Execute** (bulk-with-fallback): one ``save_objects_batch`` call across
-       every INDEXED decision's objects, then one ``delete_objects_batch`` for
-       every orphan + REMOVED shard. If either bulk call raises, we fall back
-       to per-record retries; per-record failures mutate the decision's
-       outcome to FAILED in place.
-    3. **Finalize** (state row updates): each decision's final outcome drives
+       every decision with ``desired_outcome=INDEXED``, then one
+       ``delete_objects_batch`` for every orphan + REMOVED shard. If either
+       bulk call raises, we fall back to per-record retries; per-record
+       failures mutate the decision's ``outcome`` to FAILED in place.
+    3. **Finalize** (state row updates): each decision's actual outcome drives
        the state-row stamp (``mark_as_indexed``, ``mark_as_removed``,
        ``mark_as_failed``) and the counter increment.
 
@@ -329,15 +340,18 @@ def _index_content_batch(content_keys, content_type, index_name=None, force=Fals
     _execute_deletes(decisions, algolia_client, index_name)
 
     # --- Pass 3: finalize state rows + counters -----------------------------
+    # Wrap per-decision so a DB hiccup in one record's ``mark_as_*`` doesn't
+    # abort the rest of the batch. The failure is recorded in the summary; we
+    # don't attempt a recovery ``mark_as_failed`` write here since that path
+    # could itself raise — the next run sees ``last_indexed_at`` unchanged and
+    # re-indexes idempotently.
     for decision in decisions:
         try:
             _finalize_decision(decision, results)
-        except Exception as exc:  # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             logger.exception(
                 'Finalize step raised for content_key=%s', decision.content_key,
             )
-            if decision.content is not None:
-                _safely_mark_failed(decision.content, exc)
             results.record_failure(decision.content_key)
 
     logger.info(
@@ -507,13 +521,13 @@ def _resolve_indexing_decision(
 
 def _execute_saves(decisions, algolia_client, index_name):
     """
-    Issue one bulk ``save_objects_batch`` for every INDEXED decision's
-    objects. On ``AlgoliaException``, fall back to per-record save —
-    per-record failures mutate the decision's outcome to FAILED in place.
+    Issue one bulk ``save_objects_batch`` for every decision whose
+    desired_outcome is INDEXED. On ``AlgoliaException``, fall back to per-record
+    save — per-record failures mutate the decision's actual outcome to FAILED.
     """
     indexed_decisions = [
         d for d in decisions
-        if d.outcome == RecordOutcome.INDEXED
+        if d.desired_outcome == RecordOutcome.INDEXED
     ]
     if not indexed_decisions:
         return
@@ -594,13 +608,19 @@ def _per_record_delete_fallback(decisions, algolia_client, index_name):
 def _finalize_decision(decision, results):
     """
     Apply the decision's final outcome to the state row and bump the matching
-    counter. ``decision.outcome`` already accounts for any per-record fallback
-    failures (the fallback paths mutate it to FAILED), so this is a pure
-    dispatch on the outcome.
+    counter. ``decision.outcome`` reflects what actually happened after pass 2
+    (a save or delete fallback may have moved a desired-INDEXED record to
+    FAILED), so this is a pure dispatch on the actual outcome.
+
+    Any exception raised here (e.g. a DB error from ``mark_as_*``) propagates
+    to the caller, which catches it per-record so siblings still finalize.
     """
     if decision.outcome == RecordOutcome.FAILED:
         if decision.content is not None:
-            _safely_mark_failed(decision.content, decision.failure_reason)
+            state = decision.state or ContentMetadataIndexingState.get_or_create_for_content(
+                decision.content,
+            )[0]
+            state.mark_as_failed(reason=decision.failure_reason)
         results.record_failure(decision.content_key)
     elif decision.outcome == RecordOutcome.SKIPPED:
         results.increment(RecordOutcome.SKIPPED)
@@ -610,19 +630,3 @@ def _finalize_decision(decision, results):
     elif decision.outcome == RecordOutcome.INDEXED:
         decision.state.mark_as_indexed(algolia_object_ids=decision.new_object_ids)
         results.increment(RecordOutcome.INDEXED)
-
-
-def _safely_mark_failed(content, exc):
-    """
-    Record a per-record failure on the state row, swallowing any exception
-    raised by ``mark_as_failed`` itself — we never want the failure-recording
-    path to take down the whole batch.
-    """
-    try:
-        state, _ = ContentMetadataIndexingState.get_or_create_for_content(content)
-        state.mark_as_failed(reason=exc)
-    except Exception:  # pylint: disable=broad-except
-        logger.exception(
-            'mark_as_failed itself raised for content_key=%s; original error was %r',
-            content.content_key, exc,
-        )

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -22,8 +22,9 @@ from enterprise_catalog.apps.search import tasks as search_tasks
 from enterprise_catalog.apps.search.indexing_mappings import IndexingMappings
 from enterprise_catalog.apps.search.models import ContentMetadataIndexingState
 from enterprise_catalog.apps.search.tasks import (
-    BatchOutcome,
-    BatchResults,
+    BatchSummary,
+    IndexingDecision,
+    RecordOutcome,
     _index_content_batch,
     index_courses_batch_in_algolia,
     index_pathways_batch_in_algolia,
@@ -94,8 +95,9 @@ class TestIndexContentBatch(TestCase):
 
     def test_happy_path_indexes_all_records(self):
         """
-        Three indexable, never-indexed courses → all three indexed; save +
-        mark_as_indexed called per record.
+        Three indexable, never-indexed courses → all three indexed via a
+        single bulk ``save_objects_batch`` call carrying every shard, then
+        each row's ``mark_as_indexed`` runs in pass 3.
         """
         c1 = ContentMetadataFactory(content_type=COURSE, content_key='course-A')
         c2 = ContentMetadataFactory(content_type=COURSE, content_key='course-B')
@@ -115,7 +117,13 @@ class TestIndexContentBatch(TestCase):
         self.assertEqual(result.skipped, 0)
         self.assertEqual(result.removed, 0)
         self.assertEqual(result.failed, 0)
-        self.assertEqual(self.algolia_client.save_objects_batch.call_count, 3)
+        # One bulk save across all three records, not one per record.
+        self.assertEqual(self.algolia_client.save_objects_batch.call_count, 1)
+        bulk_objects = self.algolia_client.save_objects_batch.call_args.args[0]
+        self.assertEqual(
+            {obj['objectID'] for obj in bulk_objects},
+            {f'{c.content_key}-catalog-query-uuids-0' for c in (c1, c2, c3)},
+        )
         for content in (c1, c2, c3):
             state = ContentMetadataIndexingState.objects.get(content_metadata=content)
             self.assertIsNotNone(state.last_indexed_at)
@@ -320,10 +328,11 @@ class TestIndexContentBatch(TestCase):
 
     # --- Failure handling ----------------------------------------------
 
-    def test_per_record_algolia_failure_marks_failed_and_continues(self):
+    def test_bulk_save_failure_falls_back_to_per_record_and_isolates_one_failure(self):
         """
-        AlgoliaException on save for one record → that record marked failed,
-        the other records still index successfully.
+        Bulk save raises ``AlgoliaException`` → the task falls back to
+        per-record save calls. The bad record's per-record retry still
+        raises; the two good ones succeed. Final state: 2 INDEXED, 1 FAILED.
         """
         c1 = ContentMetadataFactory(content_type=COURSE, content_key='course-ok-1')
         c2 = ContentMetadataFactory(content_type=COURSE, content_key='course-bad')
@@ -335,22 +344,159 @@ class TestIndexContentBatch(TestCase):
             _algolia_object(c3.content_key),
         ]
 
-        # Fail on the bad key only.
+        # First call (bulk across all 3 records) raises; subsequent per-record
+        # calls only raise for the bad key.
+        bulk_call_seen = {'count': 0}
+
         def save_side_effect(objects, index_name=None):  # pylint: disable=unused-argument
-            if objects[0]['aggregation_key'] == f'course:{c2.content_key}':
-                raise AlgoliaException('boom')
+            bulk_call_seen['count'] += 1
+            if bulk_call_seen['count'] == 1:
+                raise AlgoliaException('bulk boom')
+            if any(obj['aggregation_key'] == f'course:{c2.content_key}' for obj in objects):
+                raise AlgoliaException('per-record boom')
+
         self.algolia_client.save_objects_batch.side_effect = save_side_effect
 
         result = _index_content_batch(
             [c1.content_key, c2.content_key, c3.content_key], COURSE,
         )
 
+        # 1 bulk + 3 per-record retries = 4 calls
+        self.assertEqual(self.algolia_client.save_objects_batch.call_count, 4)
         self.assertEqual(result.indexed, 2)
         self.assertEqual(result.failed, 1)
         self.assertEqual(result.failed_keys, [c2.content_key])
         bad_state = ContentMetadataIndexingState.objects.get(content_metadata=c2)
         self.assertIsNotNone(bad_state.last_failure_at)
-        self.assertIn('boom', bad_state.failure_reason)
+        self.assertIn('per-record boom', bad_state.failure_reason)
+        # Good records were still marked indexed via the per-record fallback.
+        for good_content in (c1, c3):
+            good_state = ContentMetadataIndexingState.objects.get(content_metadata=good_content)
+            self.assertIsNotNone(good_state.last_indexed_at)
+
+    def test_bulk_save_succeeds_no_fallback(self):
+        """
+        Bulk save succeeds → no per-record fallback calls; one ``save_objects_batch``
+        call total.
+        """
+        c1 = ContentMetadataFactory(content_type=COURSE, content_key='course-A')
+        c2 = ContentMetadataFactory(content_type=COURSE, content_key='course-B')
+        self._set_indexable(c1.content_key, c2.content_key)
+        self.mock_get_products.return_value = [
+            _algolia_object(c1.content_key),
+            _algolia_object(c2.content_key),
+        ]
+
+        _index_content_batch([c1.content_key, c2.content_key], COURSE)
+
+        self.assertEqual(self.algolia_client.save_objects_batch.call_count, 1)
+
+    def test_per_record_save_failure_skips_orphan_delete_for_that_record(self):
+        """
+        When a record's bulk-save fallback fails, that record's orphan delete
+        is skipped (its old shards stay in place as the partial-failure
+        fallback). Other records' orphans are still bulk-deleted.
+        """
+        # Two records, both have existing shards being shrunk to one new shard.
+        c_bad = ContentMetadataFactory(content_type=COURSE, content_key='course-save-fail')
+        c_good = ContentMetadataFactory(content_type=COURSE, content_key='course-save-ok')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=c_bad,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+            algolia_object_ids=[
+                f'{c_bad.content_key}-catalog-query-uuids-0',
+                f'{c_bad.content_key}-catalog-query-uuids-1',
+            ],
+        )
+        ContentMetadataIndexingStateFactory(
+            content_metadata=c_good,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+            algolia_object_ids=[
+                f'{c_good.content_key}-catalog-query-uuids-0',
+                f'{c_good.content_key}-catalog-query-uuids-1',
+            ],
+        )
+        self._set_indexable(c_bad.content_key, c_good.content_key)
+        self.mock_get_products.return_value = [
+            _algolia_object(c_bad.content_key, shard_index=0),
+            _algolia_object(c_good.content_key, shard_index=0),
+        ]
+
+        # Bulk save raises, then bad record's per-record retry also raises.
+        save_calls = {'count': 0}
+
+        def save_side_effect(objects, index_name=None):  # pylint: disable=unused-argument
+            save_calls['count'] += 1
+            if save_calls['count'] == 1:
+                raise AlgoliaException('bulk boom')
+            if any(obj['aggregation_key'] == f'course:{c_bad.content_key}' for obj in objects):
+                raise AlgoliaException('per-record boom')
+
+        self.algolia_client.save_objects_batch.side_effect = save_side_effect
+
+        result = _index_content_batch(
+            [c_bad.content_key, c_good.content_key], COURSE,
+        )
+
+        self.assertEqual(result.indexed, 1)
+        self.assertEqual(result.failed, 1)
+        # Exactly one bulk delete call, carrying only the good record's orphan.
+        self.assertEqual(self.algolia_client.delete_objects_batch.call_count, 1)
+        deleted = self.algolia_client.delete_objects_batch.call_args.args[0]
+        self.assertEqual(set(deleted), {f'{c_good.content_key}-catalog-query-uuids-1'})
+
+    def test_bulk_delete_failure_falls_back_to_per_record(self):
+        """
+        Bulk delete raises → per-record delete fallback runs. A record whose
+        delete fails individually is marked FAILED even though its save
+        succeeded.
+        """
+        c1 = ContentMetadataFactory(content_type=COURSE, content_key='course-delete-bad')
+        c2 = ContentMetadataFactory(content_type=COURSE, content_key='course-delete-ok')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=c1,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+            algolia_object_ids=[
+                f'{c1.content_key}-catalog-query-uuids-0',
+                f'{c1.content_key}-catalog-query-uuids-1',
+            ],
+        )
+        ContentMetadataIndexingStateFactory(
+            content_metadata=c2,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+            algolia_object_ids=[
+                f'{c2.content_key}-catalog-query-uuids-0',
+                f'{c2.content_key}-catalog-query-uuids-1',
+            ],
+        )
+        self._set_indexable(c1.content_key, c2.content_key)
+        self.mock_get_products.return_value = [
+            _algolia_object(c1.content_key, shard_index=0),
+            _algolia_object(c2.content_key, shard_index=0),
+        ]
+
+        delete_calls = {'count': 0}
+
+        def delete_side_effect(ids, index_name=None):  # pylint: disable=unused-argument
+            delete_calls['count'] += 1
+            if delete_calls['count'] == 1:
+                raise AlgoliaException('bulk delete boom')
+            if f'{c1.content_key}-catalog-query-uuids-1' in ids:
+                raise AlgoliaException('per-record delete boom')
+
+        self.algolia_client.delete_objects_batch.side_effect = delete_side_effect
+
+        result = _index_content_batch(
+            [c1.content_key, c2.content_key], COURSE,
+        )
+
+        # 1 bulk + 2 per-record retries
+        self.assertEqual(self.algolia_client.delete_objects_batch.call_count, 3)
+        self.assertEqual(result.indexed, 1)
+        self.assertEqual(result.failed, 1)
+        self.assertEqual(result.failed_keys, [c1.content_key])
+        bad_state = ContentMetadataIndexingState.objects.get(content_metadata=c1)
+        self.assertIsNotNone(bad_state.last_failure_at)
 
     def test_missing_content_metadata_counts_as_failed(self):
         """
@@ -361,6 +507,92 @@ class TestIndexContentBatch(TestCase):
         result = _index_content_batch(['course-missing'], COURSE)
         self.assertEqual(result.failed, 1)
         self.assertEqual(result.failed_keys, ['course-missing'])
+
+    def test_indexed_record_orphan_delete_failure_mutates_outcome_to_failed(self):
+        """
+        A single record's save succeeds but its orphan delete fails (both
+        bulk and per-record retry). The decision is mutated from INDEXED to
+        FAILED, the state row carries the failure stamp, and the
+        already-written new shards stay in Algolia (the next run will detect
+        them via the state row's old IDs and clean up the orphan).
+
+        Pinned in isolation rather than only via the multi-record bulk-delete
+        test, so the INDEXED-to-FAILED mutation contract is explicit.
+        """
+        content = ContentMetadataFactory(content_type=COURSE, content_key='course-orphan-fail')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=content,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+            algolia_object_ids=[
+                f'{content.content_key}-catalog-query-uuids-0',
+                f'{content.content_key}-catalog-query-uuids-1',  # becomes the orphan
+            ],
+        )
+        self._set_indexable(content.content_key)
+        self.mock_get_products.return_value = [
+            _algolia_object(content.content_key, shard_index=0),
+        ]
+
+        # Save succeeds; every delete attempt (bulk + per-record retry) fails.
+        self.algolia_client.delete_objects_batch.side_effect = AlgoliaException('delete boom')
+
+        result = _index_content_batch([content.content_key], COURSE)
+
+        self.assertEqual(result.indexed, 0)
+        self.assertEqual(result.failed, 1)
+        self.assertEqual(result.failed_keys, [content.content_key])
+        # 1 bulk save (succeeded), no per-record save retry (no save failure).
+        self.algolia_client.save_objects_batch.assert_called_once()
+        # 1 bulk delete (raised) + 1 per-record retry (also raised).
+        self.assertEqual(self.algolia_client.delete_objects_batch.call_count, 2)
+        # State row reflects the failure stamp; mark_as_indexed was not called.
+        state = ContentMetadataIndexingState.objects.get(content_metadata=content)
+        self.assertIsNotNone(state.last_failure_at)
+        self.assertIn('delete boom', state.failure_reason)
+
+    def test_finalize_step_failure_isolated_to_offending_record(self):
+        """
+        If pass 3's state-row update raises (e.g. DB hiccup in
+        ``mark_as_indexed``), the failure is recorded against that one record
+        and the rest of the batch still finalizes. Pinned because pass 3 is
+        the only loop where a single record's exception can fan out and abort
+        siblings if it's not wrapped per-iteration.
+        """
+        c_ok = ContentMetadataFactory(content_type=COURSE, content_key='course-ok')
+        c_explode = ContentMetadataFactory(content_type=COURSE, content_key='course-explode')
+        self._set_indexable(c_ok.content_key, c_explode.content_key)
+        self.mock_get_products.return_value = [
+            _algolia_object(c_ok.content_key),
+            _algolia_object(c_explode.content_key),
+        ]
+
+        original_mark_as_indexed = ContentMetadataIndexingState.mark_as_indexed
+
+        def mark_as_indexed_side_effect(self, *args, **kwargs):
+            if self.content_metadata.content_key == c_explode.content_key:
+                raise RuntimeError('db boom')
+            return original_mark_as_indexed(self, *args, **kwargs)
+
+        with mock.patch.object(
+            ContentMetadataIndexingState,
+            'mark_as_indexed',
+            autospec=True,
+            side_effect=mark_as_indexed_side_effect,
+        ):
+            result = _index_content_batch(
+                [c_ok.content_key, c_explode.content_key], COURSE,
+            )
+
+        self.assertEqual(result.indexed, 1)
+        self.assertEqual(result.failed, 1)
+        self.assertEqual(result.failed_keys, [c_explode.content_key])
+        # Sibling still finalized cleanly.
+        ok_state = ContentMetadataIndexingState.objects.get(content_metadata=c_ok)
+        self.assertIsNotNone(ok_state.last_indexed_at)
+        # Offending record carries the failure stamp.
+        explode_state = ContentMetadataIndexingState.objects.get(content_metadata=c_explode)
+        self.assertIsNotNone(explode_state.last_failure_at)
+        self.assertIn('db boom', explode_state.failure_reason)
 
     # --- Plumbing ------------------------------------------------------
 
@@ -417,35 +649,35 @@ class TestIndexContentBatch(TestCase):
         self.assertEqual(result['indexed'], 1)
 
 
-class TestBatchOutcome(TestCase):
+class TestRecordOutcome(TestCase):
     """
-    Pinning tests for the ``BatchOutcome`` StrEnum.
+    Pinning tests for the ``RecordOutcome`` StrEnum.
     """
 
     def test_members_compare_equal_to_their_string_value(self):
-        self.assertEqual(BatchOutcome.INDEXED, 'indexed')
-        self.assertEqual(BatchOutcome.SKIPPED, 'skipped')
-        self.assertEqual(BatchOutcome.REMOVED, 'removed')
-        self.assertEqual(BatchOutcome.FAILED, 'failed')
+        self.assertEqual(RecordOutcome.INDEXED, 'indexed')
+        self.assertEqual(RecordOutcome.SKIPPED, 'skipped')
+        self.assertEqual(RecordOutcome.REMOVED, 'removed')
+        self.assertEqual(RecordOutcome.FAILED, 'failed')
 
 
-class TestBatchResults(TestCase):
+class TestBatchSummary(TestCase):
     """
-    Pinning tests for the ``BatchResults`` dataclass — the dispatch
+    Pinning tests for the ``BatchSummary`` dataclass — the dispatch
     helpers (``increment``, ``record_failure``) and the ``asdict()``
     conversion that the task wrappers rely on.
     """
 
     def test_increment_dispatches_via_outcome_member(self):
         """
-        ``BatchOutcome`` member values must match ``BatchResults`` attribute
+        ``RecordOutcome`` member values must match ``BatchSummary`` attribute
         names so ``setattr(results, outcome, ...)`` lands on the right field.
         """
-        results = BatchResults(content_type='course')
-        results.increment(BatchOutcome.INDEXED)
-        results.increment(BatchOutcome.INDEXED)
-        results.increment(BatchOutcome.SKIPPED)
-        results.increment(BatchOutcome.REMOVED)
+        results = BatchSummary(content_type='course')
+        results.increment(RecordOutcome.INDEXED)
+        results.increment(RecordOutcome.INDEXED)
+        results.increment(RecordOutcome.SKIPPED)
+        results.increment(RecordOutcome.REMOVED)
 
         self.assertEqual(results.indexed, 2)
         self.assertEqual(results.skipped, 1)
@@ -453,7 +685,7 @@ class TestBatchResults(TestCase):
         self.assertEqual(results.failed, 0)
 
     def test_record_failure_increments_counter_and_tracks_key(self):
-        results = BatchResults(content_type='course')
+        results = BatchSummary(content_type='course')
         results.record_failure('course-bad-1')
         results.record_failure('course-bad-2')
 
@@ -462,11 +694,11 @@ class TestBatchResults(TestCase):
 
     def test_asdict_produces_celery_safe_dict(self):
         """
-        Task wrappers convert ``BatchResults`` to a dict so the on-the-wire
+        Task wrappers convert ``BatchSummary`` to a dict so the on-the-wire
         Celery payload stays JSON-serializable.
         """
-        results = BatchResults(content_type='course')
-        results.increment(BatchOutcome.INDEXED)
+        results = BatchSummary(content_type='course')
+        results.increment(RecordOutcome.INDEXED)
         results.record_failure('course-bad')
 
         as_dict = asdict(results)
@@ -478,6 +710,54 @@ class TestBatchResults(TestCase):
             'failed': 1,
             'failed_keys': ['course-bad'],
         })
+
+
+class TestIndexingDecisionConstructors(TestCase):
+    """
+    The classmethod constructors are the public way to build an
+    ``IndexingDecision``; these pin the per-outcome field invariants so
+    callers can rely on them.
+    """
+
+    def test_skipped_carries_no_objects_or_ids(self):
+        decision = IndexingDecision.skipped(
+            content_key='c-1', content=mock.sentinel.content, state=mock.sentinel.state,
+        )
+        self.assertEqual(decision.outcome, RecordOutcome.SKIPPED)
+        self.assertEqual(decision.new_objects, [])
+        self.assertEqual(decision.new_object_ids, [])
+        self.assertEqual(decision.ids_to_delete, [])
+        self.assertIsNone(decision.failure_reason)
+
+    def test_removed_copies_ids_to_delete_into_a_list(self):
+        decision = IndexingDecision.removed(
+            content_key='c-1', content=mock.sentinel.content, state=mock.sentinel.state,
+            ids_to_delete=('id-0', 'id-1'),
+        )
+        self.assertEqual(decision.outcome, RecordOutcome.REMOVED)
+        self.assertEqual(decision.ids_to_delete, ['id-0', 'id-1'])
+        self.assertEqual(decision.new_objects, [])
+
+    def test_indexed_carries_objects_and_orphan_ids(self):
+        new_objects = [{'objectID': 'id-0'}, {'objectID': 'id-1'}]
+        decision = IndexingDecision.indexed(
+            content_key='c-1', content=mock.sentinel.content, state=mock.sentinel.state,
+            new_objects=new_objects,
+            new_object_ids=['id-0', 'id-1'],
+            ids_to_delete=['orphan-0'],
+        )
+        self.assertEqual(decision.outcome, RecordOutcome.INDEXED)
+        self.assertEqual(decision.new_objects, new_objects)
+        self.assertEqual(decision.new_object_ids, ['id-0', 'id-1'])
+        self.assertEqual(decision.ids_to_delete, ['orphan-0'])
+
+    def test_failed_allows_missing_content_and_state(self):
+        exc = ValueError('boom')
+        decision = IndexingDecision.failed(content_key='c-1', failure_reason=exc)
+        self.assertEqual(decision.outcome, RecordOutcome.FAILED)
+        self.assertIsNone(decision.content)
+        self.assertIsNone(decision.state)
+        self.assertIs(decision.failure_reason, exc)
 
 
 class TestSafelyMarkFailed(TestCase):

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -553,10 +553,14 @@ class TestIndexContentBatch(TestCase):
     def test_finalize_step_failure_isolated_to_offending_record(self):
         """
         If pass 3's state-row update raises (e.g. DB hiccup in
-        ``mark_as_indexed``), the failure is recorded against that one record
+        ``mark_as_indexed``), the failure is recorded in the batch summary
         and the rest of the batch still finalizes. Pinned because pass 3 is
         the only loop where a single record's exception can fan out and abort
         siblings if it's not wrapped per-iteration.
+
+        We do NOT try to recover by also calling ``mark_as_failed`` here —
+        that path could itself raise. The next run sees ``last_indexed_at``
+        unchanged on the offending record and re-indexes idempotently.
         """
         c_ok = ContentMetadataFactory(content_type=COURSE, content_key='course-ok')
         c_explode = ContentMetadataFactory(content_type=COURSE, content_key='course-explode')
@@ -589,10 +593,10 @@ class TestIndexContentBatch(TestCase):
         # Sibling still finalized cleanly.
         ok_state = ContentMetadataIndexingState.objects.get(content_metadata=c_ok)
         self.assertIsNotNone(ok_state.last_indexed_at)
-        # Offending record carries the failure stamp.
+        # Offending record's state row stays in its pre-finalize state — the
+        # next run re-indexes idempotently.
         explode_state = ContentMetadataIndexingState.objects.get(content_metadata=c_explode)
-        self.assertIsNotNone(explode_state.last_failure_at)
-        self.assertIn('db boom', explode_state.failure_reason)
+        self.assertIsNone(explode_state.last_indexed_at)
 
     # --- Plumbing ------------------------------------------------------
 
@@ -723,6 +727,7 @@ class TestIndexingDecisionConstructors(TestCase):
         decision = IndexingDecision.skipped(
             content_key='c-1', content=mock.sentinel.content, state=mock.sentinel.state,
         )
+        self.assertEqual(decision.desired_outcome, RecordOutcome.SKIPPED)
         self.assertEqual(decision.outcome, RecordOutcome.SKIPPED)
         self.assertEqual(decision.new_objects, [])
         self.assertEqual(decision.new_object_ids, [])
@@ -734,6 +739,7 @@ class TestIndexingDecisionConstructors(TestCase):
             content_key='c-1', content=mock.sentinel.content, state=mock.sentinel.state,
             ids_to_delete=('id-0', 'id-1'),
         )
+        self.assertEqual(decision.desired_outcome, RecordOutcome.REMOVED)
         self.assertEqual(decision.outcome, RecordOutcome.REMOVED)
         self.assertEqual(decision.ids_to_delete, ['id-0', 'id-1'])
         self.assertEqual(decision.new_objects, [])
@@ -746,6 +752,7 @@ class TestIndexingDecisionConstructors(TestCase):
             new_object_ids=['id-0', 'id-1'],
             ids_to_delete=['orphan-0'],
         )
+        self.assertEqual(decision.desired_outcome, RecordOutcome.INDEXED)
         self.assertEqual(decision.outcome, RecordOutcome.INDEXED)
         self.assertEqual(decision.new_objects, new_objects)
         self.assertEqual(decision.new_object_ids, ['id-0', 'id-1'])
@@ -754,28 +761,25 @@ class TestIndexingDecisionConstructors(TestCase):
     def test_failed_allows_missing_content_and_state(self):
         exc = ValueError('boom')
         decision = IndexingDecision.failed(content_key='c-1', failure_reason=exc)
+        self.assertEqual(decision.desired_outcome, RecordOutcome.FAILED)
         self.assertEqual(decision.outcome, RecordOutcome.FAILED)
         self.assertIsNone(decision.content)
         self.assertIsNone(decision.state)
         self.assertIs(decision.failure_reason, exc)
 
-
-class TestSafelyMarkFailed(TestCase):
-    """
-    The state-update path must not itself blow up the batch.
-    """
-    # pylint: disable=protected-access
-
-    def test_swallows_exceptions_from_mark_as_failed(self):
+    def test_per_record_save_failure_mutates_outcome_only_not_desired(self):
         """
-        If ``mark_as_failed`` raises, the helper logs and returns rather than
-        propagating — callers shouldn't have their batch failed by the
-        failure-recording path.
+        Pass 2's per-record save fallback updates ``outcome`` to FAILED but
+        leaves ``desired_outcome`` as INDEXED so the original plan stays
+        readable for debugging.
         """
-        content = ContentMetadataFactory(content_type=COURSE, content_key='course-explode')
-        with mock.patch.object(
-            ContentMetadataIndexingState, 'mark_as_failed',
-            side_effect=RuntimeError('db down'),
-        ):
-            # Should not raise.
-            search_tasks._safely_mark_failed(content, ValueError('original'))
+        decision = IndexingDecision.indexed(
+            content_key='c-1', content=mock.sentinel.content, state=mock.sentinel.state,
+            new_objects=[{'objectID': 'id-0'}],
+            new_object_ids=['id-0'],
+            ids_to_delete=[],
+        )
+        # Simulate the fallback mutation.
+        decision.outcome = RecordOutcome.FAILED
+        self.assertEqual(decision.desired_outcome, RecordOutcome.INDEXED)
+        self.assertEqual(decision.outcome, RecordOutcome.FAILED)

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -445,6 +445,15 @@ ALGOLIA = {
 # update_content_metadata run), so a 30-minute TTL is a safe default.
 ALGOLIA_INDEXING_MAPPINGS_CACHE_TIMEOUT = 60 * 30
 
+# How many Algolia objects we send per HTTP request when the incremental
+# indexing batch tasks call ``save_objects_batch`` / ``delete_objects_batch``.
+# The Algolia SDK auto-chunks at 1000; we chunk smaller to limit the blast
+# radius when a request fails (each chunk is an independently-failing unit
+# of work). 100 keeps requests small enough that a typical task batch
+# fits in 1-2 HTTP calls but a partial failure only loses one chunk's
+# worth of work to the per-record fallback path.
+ALGOLIA_INDEXING_CHUNK_SIZE = 100
+
 # Which fields should be plucked from the /search/all course-discovery API
 # response in `update_catalog_metadata_task` for course content metadata?
 COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL = os.environ.get(

--- a/scripts/algolia_batch_smoke.py
+++ b/scripts/algolia_batch_smoke.py
@@ -28,6 +28,7 @@ sandbox, that's already configured.
 
 import os
 import sys
+import time
 import uuid
 from pathlib import Path
 
@@ -118,12 +119,13 @@ objects = [_make_obj(i) for i in range(3)]
 object_ids = [obj['objectID'] for obj in objects]
 
 try:
-    save_response = _step(
+    _step(
         'save_objects_batch (3 records)',
         lambda: client.save_objects_batch(objects),
     )
-    # Block until the records are committed and searchable.
-    save_response.wait()
+    # save_objects_batch is fire-and-forget per ADR 0012; sleep briefly to let
+    # Algolia publish before asserting searchability.
+    time.sleep(2)
 
     found_ids = _step(
         'get_object_ids_for_aggregation_key',
@@ -152,12 +154,11 @@ try:
     assert set(alt_found) == set(object_ids)
 
 finally:
-    cleanup_response = _step(
+    _step(
         'delete_objects_batch (cleanup)',
         lambda: client.delete_objects_batch(object_ids),
     )
-    if cleanup_response is not None:
-        cleanup_response.wait()
+    time.sleep(2)
 
     leftover = client.get_object_ids_for_aggregation_key(AGGREGATION_KEY)
     if leftover:


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-11813

Refactor _index_content_batch into a three-pass pipeline that aggregates Algolia I/O across the task batch:
1. Resolve each content_key into an IndexingDecision (no Algolia writes except the rare first-contact browse via _existing_shard_ids).
2. One bulk save_objects_batch and one bulk delete_objects_batch across the batch. On AlgoliaException, fall back to per-record retries; per-record failures mutate decision.outcome = FAILED in place.
3. Finalize state rows + counters by dispatching on decision.outcome.

The Algolia client chunks save/delete payloads at `ALGOLIA_INDEXING_CHUNK_SIZE` (default 100) to bound partial-failure blast radius; Algolia upserts/deletes by objectID so retries are idempotent.

Also renames BatchOutcome -> RecordOutcome and _RecordPlan -> IndexingDecision (with classmethod constructors per outcome).

## How to review this PR

### Read is in this order, probably

1. `IndexingDecision` + `RecordOutcome` in `enterprise_catalog/apps/search/tasks.py` - each of these is per-aggregation-key. They're aggregated inside `BatchResults` because each task operates on a batch (list) of content keys).
2. `_index_content_batch` (same file) — the three-pass orchestrator that executes the task below
3. Pass 1: `_resolve_indexing_decision` + `_existing_shard_ids`.
4. Pass 2: `_execute_saves` / `_execute_deletes` and their per-record fallbacks. These change the corresponding `IndexingDecision.outcome` of each of the records.
5. Pass 3: `_finalize_decision` — pure dispatch on `decision.outcome` to update our internal state django records.
6. `enterprise_catalog/apps/api_client/algolia.py` — chunking on `save_objects_batch` / `delete_objects_batch`.
7. Tests, especially the fallback-mutation cases.

### The three-pass pipeline

```
        content_keys (~10 per task)
              │
              ▼
   ┌──────────────────────────────┐
   │ Pass 1: Resolve              │   _resolve_indexing_decision per key
   │ ────────────────             │   produces IndexingDecision with
   │ no Algolia writes*           │   outcome ∈ {INDEXED, SKIPPED,
   │                              │              REMOVED, FAILED}
   └──────────────┬───────────────┘   *one browse per first-contact key
                  │
                  ▼
   ┌──────────────────────────────┐
   │ Pass 2: Execute              │   1 bulk save  → fallback per-record
   │ ────────────────             │   1 bulk delete → fallback per-record
   │ Algolia I/O                  │   per-record fail → mutate outcome
   └──────────────┬───────────────┘                    to FAILED
                  │
                  ▼
   ┌──────────────────────────────┐
   │ Pass 3: Finalize             │   dispatch on decision.outcome:
   │ ────────────────             │     INDEXED → mark_as_indexed
   │ state rows + counters        │     REMOVED → mark_as_removed
   │                              │     SKIPPED → counter only
   └──────────────────────────────┘     FAILED  → mark_as_failed
```

### Bulk-with-fallback

```
   indexed_decisions (have new_objects to write)
           │
           ▼
   algolia_client.save_objects_batch(all_objects)
           │
        ┌──┴──┐
        │     │
     success  AlgoliaException
        │     │
        │     ▼
        │   for decision in indexed_decisions:
        │       try save_objects_batch(decision.new_objects)
        │       except AlgoliaException as exc:
        │           decision.outcome = RecordOutcome.FAILED   ← mutation
        │           decision.failure_reason = exc
        ▼
   ── pass 3 reads decision.outcome ──
```

It's the same shape for `_execute_deletes`, just review what we're doing with our internal state records.

Idempotency: when a bulk call raises mid-stream, the algolia API has already accepted some chunks. The per-record retries re-write those records; Algolia upserts/deletes by `objectID`, so this is correct, not duplicated.

### Things flagged during review (decided as-is)

- `_existing_shard_ids` issues an Algolia browse during pass 1 for first-contact records, breaking the "no I/O in planning" purity. Acceptable trade because the state row is the system of record for everything we wrote, and the fallback is rare (first-time index, or content carried over from the legacy reindexer).
- `decision.outcome` is mutable. In-place mutation is what makes pass 3 a pure dispatch; we explicitly chose this over threading failure sets through.
- Default chunk size of 100. Typical task batch (10 content_keys × ~3 shards) fits in one HTTP call; we'll tune if production patterns change.
- `test_indexed_record_orphan_delete_failure_mutates_outcome_to_failed` pins the INDEXED -> FAILED mutation in isolation, complementing the multi-record bulk-delete test.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
