### PR TITLE
feat: add phase 4a algolia indexing dispatcher

### DIFF
--- a/docs/algolia-reindexing/phase-4-plan.md
+++ b/docs/algolia-reindexing/phase-4-plan.md
@@ -1,0 +1,289 @@
+# Phase 4a Plan: Algolia Incremental Indexing Dispatcher (stale/failed → batch → dispatch)
+
+This document captures the implementation plan for **Phase 4a** of the incremental Algolia indexing project in `edx/enterprise-catalog`.
+
+Scope: implement the **scheduled dispatcher task** that queries for **stale and/or failed** records and dispatches **batch indexing tasks**.
+
+> Note: This plan is intentionally detailed so it can be used later to craft an ADR.
+
+---
+
+## Background / Context
+
+The new incremental indexing architecture replaces the legacy monolithic Algolia reindex with a **dispatcher → parallel batch tasks** model.
+
+Phase 3 introduced:
+
+- Content-type batch indexing tasks (courses/programs/pathways)
+- `IndexingMappings` caching via `enterprise_catalog/apps/search/indexing_mappings.py`
+  - The cache computes **indexable content keys** via the legacy partition helpers.
+
+Phase 4 is responsible for:
+
+- Dispatcher task(s) that decide *what to index* and *when*, and fan out batch tasks.
+
+This Phase 4a slice covers only the **primary/scheduled dispatcher**:
+
+- `dispatch_algolia_indexing`
+
+Not included in this slice:
+
+- `dispatch_algolia_indexing_for_catalog_query` (catalog-query-specific dispatcher)
+
+---
+
+## Goals
+
+- Identify **records needing indexing**:
+  - never indexed
+  - stale (content modified since last index)
+  - failed previously (retry)
+  - programs/pathways: stale when child content was indexed more recently
+- Batch work into small parallel units (default 10 keys per task).
+- Dispatch batch indexing tasks without blocking.
+- Support `dry_run` for safe execution/testing.
+- Avoid unnecessary recomputation by using the cached `IndexingMappings` and warming it once per dispatcher run.
+
+---
+
+## Non-goals
+
+- No membership-removal detection for a specific catalog query (that's the catalog-query-specific dispatcher).
+- No integration into the daily cron chain / API endpoint in this slice (that's later integration work).
+
+---
+
+## Key Decisions
+
+### 1) Partitioning happens in `IndexingMappings`, not in the dispatcher
+
+We will **not** call the partition helpers directly in the dispatcher. The dispatcher will rely on:
+
+- `get_indexing_mappings()` from `enterprise_catalog/apps/search/indexing_mappings.py`
+
+That module already calls:
+
+- `partition_course_keys_for_indexing(...)`
+- `partition_program_keys_for_indexing(...)`
+
+…and computes:
+
+- `IndexingMappings.all_indexable_content_keys`
+
+This avoids duplicating “indexable content” logic in multiple layers.
+
+### 2) Cache invalidation only for force runs
+
+- If `force=True`, the dispatcher will call `invalidate_indexing_mappings_cache()` before warming mappings.
+- If `force=False` (stragglers/retry style runs), we will *not* invalidate; TTL is the safety net.
+
+### 3) Programs/pathways staleness depends on child indexing
+
+- Programs are stale if a child course has been indexed more recently.
+- Pathways are stale if a child program has been indexed more recently.
+
+This is implemented immediately in Phase 4a.
+
+### 4) UUID-based program key detection
+
+`IndexingMappings.pathway_to_program_course_keys[pathway_key]` contains a **mixed set** of:
+
+- course content keys (not UUIDs)
+- program content keys (UUID strings)
+
+We distinguish program keys by UUID parsing.
+
+---
+
+## Proposed Public API
+
+### Celery Task: `dispatch_algolia_indexing`
+
+**Location**: `enterprise_catalog/apps/search/tasks.py`
+
+**Signature (proposed)**:
+
+```python
+dispatch_algolia_indexing(
+    *,
+    force: bool = False,
+    dry_run: bool = False,
+    include_failed: bool = True,
+    index_name: str | None = None,
+)
+```
+
+**Parameters**:
+
+- `force`:
+  - `True`: index all indexable records regardless of staleness.
+  - `False`: index only stale/failed records.
+- `dry_run`:
+  - `True`: compute and log batches, but do not enqueue tasks.
+- `include_failed`:
+  - `True`: include previously failed records for retry.
+  - Note: when `force=True`, this flag is effectively irrelevant because we index everything anyway.
+- `index_name`:
+  - optional override to target a non-default Algolia index (e.g., v2) by passing through to batch tasks.
+
+---
+
+## Dispatcher Algorithm
+
+### Step 0: Cache management
+
+1. If `force=True`, call `invalidate_indexing_mappings_cache()`.
+2. Warm mappings with `get_indexing_mappings()` synchronously.
+
+This provides:
+
+- `program_to_course_keys`
+- `pathway_to_program_course_keys`
+- `all_indexable_content_keys`
+
+### Step 1: Determine indexable keys per content type
+
+We avoid guessing based on key prefixes.
+
+- Use `mappings.all_indexable_content_keys` as the global set.
+- Derive per-type indexable keys by querying `ContentMetadata` by `content_type` and `content_key__in` that set:
+
+  - courses: `content_type=COURSE`
+  - programs: `content_type=PROGRAM`
+  - pathways: `content_type=LEARNER_PATHWAY`
+
+### Step 2: Stale/failed filtering
+
+#### Courses (when `force=False`)
+Include a course key when any is true:
+
+- never indexed: `state.last_indexed_at is NULL`
+- stale: `ContentMetadata.modified > state.last_indexed_at`
+- failed and retry enabled: `include_failed=True` and `state.last_failure_at is not NULL`
+
+When `force=True`, include all indexable course keys.
+
+#### Programs (when `force=False`)
+Include a program key when any is true:
+
+- never indexed
+- failed (if enabled)
+- stale via child course indexing:
+  - any child course `last_indexed_at > program.last_indexed_at`
+  - child course keys come from `mappings.program_to_course_keys[program_key]`
+
+When `force=True`, include all indexable program keys.
+
+#### Pathways (when `force=False`)
+Include a pathway key when any is true:
+
+- never indexed
+- failed (if enabled)
+- stale via child program indexing:
+  - any child program `last_indexed_at > pathway.last_indexed_at`
+  - child keys come from `mappings.pathway_to_program_course_keys[pathway_key]`
+  - extract program keys by UUID parsing (program `content_key` is always a UUID string)
+
+When `force=True`, include all indexable pathway keys.
+
+### Step 3: Batch and dispatch
+
+- Batch size: `settings.ALGOLIA_INDEXING_BATCH_SIZE` (default: 10)
+- Build per-type batches, then dispatch as a **serial chain of Celery groups**:
+
+  ```
+  chain(
+      group(course_batches),     # all course tasks run in parallel
+      group(program_batches),    # starts only after ALL courses finish
+      group(pathway_batches),    # starts only after ALL programs finish
+  ).apply_async()
+  ```
+
+  Tasks use `.si()` (immutable signatures) so each task's kwargs are fixed at
+  dispatch time and Celery does not forward previous group results as positional
+  arguments.
+
+  Empty groups are omitted from the chain.
+
+**Why ordering matters — child-staleness propagation:**
+
+Programs and pathways detect staleness by comparing their own
+`last_indexed_at` against the `last_indexed_at` of their child content.
+That comparison is only meaningful if child timestamps reflect the current
+run — i.e. if courses were indexed *before* programs are evaluated, and
+programs were indexed *before* pathways are evaluated.  If all three types
+were dispatched simultaneously (flat `.delay()` per batch), a program task
+could execute before its child course task writes the updated
+`last_indexed_at`, causing the program to be incorrectly skipped as
+non-stale.  The chain-of-groups guarantee eliminates that race.
+
+See ADR 0013 for the full rationale.
+
+### Step 4: Logging and return value
+
+The dispatcher returns a summary dict suitable for CLI/ops visibility, e.g.:
+
+```python
+{
+  "force": False,
+  "dry_run": False,
+  "batch_size": 10,
+  "index_name": None,
+  "dispatched": {
+    "course": {"records": 123, "batches": 13},
+    "program": {"records": 45, "batches": 5},
+    "learnerpathway": {"records": 6, "batches": 1},
+  },
+}
+```
+
+---
+
+## Performance / Query Strategy
+
+Avoid N+1 queries by bulk-loading required state.
+
+For each content type, the dispatcher should:
+
+- bulk fetch `ContentMetadata` for the type (only fields needed, e.g. `content_key`, `modified`).
+- bulk fetch `ContentMetadataIndexingState` for the same keys.
+
+For child-staleness checks:
+
+- programs: bulk fetch course states for all child course keys referenced by programs under consideration.
+- pathways: bulk fetch program states for all child program keys (UUIDs) referenced by pathways under consideration.
+
+Compute staleness comparisons in Python using dict lookups keyed by `content_key`.
+
+---
+
+## Testing Plan
+
+Add unit tests in `enterprise_catalog/apps/search/tests/test_tasks.py`:
+
+1. **`dry_run=True`**: no `.delay()` calls; summary matches expected counts.
+2. **force cache behavior**:
+   - `force=True` calls `invalidate_indexing_mappings_cache()`.
+   - `force=False` does not.
+3. **courses stale detection**:
+   - never indexed included
+   - modified > last_indexed_at included
+   - modified <= last_indexed_at excluded
+4. **include_failed**:
+   - failed record included when `include_failed=True`
+5. **program child-staleness**:
+   - program included when any child course last_indexed_at > program last_indexed_at
+6. **pathway child-staleness (UUID program keys)**:
+   - pathway included when any child program (UUID key) last_indexed_at > pathway last_indexed_at
+7. **batching math**:
+   - correct number of dispatched tasks based on batch size
+
+---
+
+## Follow-ups (out of Phase 4a scope)
+
+- Implement `dispatch_algolia_indexing_for_catalog_query` for API-triggered catalog refreshes (membership removal detection via Algolia diff).
+- Integrate dispatchers into:
+  - daily cron chain after `update_content_metadata`
+  - API refresh endpoint `EnterpriseCatalogRefreshDataFromDiscovery`
+- Add management command wrapper for manual runs.

--- a/docs/algolia-reindexing/tech-spec.md
+++ b/docs/algolia-reindexing/tech-spec.md
@@ -749,6 +749,10 @@ Instead of updating each frontend's `ALGOLIA_INDEX_NAME` env var and deploying s
 
 ### Phase 4: Dispatcher Tasks
 
+**Design Clarification**
+* Dependency order does actually matter for child->parent content staleness checking.
+* Having one Celery task per content type is helpful from a resource-consumption (celery queue design) standpoint.
+
 **Summary**: Create two dispatcher tasks
 
 * one that queries for stale/failed records and dispatches batch indexing tasks. We'll run this one on a schedule.
@@ -760,7 +764,7 @@ Instead of updating each frontend's `ALGOLIA_INDEX_NAME` env var and deploying s
 - Implement `_get_stale_content_keys(content_type, force, include_failed)` helper
 - Create `dispatch_algolia_indexing_for_catalog_query` task
 - Implement batching logic (default batch size 10, configurable)
-- Dispatch tasks in dependency order: courses → programs → pathways
+- Dispatch tasks in this order: courses -> programs -> pathways
 - Support `dry_run` mode for testing
 - Add `ALGOLIA_INDEXING_BATCH_SIZE` setting
 - Pre-warm `IndexingMappings` before fan-out: call

--- a/docs/decisions/0013-dispatcher-serial-chain-ordering.rst
+++ b/docs/decisions/0013-dispatcher-serial-chain-ordering.rst
@@ -1,0 +1,86 @@
+Dispatcher Uses Serial Chain-of-Groups for Content-Type Ordering
+================================================================
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+The Phase 4a dispatcher (``dispatch_algolia_indexing``) fans out three
+content types — courses, programs, and learner pathways — to parallel batch
+indexing tasks.  The original design enqueued all batch tasks with flat
+``.delay()`` calls, treating the three types as independent.
+
+During code review it became clear that this independence assumption is
+incorrect.  Staleness detection for **programs** and **pathways** is
+implemented by comparing the parent's ``last_indexed_at`` against the
+``last_indexed_at`` of its *child* content (child courses for programs;
+child programs for pathways).  Specifically:
+
+* A program is considered stale — and therefore re-dispatched — when any of
+  its child courses has a ``last_indexed_at`` that is *newer* than the
+  program's own ``last_indexed_at``.
+* A pathway is considered stale when any of its child programs is newer.
+
+``ContentMetadataIndexingState.last_indexed_at`` is only written **after**
+a batch task successfully completes.  If course batches and program batches
+are dispatched simultaneously (or interleaved by Celery), a program batch
+task may execute before its child course tasks have finished writing their
+updated timestamps.  In that case the program incorrectly appears
+non-stale, is skipped, and its Algolia shards are left with outdated
+parent-level metadata until the next dispatcher run catches it.
+
+Decision
+--------
+
+The dispatcher assembles batch task signatures into a **chain of Celery
+groups**:
+
+.. code-block:: text
+
+    chain(
+        group(all_course_batches),    # parallel; must ALL complete first
+        group(all_program_batches),   # parallel; must ALL complete first
+        group(all_pathway_batches),   # parallel
+    ).apply_async()
+
+Each group runs its contained tasks in parallel.  Celery does not start the
+next group in the chain until every task in the current group has
+acknowledged completion.  This guarantees:
+
+1. All course ``last_indexed_at`` timestamps are up to date before any
+   program staleness check runs.
+2. All program ``last_indexed_at`` timestamps are up to date before any
+   pathway staleness check runs.
+
+Batch task signatures are built with ``.si()`` (immutable signatures) so
+the return values from one group are not forwarded as positional arguments
+to the next group's tasks — each task receives only the kwargs it was
+constructed with.  Empty groups (content types with zero batches to
+dispatch) are omitted from the chain so no no-op tasks are enqueued.
+
+Consequences
+------------
+
+* **Correctness**: child-staleness propagation now works in a single
+  dispatcher pass.  Without this change, a course updated between two
+  dispatcher runs would correctly trigger a program re-index only on the
+  *second* run after the update (the first run would update the course
+  timestamp, but the program would only see the new timestamp on the next
+  pass).
+* **Latency**: total wall-clock time for a full dispatcher pass increases
+  slightly because programs cannot start until all course batches finish.
+  In practice the added latency is small relative to the batch task
+  processing time, and the correctness gain outweighs it.
+* **Celery backend required**: Celery chains with groups require a result
+  backend (e.g. Redis) to track group completion.  This is already a
+  requirement for the broader Celery setup in this service (Redis is used
+  for the task queue), so no new infrastructure is needed.
+* **``CELERY_TASK_ALWAYS_EAGER`` compatibility**: in eager mode (used by
+  unit tests), Celery executes chains and groups synchronously in the
+  correct order.  The unit tests mock the task ``.si()`` method and the
+  ``chain``/``group`` callables to prevent actual dispatch and to assert
+  on which content_keys were selected for each content type.

--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -41,12 +41,18 @@ Design notes worth keeping in mind:
 """
 import logging
 from collections import defaultdict
+from collections.abc import Generator, Iterable
 from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from enum import StrEnum
+from itertools import islice
+from typing import Any, TypedDict, TypeVar
+from uuid import UUID
 
 from algoliasearch.exceptions import AlgoliaException
-from celery import shared_task
+from celery import chain, group, shared_task
 from celery_utils.logged_task import LoggedTask
+from django.conf import settings
 from django.db import IntegrityError
 from django.db.utils import OperationalError
 from requests.exceptions import ConnectionError as RequestsConnectionError
@@ -65,11 +71,23 @@ from enterprise_catalog.apps.catalog.models import ContentMetadata
 from enterprise_catalog.apps.search.indexing_mappings import (
     IndexingMappings,
     get_indexing_mappings,
+    invalidate_indexing_mappings_cache,
 )
 from enterprise_catalog.apps.search.models import ContentMetadataIndexingState
 
 
 logger = logging.getLogger(__name__)
+
+# TypeVar for the generic _chunked helper.
+_T = TypeVar('_T')
+
+
+class _ContentState(TypedDict):
+    """
+    Type alias for the per-record state dict returned by _get_indexing_state_by_key.
+    """
+    last_indexed_at: datetime | None
+    last_failure_at: datetime | None
 
 
 UNREADY_TASK_RETRY_COUNTDOWN_SECONDS = 60 * 5
@@ -141,7 +159,9 @@ class _LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
 
 
 @shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
-def index_courses_batch_in_algolia(self, content_keys, index_name=None, force=False):  # pylint: disable=unused-argument
+def index_courses_batch_in_algolia(
+    self, content_keys, index_name=None, force=False,  # pylint: disable=unused-argument
+):
     """
     Index a small batch of course ContentMetadata records into Algolia.
 
@@ -152,7 +172,9 @@ def index_courses_batch_in_algolia(self, content_keys, index_name=None, force=Fa
 
 
 @shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
-def index_programs_batch_in_algolia(self, content_keys, index_name=None, force=False):  # pylint: disable=unused-argument
+def index_programs_batch_in_algolia(
+    self, content_keys, index_name=None, force=False,  # pylint: disable=unused-argument
+):
     """
     Index a small batch of program ContentMetadata records into Algolia.
 
@@ -163,7 +185,9 @@ def index_programs_batch_in_algolia(self, content_keys, index_name=None, force=F
 
 
 @shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
-def index_pathways_batch_in_algolia(self, content_keys, index_name=None, force=False):  # pylint: disable=unused-argument
+def index_pathways_batch_in_algolia(
+    self, content_keys, index_name=None, force=False,  # pylint: disable=unused-argument
+):
     """
     Index a small batch of learner pathway ContentMetadata records into Algolia.
 
@@ -171,6 +195,114 @@ def index_pathways_batch_in_algolia(self, content_keys, index_name=None, force=F
     Celery payload stays JSON-serializable.
     """
     return asdict(_index_content_batch(content_keys, LEARNER_PATHWAY, index_name=index_name, force=force))
+
+
+@shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
+def dispatch_algolia_indexing(
+    self,  # pylint: disable=unused-argument
+    force=False,
+    dry_run=False,
+    include_failed=True,
+    index_name=None,
+):
+    """
+    Dispatch Phase 4a incremental Algolia indexing batch tasks.
+
+    When ``force=True``, dispatch every currently-indexable record. Otherwise,
+    dispatch only records that have never been indexed, are stale, or have a
+    recorded failure that should be retried.
+
+    **Dispatch ordering matters for child-staleness propagation.**
+
+    Programs and pathways use ``last_indexed_at`` timestamps on their *child*
+    content to decide whether they are stale: a program is stale when any of
+    its child courses was indexed more recently than the program itself, and a
+    pathway is stale when any of its child programs is newer.
+
+    Because those timestamps are only advanced *after* the child batch tasks
+    complete, we must guarantee that all course batches finish before any
+    program batches start, and all program batches finish before any pathway
+    batches start.  This is achieved by assembling the batches into a
+    ``chain`` of Celery ``group``\\s (courses → programs → pathways).  Each
+    group runs in parallel internally; Celery does not start the next group
+    until every task in the current group has completed.  Empty groups are
+    omitted from the chain.
+    """
+    if force:
+        invalidate_indexing_mappings_cache()
+
+    mappings = get_indexing_mappings()
+    batch_size = getattr(settings, 'ALGOLIA_INDEXING_BATCH_SIZE', 10)
+    indexable_keys_by_type = _get_indexable_keys_by_content_type(
+        mappings.all_indexable_content_keys,
+    )
+
+    content_keys_to_dispatch: dict[str, list[str]] = {
+        COURSE: _get_course_keys_for_dispatch(
+            content_keys=indexable_keys_by_type[COURSE],
+            force=force,
+            include_failed=include_failed,
+        ),
+        PROGRAM: _get_program_keys_for_dispatch(
+            content_keys=indexable_keys_by_type[PROGRAM],
+            program_to_course_keys=mappings.program_to_course_keys,
+            force=force,
+            include_failed=include_failed,
+        ),
+        LEARNER_PATHWAY: _get_pathway_keys_for_dispatch(
+            content_keys=indexable_keys_by_type[LEARNER_PATHWAY],
+            pathway_to_program_course_keys=mappings.pathway_to_program_course_keys,
+            force=force,
+            include_failed=include_failed,
+        ),
+    }
+
+    task_by_content_type = {
+        COURSE: index_courses_batch_in_algolia,
+        PROGRAM: index_programs_batch_in_algolia,
+        LEARNER_PATHWAY: index_pathways_batch_in_algolia,
+    }
+    summary = {
+        'force': force,
+        'dry_run': dry_run,
+        'batch_size': batch_size,
+        'index_name': index_name,
+        'dispatched': {},
+    }
+
+    # Build per-type batches and record summary counts before dispatching.
+    batches_by_type = {}
+    for content_type in (COURSE, PROGRAM, LEARNER_PATHWAY):
+        content_keys = content_keys_to_dispatch[content_type]
+        batches = _chunked(content_keys, batch_size)
+        batches_by_type[content_type] = batches
+        summary['dispatched'][content_type] = {'records': 0, 'batches': 0}
+
+    # Build a chain of groups: courses -> programs -> pathways.
+    # Tasks use .si() (immutable signatures) so each task's kwargs are
+    # fixed at dispatch time and Celery does not forward the previous
+    # group's return values as positional arguments.
+    ordered_groups = []
+    for content_type in (COURSE, PROGRAM, LEARNER_PATHWAY):
+        content_type_group_tasks = []
+        for batch in batches_by_type[content_type]:
+            summary['dispatched'][content_type]['batches'] += 1
+            summary['dispatched'][content_type]['records'] += len(batch)
+            if dry_run:
+                continue
+            content_type_group_tasks.append(
+                task_by_content_type[content_type].si(
+                    content_keys=batch, force=force, index_name=index_name,
+                ),
+            )
+        if content_type_group_tasks:
+            ordered_groups.append(group(content_type_group_tasks))
+
+    if not dry_run and len(ordered_groups) >= 1:
+        chain(*ordered_groups).apply_async()
+
+    logger.info('dispatch_algolia_indexing summary=%s', summary)
+    return summary
 
 
 @dataclass
@@ -274,7 +406,12 @@ class IndexingDecision:
         )
 
 
-def _index_content_batch(content_keys, content_type, index_name=None, force=False):
+def _index_content_batch(
+    content_keys: list[str],
+    content_type: str,
+    index_name: str | None = None,
+    force: bool = False,
+) -> BatchSummary:
     """
     Drive the per-record indexing loop for a batch of content_keys via three
     coordinated passes:
@@ -365,6 +502,251 @@ def _index_content_batch(content_keys, content_type, index_name=None, force=Fals
     return results
 
 
+def _chunked(iterable: Iterable[_T], size: int) -> Generator[list[_T], None, None]:
+    """
+    Yield successive ``list`` batches from ``iterable`` with at most ``size``
+    items per batch.
+    """
+    iterator = iter(iterable)
+    while True:
+        batch = list(islice(iterator, size))
+        if not batch:
+            return
+        yield batch
+
+
+def _get_indexable_keys_by_content_type(
+    all_indexable_content_keys: Iterable[str],
+) -> dict[str, list[str]]:
+    """
+    Return a deterministic list of indexable content_keys for each supported
+    content type.
+    """
+    indexable_keys_by_type = {
+        COURSE: [],
+        PROGRAM: [],
+        LEARNER_PATHWAY: [],
+    }
+    if not all_indexable_content_keys:
+        return indexable_keys_by_type
+
+    queryset = ContentMetadata.objects.filter(
+        content_key__in=all_indexable_content_keys,
+        content_type__in=(COURSE, PROGRAM, LEARNER_PATHWAY),
+    ).values_list(
+        'content_type', 'content_key',
+    ).order_by(
+        'content_type', 'content_key',
+    )
+
+    for content_type, content_key in queryset:
+        indexable_keys_by_type[content_type].append(content_key)
+    return indexable_keys_by_type
+
+
+def _get_content_modified_by_key(
+    content_keys: Iterable[str],
+    content_type: str,
+) -> dict[str, datetime]:
+    """
+    Return ``content_key -> modified`` for the requested content type.
+    """
+    if not content_keys:
+        return {}
+    return dict(
+        ContentMetadata.objects.filter(
+            content_key__in=content_keys,
+            content_type=content_type,
+        ).values_list('content_key', 'modified')
+    )
+
+
+def _get_indexing_state_by_key(
+    content_keys: Iterable[str],
+) -> dict[str, _ContentState]:
+    """
+    Return ``content_key -> {'last_indexed_at', 'last_failure_at'}``.
+    """
+    if not content_keys:
+        return {}
+
+    queryset = ContentMetadataIndexingState.objects.filter(
+        content_metadata__content_key__in=content_keys,
+    ).values_list(
+        'content_metadata__content_key',
+        'last_indexed_at',
+        'last_failure_at',
+    )
+
+    return {
+        content_key: {
+            'last_indexed_at': last_indexed_at,
+            'last_failure_at': last_failure_at,
+        }
+        for content_key, last_indexed_at, last_failure_at in queryset
+    }
+
+
+def _should_retry_failed_record(
+    state_by_key: dict[str, _ContentState],
+    content_key: str,
+    include_failed: bool,
+) -> bool:
+    """
+    Return whether a recorded failure should be retried for ``content_key``.
+    """
+    if not include_failed:
+        return False
+    state = state_by_key.get(content_key)
+    return bool(state and state['last_failure_at'])
+
+
+def _get_course_keys_for_dispatch(
+    content_keys: list[str],
+    force: bool,
+    include_failed: bool,
+) -> list[str]:
+    """
+    Return the course content_keys that the dispatcher should enqueue.
+    """
+    if force:
+        return list(content_keys)
+
+    content_modified_by_key = _get_content_modified_by_key(content_keys, COURSE)
+    state_by_key = _get_indexing_state_by_key(content_keys)
+    keys_to_dispatch = []
+    for content_key in content_keys:
+        state = state_by_key.get(content_key)
+        if state is None or state['last_indexed_at'] is None:
+            keys_to_dispatch.append(content_key)
+            continue
+        if content_modified_by_key[content_key] > state['last_indexed_at']:
+            keys_to_dispatch.append(content_key)
+            continue
+        if _should_retry_failed_record(state_by_key, content_key, include_failed):
+            keys_to_dispatch.append(content_key)
+    return keys_to_dispatch
+
+
+def _get_program_keys_for_dispatch(
+    content_keys: list[str],
+    program_to_course_keys: dict[str, set[str]],
+    force: bool,
+    include_failed: bool,
+) -> list[str]:
+    """
+    Return the program content_keys that the dispatcher should enqueue.
+    """
+    if force:
+        return list(content_keys)
+
+    state_by_key = _get_indexing_state_by_key(content_keys)
+    all_child_course_keys = {
+        child_key
+        for program_key in content_keys
+        for child_key in program_to_course_keys.get(program_key, ())
+    }
+    child_state_by_key = _get_indexing_state_by_key(all_child_course_keys)
+
+    keys_to_dispatch = []
+    for content_key in content_keys:
+        state = state_by_key.get(content_key)
+        if state is None or state['last_indexed_at'] is None:
+            keys_to_dispatch.append(content_key)
+            continue
+        if _should_retry_failed_record(state_by_key, content_key, include_failed):
+            keys_to_dispatch.append(content_key)
+            continue
+        if _has_newer_child_index(
+            program_to_course_keys.get(content_key, ()),
+            child_state_by_key,
+            state['last_indexed_at'],
+        ):
+            keys_to_dispatch.append(content_key)
+    return keys_to_dispatch
+
+
+def _get_pathway_keys_for_dispatch(
+    content_keys: list[str],
+    pathway_to_program_course_keys: dict[str, set[str]],
+    force: bool,
+    include_failed: bool,
+) -> list[str]:
+    """
+    Return the learner pathway content_keys that the dispatcher should enqueue.
+    """
+    if force:
+        return list(content_keys)
+
+    state_by_key = _get_indexing_state_by_key(content_keys)
+    child_program_keys_by_pathway = {
+        pathway_key: _extract_program_keys(
+            pathway_to_program_course_keys.get(pathway_key, ())
+        )
+        for pathway_key in content_keys
+    }
+    all_child_program_keys = {
+        child_key
+        for child_program_keys in child_program_keys_by_pathway.values()
+        for child_key in child_program_keys
+    }
+    child_state_by_key = _get_indexing_state_by_key(all_child_program_keys)
+
+    keys_to_dispatch = []
+    for content_key in content_keys:
+        state = state_by_key.get(content_key)
+        if state is None or state['last_indexed_at'] is None:
+            keys_to_dispatch.append(content_key)
+            continue
+        if _should_retry_failed_record(state_by_key, content_key, include_failed):
+            keys_to_dispatch.append(content_key)
+            continue
+        if _has_newer_child_index(
+            child_program_keys_by_pathway[content_key],
+            child_state_by_key,
+            state['last_indexed_at'],
+        ):
+            keys_to_dispatch.append(content_key)
+    return keys_to_dispatch
+
+
+def _has_newer_child_index(
+    child_keys: Iterable[str],
+    child_state_by_key: dict[str, _ContentState],
+    parent_last_indexed_at: datetime,
+) -> bool:
+    """
+    Return whether any child was indexed more recently than its parent.
+    """
+    for child_key in child_keys:
+        child_state = child_state_by_key.get(child_key)
+        if child_state and child_state['last_indexed_at'] and child_state['last_indexed_at'] > parent_last_indexed_at:
+            return True
+    return False
+
+
+def _extract_program_keys(content_keys: Iterable[str]) -> list[str]:
+    """
+    Return only UUID-shaped keys from a mixed course/program iterable.
+    """
+    return [
+        content_key
+        for content_key in content_keys
+        if _is_uuid_string(content_key)
+    ]
+
+
+def _is_uuid_string(value: Any) -> bool:
+    """
+    Return whether ``value`` parses cleanly as a UUID after string coercion.
+    """
+    try:
+        UUID(str(value))
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
 def _build_objects_by_content_key(
     content_keys: list[str],
     content_type: str,
@@ -404,7 +786,7 @@ def _build_objects_by_content_key(
     return objects_by_content_key
 
 
-def _aggregation_key_for(content_type, content_key):
+def _aggregation_key_for(content_type: str, content_key: str) -> str:
     """
     The legacy Algolia object generator emits ``aggregation_key`` as
     ``"{content_type}:{content_key}"`` (e.g. ``"course:edX+DemoX"``). The
@@ -414,7 +796,12 @@ def _aggregation_key_for(content_type, content_key):
     return f'{content_type}:{content_key}'
 
 
-def _existing_shard_ids(state, aggregation_key, algolia_client, index_name):
+def _existing_shard_ids(
+    state: ContentMetadataIndexingState,
+    aggregation_key: str,
+    algolia_client: AlgoliaSearchClient,
+    index_name: str | None,
+) -> list[str]:
     """
     Return the Algolia shard objectIDs Algolia is hosting for a content
     record.
@@ -519,7 +906,11 @@ def _resolve_indexing_decision(
         )
 
 
-def _execute_saves(decisions, algolia_client, index_name):
+def _execute_saves(
+    decisions: list[IndexingDecision],
+    algolia_client: AlgoliaSearchClient,
+    index_name: str | None,
+) -> None:
     """
     Issue one bulk ``save_objects_batch`` for every decision whose
     desired_outcome is INDEXED. On ``AlgoliaException``, fall back to per-record
@@ -543,7 +934,11 @@ def _execute_saves(decisions, algolia_client, index_name):
         _per_record_save_fallback(indexed_decisions, algolia_client, index_name)
 
 
-def _per_record_save_fallback(decisions, algolia_client, index_name):
+def _per_record_save_fallback(
+    decisions: list[IndexingDecision],
+    algolia_client: AlgoliaSearchClient,
+    index_name: str | None,
+) -> None:
     """
     Retry each decision's save individually. On per-record failure, mutate
     the decision's outcome to FAILED so pass 3 dispatches via the FAILED
@@ -560,7 +955,11 @@ def _per_record_save_fallback(decisions, algolia_client, index_name):
             decision.failure_reason = exc
 
 
-def _execute_deletes(decisions, algolia_client, index_name):
+def _execute_deletes(
+    decisions: list[IndexingDecision],
+    algolia_client: AlgoliaSearchClient,
+    index_name: str | None,
+) -> None:
     """
     Issue one bulk ``delete_objects_batch`` for every orphan + REMOVED shard
     across the batch. Decisions whose save fallback failed have already been
@@ -589,7 +988,11 @@ def _execute_deletes(decisions, algolia_client, index_name):
         _per_record_delete_fallback(delete_decisions, algolia_client, index_name)
 
 
-def _per_record_delete_fallback(decisions, algolia_client, index_name):
+def _per_record_delete_fallback(
+    decisions: list[IndexingDecision],
+    algolia_client: AlgoliaSearchClient,
+    index_name: str | None,
+) -> None:
     """
     Retry each decision's delete individually. On per-record failure, mutate
     the decision's outcome to FAILED.
@@ -605,7 +1008,7 @@ def _per_record_delete_fallback(decisions, algolia_client, index_name):
             decision.failure_reason = exc
 
 
-def _finalize_decision(decision, results):
+def _finalize_decision(decision: IndexingDecision, results: BatchSummary) -> None:
     """
     Apply the decision's final outcome to the state row and bump the matching
     counter. ``decision.outcome`` reflects what actually happened after pass 2

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -4,10 +4,12 @@ Tests for the Phase 3 incremental Algolia indexing batch tasks.
 from dataclasses import asdict
 from datetime import timedelta
 from unittest import mock
+from uuid import uuid4
 
 import ddt
 from algoliasearch.exceptions import AlgoliaException
 from django.test import TestCase
+from django.test.utils import override_settings
 
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
@@ -25,7 +27,16 @@ from enterprise_catalog.apps.search.tasks import (
     BatchSummary,
     IndexingDecision,
     RecordOutcome,
+    _chunked,
+    _extract_program_keys,
+    _get_content_modified_by_key,
+    _get_indexable_keys_by_content_type,
+    _get_indexing_state_by_key,
+    _has_newer_child_index,
     _index_content_batch,
+    _is_uuid_string,
+    _should_retry_failed_record,
+    dispatch_algolia_indexing,
     index_courses_batch_in_algolia,
     index_pathways_batch_in_algolia,
     index_programs_batch_in_algolia,
@@ -46,6 +57,13 @@ def _algolia_object(content_key, content_type=COURSE, shard_index=0):
         'objectID': f'{content_key}-catalog-query-uuids-{shard_index}',
         'aggregation_key': f'{content_type}:{content_key}',
     }
+
+
+def _program_content_key():
+    """
+    Build a UUID-formatted content_key for program records.
+    """
+    return str(uuid4())
 
 
 @ddt.ddt
@@ -651,6 +669,424 @@ class TestIndexContentBatch(TestCase):
 
         self.assertEqual(result['content_type'], content_type)
         self.assertEqual(result['indexed'], 1)
+
+
+@override_settings(ALGOLIA_INDEXING_BATCH_SIZE=2)
+class TestDispatchAlgoliaIndexing(TestCase):
+    """
+    Tests for the Phase 4a dispatcher task.
+    """
+    # pylint: disable=no-value-for-parameter
+
+    def setUp(self):
+        self.mock_get_mappings = mock.patch.object(
+            search_tasks, 'get_indexing_mappings',
+        ).start()
+        self.mock_invalidate_cache = mock.patch.object(
+            search_tasks, 'invalidate_indexing_mappings_cache',
+        ).start()
+        self.mock_course_si = mock.patch.object(
+            search_tasks.index_courses_batch_in_algolia, 'si',
+        ).start()
+        self.mock_program_si = mock.patch.object(
+            search_tasks.index_programs_batch_in_algolia, 'si',
+        ).start()
+        self.mock_pathway_si = mock.patch.object(
+            search_tasks.index_pathways_batch_in_algolia, 'si',
+        ).start()
+        # Prevent actual Celery chain/group dispatch
+        self.mock_group = mock.patch.object(search_tasks, 'group').start()
+        self.mock_chain = mock.patch.object(search_tasks, 'chain').start()
+        self.addCleanup(mock.patch.stopall)
+
+    def _set_mappings(
+        self,
+        *,
+        all_indexable_content_keys,
+        program_to_course_keys=None,
+        pathway_to_program_course_keys=None,
+    ):
+        self.mock_get_mappings.return_value = IndexingMappings(
+            program_to_course_keys=program_to_course_keys or {},
+            pathway_to_program_course_keys=pathway_to_program_course_keys or {},
+            all_indexable_content_keys=set(all_indexable_content_keys),
+        )
+
+    def test_dry_run_returns_summary_without_dispatching(self):
+        course = ContentMetadataFactory(content_type=COURSE, content_key='course-dry-run')
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='pathway-dry-run')
+        self._set_mappings(
+            all_indexable_content_keys=[course.content_key, program.content_key, pathway.content_key],
+        )
+
+        result = dispatch_algolia_indexing(force=True, dry_run=True, index_name='enterprise_catalog_v2')
+
+        self.assertEqual(result, {
+            'force': True,
+            'dry_run': True,
+            'batch_size': 2,
+            'index_name': 'enterprise_catalog_v2',
+            'dispatched': {
+                COURSE: {'records': 1, 'batches': 1},
+                PROGRAM: {'records': 1, 'batches': 1},
+                LEARNER_PATHWAY: {'records': 1, 'batches': 1},
+            },
+        })
+        self.mock_invalidate_cache.assert_called_once_with()
+        self.mock_course_si.assert_not_called()
+        self.mock_program_si.assert_not_called()
+        self.mock_pathway_si.assert_not_called()
+
+    def test_force_false_does_not_invalidate_cache(self):
+        course = ContentMetadataFactory(content_type=COURSE, content_key='course-no-force')
+        self._set_mappings(all_indexable_content_keys=[course.content_key])
+
+        dispatch_algolia_indexing(force=False)
+
+        self.mock_invalidate_cache.assert_not_called()
+
+    def test_courses_dispatch_never_indexed_stale_and_failed_records(self):
+        never_indexed = ContentMetadataFactory(content_type=COURSE, content_key='course-never-indexed')
+        stale = ContentMetadataFactory(content_type=COURSE, content_key='course-stale')
+        current = ContentMetadataFactory(content_type=COURSE, content_key='course-current')
+        failed = ContentMetadataFactory(content_type=COURSE, content_key='course-failed')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=stale,
+            last_indexed_at=stale.modified - timedelta(hours=1),
+        )
+        ContentMetadataIndexingStateFactory(
+            content_metadata=current,
+            last_indexed_at=current.modified + timedelta(hours=1),
+        )
+        ContentMetadataIndexingStateFactory(
+            content_metadata=failed,
+            last_indexed_at=failed.modified + timedelta(hours=1),
+            last_failure_at=localized_utcnow(),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[
+                never_indexed.content_key,
+                stale.content_key,
+                current.content_key,
+                failed.content_key,
+            ],
+        )
+
+        result = dispatch_algolia_indexing(force=False, include_failed=True)
+
+        self.assertEqual(result['dispatched'][COURSE], {'records': 3, 'batches': 2})
+        self.assertEqual(self.mock_course_si.call_count, 2)
+        dispatched_batches = [
+            call.kwargs['content_keys']
+            for call in self.mock_course_si.call_args_list
+        ]
+        self.assertEqual(
+            dispatched_batches,
+            [
+                ['course-failed', 'course-never-indexed'],
+                ['course-stale'],
+            ],
+        )
+
+    def test_failed_courses_can_be_excluded_from_retry(self):
+        failed = ContentMetadataFactory(content_type=COURSE, content_key='course-failed-no-retry')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=failed,
+            last_indexed_at=failed.modified + timedelta(hours=1),
+            last_failure_at=localized_utcnow(),
+        )
+        self._set_mappings(all_indexable_content_keys=[failed.content_key])
+
+        result = dispatch_algolia_indexing(force=False, include_failed=False)
+
+        self.assertEqual(result['dispatched'][COURSE], {'records': 0, 'batches': 0})
+        self.mock_course_si.assert_not_called()
+
+    def test_programs_dispatch_when_child_course_indexed_more_recently(self):
+        child_course = ContentMetadataFactory(content_type=COURSE, content_key='course-program-child')
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        program_state = ContentMetadataIndexingStateFactory(
+            content_metadata=program,
+            last_indexed_at=localized_utcnow() - timedelta(hours=2),
+        )
+        ContentMetadataIndexingStateFactory(
+            content_metadata=child_course,
+            last_indexed_at=program_state.last_indexed_at + timedelta(hours=1),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[child_course.content_key, program.content_key],
+            program_to_course_keys={program.content_key: {child_course.content_key}},
+        )
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'][PROGRAM], {'records': 1, 'batches': 1})
+        self.mock_program_si.assert_called_once_with(
+            content_keys=[program.content_key],
+            force=False,
+            index_name=None,
+        )
+
+    def test_pathways_dispatch_when_child_program_is_newer(self):
+        child_program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='pathway-stale')
+        pathway_state = ContentMetadataIndexingStateFactory(
+            content_metadata=pathway,
+            last_indexed_at=localized_utcnow() - timedelta(hours=2),
+        )
+        ContentMetadataIndexingStateFactory(
+            content_metadata=child_program,
+            last_indexed_at=pathway_state.last_indexed_at + timedelta(hours=1),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[child_program.content_key, pathway.content_key],
+            pathway_to_program_course_keys={
+                pathway.content_key: {'course-not-a-uuid', child_program.content_key},
+            },
+        )
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'][LEARNER_PATHWAY], {'records': 1, 'batches': 1})
+        self.mock_pathway_si.assert_called_once_with(
+            content_keys=[pathway.content_key],
+            force=False,
+            index_name=None,
+        )
+
+    def test_batching_uses_configured_batch_size(self):
+        courses = [
+            ContentMetadataFactory(content_type=COURSE, content_key=f'course-batch-{index}')
+            for index in range(5)
+        ]
+        self._set_mappings(
+            all_indexable_content_keys=[course.content_key for course in courses],
+        )
+
+        result = dispatch_algolia_indexing(force=True)
+
+        self.assertEqual(result['dispatched'][COURSE], {'records': 5, 'batches': 3})
+        self.assertEqual(self.mock_course_si.call_count, 3)
+        self.assertEqual(
+            [call.kwargs['content_keys'] for call in self.mock_course_si.call_args_list],
+            [
+                ['course-batch-0', 'course-batch-1'],
+                ['course-batch-2', 'course-batch-3'],
+                ['course-batch-4'],
+            ],
+        )
+
+    def test_empty_mappings_dispatch_no_records(self):
+        """
+        Empty indexable mappings produce zero dispatches for all content types.
+        """
+        self._set_mappings(all_indexable_content_keys=[])
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'], {
+            COURSE: {'records': 0, 'batches': 0},
+            PROGRAM: {'records': 0, 'batches': 0},
+            LEARNER_PATHWAY: {'records': 0, 'batches': 0},
+        })
+        self.mock_course_si.assert_not_called()
+        self.mock_program_si.assert_not_called()
+        self.mock_pathway_si.assert_not_called()
+
+    def test_programs_dispatch_when_never_indexed(self):
+        """
+        Programs with no indexing state are always dispatched.
+        """
+        child_course = ContentMetadataFactory(
+            content_type=COURSE, content_key='course-program-child-never-indexed',
+        )
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        self._set_mappings(
+            all_indexable_content_keys=[child_course.content_key, program.content_key],
+            program_to_course_keys={program.content_key: {child_course.content_key}},
+        )
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'][PROGRAM], {'records': 1, 'batches': 1})
+        self.mock_program_si.assert_called_once_with(
+            content_keys=[program.content_key],
+            force=False,
+            index_name=None,
+        )
+
+    def test_programs_dispatch_failed_records_when_include_failed_true(self):
+        """
+        Failed program records are retried when ``include_failed=True``.
+        """
+        child_course = ContentMetadataFactory(
+            content_type=COURSE, content_key='course-program-child-with-failed-parent',
+        )
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        ContentMetadataIndexingStateFactory(
+            content_metadata=program,
+            last_indexed_at=localized_utcnow(),
+            last_failure_at=localized_utcnow(),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[child_course.content_key, program.content_key],
+            program_to_course_keys={program.content_key: {child_course.content_key}},
+        )
+
+        result = dispatch_algolia_indexing(force=False, include_failed=True)
+
+        self.assertEqual(result['dispatched'][PROGRAM], {'records': 1, 'batches': 1})
+        self.mock_program_si.assert_called_once_with(
+            content_keys=[program.content_key],
+            force=False,
+            index_name=None,
+        )
+
+    def test_pathways_dispatch_when_never_indexed(self):
+        """
+        Pathways with no indexing state are always dispatched.
+        """
+        child_program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='pathway-never-indexed')
+        self._set_mappings(
+            all_indexable_content_keys=[child_program.content_key, pathway.content_key],
+            pathway_to_program_course_keys={pathway.content_key: {child_program.content_key}},
+        )
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'][LEARNER_PATHWAY], {'records': 1, 'batches': 1})
+        self.mock_pathway_si.assert_called_once_with(
+            content_keys=[pathway.content_key],
+            force=False,
+            index_name=None,
+        )
+
+    def test_pathways_dispatch_failed_records_when_include_failed_true(self):
+        """
+        Failed pathway records are retried when ``include_failed=True``.
+        """
+        child_program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='pathway-failed')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=pathway,
+            last_indexed_at=localized_utcnow(),
+            last_failure_at=localized_utcnow(),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[child_program.content_key, pathway.content_key],
+            pathway_to_program_course_keys={pathway.content_key: {child_program.content_key}},
+        )
+
+        result = dispatch_algolia_indexing(force=False, include_failed=True)
+
+        self.assertEqual(result['dispatched'][LEARNER_PATHWAY], {'records': 1, 'batches': 1})
+        self.mock_pathway_si.assert_called_once_with(
+            content_keys=[pathway.content_key],
+            force=False,
+            index_name=None,
+        )
+
+    def test_pathways_not_dispatched_when_child_keys_are_non_uuid_courses_only(self):
+        """
+        Pathways with only non-UUID child keys are not dispatched as child updates.
+        """
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='pathway-courses-only')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=pathway,
+            last_indexed_at=localized_utcnow(),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[pathway.content_key],
+            pathway_to_program_course_keys={
+                pathway.content_key: {'course-v1:edX+DemoX+2024', 'course-v1:edX+TestX+2024'},
+            },
+        )
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'][LEARNER_PATHWAY], {'records': 0, 'batches': 0})
+        self.mock_pathway_si.assert_not_called()
+
+
+@ddt.ddt
+class TestDispatchAlgoliaIndexingHelpers(TestCase):
+    """
+    Focused tests for Phase 4a helper functions.
+    """
+
+    def test_chunked_with_empty_input_yields_no_batches(self):
+        """
+        ``_chunked`` returns an empty iterator when the input is empty.
+        """
+        self.assertEqual(list(_chunked([], 2)), [])
+
+    def test_get_indexable_keys_by_content_type_returns_empty_defaults(self):
+        """
+        Empty ``all_indexable_content_keys`` returns empty lists for each type.
+        """
+        self.assertEqual(_get_indexable_keys_by_content_type(set()), {
+            COURSE: [],
+            PROGRAM: [],
+            LEARNER_PATHWAY: [],
+        })
+
+    def test_get_content_modified_by_key_empty_input(self):
+        """
+        ``_get_content_modified_by_key`` short-circuits for empty key lists.
+        """
+        self.assertEqual(_get_content_modified_by_key([], COURSE), {})
+
+    def test_get_indexing_state_by_key_empty_input(self):
+        """
+        ``_get_indexing_state_by_key`` short-circuits for empty key lists.
+        """
+        self.assertEqual(_get_indexing_state_by_key([]), {})
+
+    def test_should_retry_failed_record_when_excluded_or_missing_state(self):
+        """
+        ``_should_retry_failed_record`` is false when retries are disabled or missing state.
+        """
+        self.assertFalse(_should_retry_failed_record({}, 'missing', include_failed=True))
+        self.assertFalse(_should_retry_failed_record({
+            'course-key': {'last_failure_at': localized_utcnow()},
+        }, 'course-key', include_failed=False))
+
+    def test_has_newer_child_index_ignores_children_without_last_indexed_at(self):
+        """
+        ``_has_newer_child_index`` ignores child records with no ``last_indexed_at``.
+        """
+        self.assertFalse(_has_newer_child_index(
+            child_keys=['child-key'],
+            child_state_by_key={'child-key': {'last_indexed_at': None}},
+            parent_last_indexed_at=localized_utcnow(),
+        ))
+
+    @ddt.data(
+        ('550e8400-e29b-41d4-a716-446655440000', True),
+        ('course-v1:edX+DemoX+2024', False),
+        (1234, False),
+        (None, False),
+    )
+    @ddt.unpack
+    def test_is_uuid_string_edge_cases(self, value, expected):
+        """
+        ``_is_uuid_string`` handles both string and non-string values safely.
+        """
+        self.assertEqual(_is_uuid_string(value), expected)
+
+    def test_extract_program_keys_filters_non_uuid_values(self):
+        """
+        ``_extract_program_keys`` keeps only UUID-shaped values from mixed input.
+        """
+        program_key = '550e8400-e29b-41d4-a716-446655440000'
+        self.assertEqual(_extract_program_keys([
+            program_key,
+            'course-v1:edX+DemoX+2024',
+            1234,
+            None,
+        ]), [program_key])
 
 
 class TestRecordOutcome(TestCase):

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -454,6 +454,10 @@ ALGOLIA_INDEXING_MAPPINGS_CACHE_TIMEOUT = 60 * 30
 # worth of work to the per-record fallback path.
 ALGOLIA_INDEXING_CHUNK_SIZE = 100
 
+# How many content records the dispatcher includes in each incremental
+# indexing task it fans out to Celery workers.
+ALGOLIA_INDEXING_BATCH_SIZE = 10
+
 # Which fields should be plucked from the /search/all course-discovery API
 # response in `update_catalog_metadata_task` for course content metadata?
 COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL = os.environ.get(


### PR DESCRIPTION
## Summary
Phase 3 introduced content-type batch indexers; this change adds the Phase 4a scheduled dispatcher that decides what needs reindexing and fans that work out into batch tasks. The dispatcher now supports full forced runs and straggler/retry runs without reintroducing the legacy monolithic reindex path.

## Details
- **Dispatcher task**
  - Adds `dispatch_algolia_indexing(...)` in `enterprise_catalog/apps/search/tasks.py`
  - Warms cached `IndexingMappings` once per run
  - Invalidates the mappings cache only for `force=True`
  - Returns an ops-friendly summary of records and batches per content type
  - Supports `dry_run`, `include_failed`, and `index_name`

- **Selection logic**
  - **Courses**: dispatches records that were never indexed, have `modified > last_indexed_at`, or previously failed (when retries are enabled)
  - **Programs**: dispatches records that were never indexed, failed, or are stale because a child course was indexed more recently
  - **Pathways**: dispatches records that were never indexed, failed, or are stale because a child program was indexed more recently
  - Uses UUID parsing to distinguish program keys from mixed pathway child mappings

- **Batch fan-out**
  - Adds configurable dispatcher batch sizing via `ALGOLIA_INDEXING_BATCH_SIZE` (default `10`)
  - Chunks per-content-type keys and enqueues the existing Phase 3 batch tasks without blocking

- **Coverage**
  - Adds focused task tests for:
    - dry-run behavior
    - cache invalidation rules
    - stale/failed course selection
    - program child-course staleness
    - pathway child-program staleness
    - batching math and dispatched task counts

Example dispatcher shape:

```python
dispatch_algolia_indexing(
    force=False,
    dry_run=False,
    include_failed=True,
    index_name='enterprise_catalog_v2',
)
```

This produces summary data like:

```python
{
    "force": False,
    "dry_run": False,
    "batch_size": 10,
    "index_name": "enterprise_catalog_v2",
    "dispatched": {
        "course": {"records": 123, "batches": 13},
        "program": {"records": 45, "batches": 5},
        "learnerpathway": {"records": 6, "batches": 1},
    },
}
```

## Meta
https://2u-internal.atlassian.net/browse/ENT-11692

Copilot Agent-Logs-Url: https://github.com/edx/enterprise-catalog/sessions/47be5d9d-c832-4ce2-8e64-1130a8b1cd5a

I used a copilot agent to generate the code (in separate branch, merged into this one): https://github.com/edx/enterprise-catalog/pull/99

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
