### PR TITLE
feat: add phase 4b algolia indexing dispatcher

### DIFF
--- a/docs/algolia-reindexing/phase-4b-plan.md
+++ b/docs/algolia-reindexing/phase-4b-plan.md
@@ -1,0 +1,223 @@
+# Phase 4b Plan: Catalog-Query Dispatcher (membership + removals → batch → dispatch)
+
+This document captures the implementation plan for **Phase 4b** of the incremental Algolia indexing project in `edx/enterprise-catalog`.
+
+Scope: implement the **catalog-query-specific dispatcher task** that indexes all content associated with a given `CatalogQuery`, and also handles **membership removals** by diffing Algolia vs. the database.
+
+> Note: This plan is intentionally detailed so it can be used later to craft an ADR.
+
+---
+
+## Background / Context
+
+The incremental indexing system uses a **dispatcher → parallel batch tasks** architecture.
+
+Phase 4 includes two dispatcher tasks:
+
+1. **Phase 4a**: scheduled dispatcher for stale/failed records (`dispatch_algolia_indexing`)
+2. **Phase 4b**: **catalog-query-specific dispatcher** (`dispatch_algolia_indexing_for_catalog_query`)
+
+Phase 4b is used by the API refresh flow (POST to `EnterpriseCatalogRefreshDataFromDiscovery`) when incremental indexing is enabled.
+
+The tricky part: **membership removals**. When content is removed from a catalog query, its `ContentMetadata.modified` may not change, so staleness detection alone won’t pick it up. We must reindex removed content so the Algolia facet membership is updated (old facets removed).
+
+---
+
+## Goals
+
+- Index all content that is currently a member of a given `CatalogQuery`.
+- Detect membership removals by querying Algolia for content currently facet-tagged with this catalog query and diffing against DB membership.
+- Dispatch the existing Phase 3 batch indexing tasks in small batches (default 10).
+- Support `dry_run` for safe testing.
+- Support `force` to bypass per-record staleness checks inside batch tasks (useful for correctness after large membership changes).
+
+---
+
+## Non-goals
+
+- No attempt to "stream" changes; this is dispatcher-based, invoked per API refresh.
+- No attempt to track pre-update membership state in the DB; we use Algolia as "what was indexed" and the DB as "what should be indexed".
+
+---
+
+## Key Decisions
+
+### 1) Removals are detected via Algolia diff, not DB history
+
+We will *not* try to snapshot membership before `update_catalog_metadata` runs. Instead:
+
+- Query Algolia for currently indexed aggregation keys tagged with the catalog query facet.
+- Query DB for current membership aggregation keys for that catalog query.
+- Compute removed keys as a set difference.
+
+This keeps the API refresh flow simpler and uses Algolia as the “what is currently indexed” reference.
+
+### 2) Use `aggregation_key` format for set diff
+
+We do set math using the canonical form:
+
+- `"{content_type}:{content_key}"`
+
+This matches the legacy generator output and the structures used elsewhere in the incremental system.
+
+### 3) Partitioning is not done here
+
+Like Phase 4a, we will not re-run partition helpers directly. Indexability constraints are handled by:
+
+- the batch task’s existing logic (it checks against `mappings.all_indexable_content_keys` and can route to REMOVED)
+- and by scoping the DB membership query to `ContentMetadata` rows actually present
+
+---
+
+## Proposed Public API
+
+### Celery Task: `dispatch_algolia_indexing_for_catalog_query`
+
+**Location**: `enterprise_catalog/apps/search/tasks.py`
+
+**Signature**:
+
+```python
+# Celery shared_task — invoke via .delay() or .apply_async()
+dispatch_algolia_indexing_for_catalog_query(
+    catalog_query_id,   # positional; CatalogQuery primary key (int)
+    dry_run=False,
+    force=False,
+    include_failed=True,
+    index_name=None,
+)
+```
+
+**Parameters**:
+
+- `catalog_query_id`: required; the `CatalogQuery` primary key
+- `dry_run`: compute & log work, but do not enqueue batch tasks
+- `force`: passed through to batch tasks; when True, batch tasks bypass their per-record skip (`last_indexed_at >= modified`)
+- `include_failed`: include records with `last_failure_at` (useful if API refresh is also expected to “unstick” failures)
+- `index_name`: optional index override (e.g., v2) passed through to batch tasks and Algolia client methods used by the dispatcher
+
+---
+
+## Dispatcher Algorithm
+
+### Step 0: Load inputs
+
+1. Load `CatalogQuery` by id.
+2. Obtain an initialized Algolia client (same initialization pattern as existing tasks/client helpers).
+
+### Step 1: Compute DB membership aggregation keys
+
+Build:
+
+- `db_aggregation_keys = {f"{cm.content_type}:{cm.content_key}" for cm in catalog_query.content_metadata.all()}`
+
+Notes:
+- We’ll ensure this query is efficient (values_list + iterator if needed).
+- This yields the “should be indexed” membership set.
+
+### Step 2: Compute Algolia membership aggregation keys (currently indexed)
+
+Call the Algolia helper from Phase 2:
+
+- `algolia_aggregation_keys = algolia_client.get_aggregation_keys_for_catalog_query(catalog_query.uuid, index_name=index_name)`
+
+This yields the “is currently indexed under this facet” set.
+
+### Step 3: Diff to find removed content
+
+Compute:
+
+- `removed_aggregation_keys = algolia_aggregation_keys - db_aggregation_keys`
+- `all_aggregation_keys_to_index = db_aggregation_keys | removed_aggregation_keys`
+
+Rationale:
+- DB members must be indexed to reflect new membership.
+- Removed content must be indexed to remove the stale facet(s).
+
+### Step 4: Convert aggregation keys → content keys grouped by type
+
+Parse each aggregation key into `(content_type, content_key)`.
+
+Group by content type into lists:
+- courses
+- programs
+- pathways
+
+(Other content types may exist in Algolia / ContentMetadata; for Phase 4b we will either ignore unknown types or log them explicitly and skip.)
+
+### Step 5: Optional stale/failed filtering (when force=False)
+
+Even though API refresh is generally “index everything in this catalog”, we still may want to avoid unnecessary work:
+
+- If `force=True`: skip filtering, dispatch all keys found.
+- If `force=False`:
+  - Apply the same per-type staleness logic as Phase 4a: courses use `ContentMetadata.modified > last_indexed_at`; programs and pathways additionally check child-staleness (re-dispatch when a child was indexed more recently than the parent).
+  - Additionally, if `include_failed=True`, include keys with `last_failure_at` regardless of staleness.
+
+Important: we should be careful not to filter out “removed” content due to staleness rules, because removed content’s `modified` likely won’t change. For removed keys, we should treat them as “must index” regardless of staleness when the key appears in `removed_aggregation_keys`.
+
+**Proposed rule**:
+- Always include removed keys.
+- For DB-member keys, apply stale/failed filtering only when `force=False`.
+
+### Step 6: Batch and dispatch
+
+- Batch size: `settings.ALGOLIA_INDEXING_BATCH_SIZE` (default 10)
+- Enqueue the existing batch tasks per content type:
+  - `index_courses_batch_in_algolia.delay(content_keys=batch, index_name=index_name, force=force)`
+  - `index_programs_batch_in_algolia.delay(...)`
+  - `index_pathways_batch_in_algolia.delay(...)`
+
+If `dry_run=True`, do not enqueue; return/log “would dispatch” summary.
+
+### Step 7: Return summary
+
+Return a dict such as:
+
+```python
+{
+  "catalog_query_id": 123,
+  "force": False,
+  "dry_run": True,
+  "batch_size": 10,
+  "db_membership_count": 456,
+  "algolia_membership_count": 470,
+  "removed_count": 14,
+  "dispatched": {
+    "course": {"records": 300, "batches": 30},
+    "program": {"records": 120, "batches": 12},
+    "learnerpathway": {"records": 50, "batches": 5},
+  },
+}
+```
+
+---
+
+## Performance / Query Strategy
+
+- DB membership query should be `values_list("content_type", "content_key")` to avoid loading full models.
+- Indexing-state lookups (for optional filtering) should be bulk queries keyed by content_key and content_type, not per-record queries.
+- Algolia query should use the batch-friendly facet/browse API via the existing `get_aggregation_keys_for_catalog_query` helper.
+
+---
+
+## Testing Plan
+
+Add unit tests in `enterprise_catalog/apps/search/tests/test_tasks.py` (or a new dispatcher-focused test module if preferred):
+
+1. **Diff math**: removed keys are computed as `algolia - db`
+2. **Removed keys are always included** even when `force=False` and even if not stale
+3. **Grouping by content type** from aggregation keys is correct
+4. **Batch sizing** matches `ALGOLIA_INDEXING_BATCH_SIZE`
+5. **dry_run**: no `.si()` calls and `dispatched` counts reflect what would run
+6. **index_name** is passed through to:
+   - Algolia diff query helper
+   - batch tasks
+7. **include_failed**: failed keys included even if not stale (for DB-member keys)
+
+---
+
+## Follow-ups (out of Phase 4b scope)
+
+- Integration into the API refresh endpoint (Phase 6), guarded by the feature flag.
+- Observability improvements (metrics around removed count / dispatcher run time).

--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -67,7 +67,8 @@ from enterprise_catalog.apps.catalog.constants import (
     LEARNER_PATHWAY,
     PROGRAM,
 )
-from enterprise_catalog.apps.catalog.models import ContentMetadata
+from enterprise_catalog.apps.catalog.models import CatalogQuery, ContentMetadata
+from enterprise_catalog.apps.catalog.utils import _partition_aggregation_key
 from enterprise_catalog.apps.search.indexing_mappings import (
     IndexingMappings,
     get_indexing_mappings,
@@ -167,6 +168,8 @@ def index_courses_batch_in_algolia(
 
     Returns a plain dict (via ``dataclasses.asdict``) so the on-the-wire
     Celery payload stays JSON-serializable.
+    Note that for this and the tasks below, the `self` argument is not directly used by the task,
+    but the django-celery-results backend depends on it for persisting task metadata.
     """
     return asdict(_index_content_batch(content_keys, COURSE, index_name=index_name, force=force))
 
@@ -195,6 +198,51 @@ def index_pathways_batch_in_algolia(
     Celery payload stays JSON-serializable.
     """
     return asdict(_index_content_batch(content_keys, LEARNER_PATHWAY, index_name=index_name, force=force))
+
+
+def _build_ordered_groups(
+    records_by_type: dict[str, list[str]],
+    batch_size: int,
+    force: bool,
+    index_name: str | None,
+    dry_run: bool,
+) -> tuple[list, dict]:
+    """
+    Materialize per-type content-key batches into an ordered list of Celery
+    ``group``\\s (courses → programs → pathways) and a summary count dict.
+
+    Tasks use ``.si()`` (immutable signatures) so each task's kwargs are fixed
+    at dispatch time and Celery does not forward the previous group's return
+    values as positional arguments.  Empty groups are omitted from the list so
+    callers can pass the result directly to ``chain(*ordered_groups)``.
+
+    Returns:
+        ordered_groups: list of ``group`` objects, one per non-empty content
+            type, in courses → programs → pathways order.
+        dispatched_summary: ``{content_type: {'records': int, 'batches': int}}``
+    """
+    task_by_content_type = {
+        COURSE: index_courses_batch_in_algolia,
+        PROGRAM: index_programs_batch_in_algolia,
+        LEARNER_PATHWAY: index_pathways_batch_in_algolia,
+    }
+    ordered_groups = []
+    dispatched_summary = {}
+    for content_type in (COURSE, PROGRAM, LEARNER_PATHWAY):
+        tasks, batch_count, record_count = [], 0, 0
+        for batch in _chunked(records_by_type.get(content_type, []), batch_size):
+            batch_count += 1
+            record_count += len(batch)
+            if not dry_run:
+                tasks.append(
+                    task_by_content_type[content_type].si(
+                        content_keys=batch, force=force, index_name=index_name,
+                    )
+                )
+        dispatched_summary[content_type] = {'records': record_count, 'batches': batch_count}
+        if tasks:
+            ordered_groups.append(group(tasks))
+    return ordered_groups, dispatched_summary
 
 
 @shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
@@ -237,71 +285,131 @@ def dispatch_algolia_indexing(
         mappings.all_indexable_content_keys,
     )
 
-    content_keys_to_dispatch: dict[str, list[str]] = {
-        COURSE: _get_course_keys_for_dispatch(
-            content_keys=indexable_keys_by_type[COURSE],
-            force=force,
-            include_failed=include_failed,
-        ),
-        PROGRAM: _get_program_keys_for_dispatch(
-            content_keys=indexable_keys_by_type[PROGRAM],
-            program_to_course_keys=mappings.program_to_course_keys,
-            force=force,
-            include_failed=include_failed,
-        ),
-        LEARNER_PATHWAY: _get_pathway_keys_for_dispatch(
-            content_keys=indexable_keys_by_type[LEARNER_PATHWAY],
-            pathway_to_program_course_keys=mappings.pathway_to_program_course_keys,
-            force=force,
-            include_failed=include_failed,
-        ),
-    }
+    content_keys_to_dispatch = _get_keys_to_dispatch_by_type(
+        content_keys_by_type=indexable_keys_by_type,
+        mappings=mappings,
+        force=force,
+        include_failed=include_failed,
+    )
 
-    task_by_content_type = {
-        COURSE: index_courses_batch_in_algolia,
-        PROGRAM: index_programs_batch_in_algolia,
-        LEARNER_PATHWAY: index_pathways_batch_in_algolia,
-    }
+    ordered_groups, dispatched_summary = _build_ordered_groups(
+        records_by_type=content_keys_to_dispatch,
+        batch_size=batch_size,
+        force=force,
+        index_name=index_name,
+        dry_run=dry_run,
+    )
     summary = {
         'force': force,
         'dry_run': dry_run,
         'batch_size': batch_size,
         'index_name': index_name,
-        'dispatched': {},
+        'dispatched': dispatched_summary,
     }
 
-    # Build per-type batches and record summary counts before dispatching.
-    batches_by_type = {}
-    for content_type in (COURSE, PROGRAM, LEARNER_PATHWAY):
-        content_keys = content_keys_to_dispatch[content_type]
-        batches = _chunked(content_keys, batch_size)
-        batches_by_type[content_type] = batches
-        summary['dispatched'][content_type] = {'records': 0, 'batches': 0}
-
-    # Build a chain of groups: courses -> programs -> pathways.
-    # Tasks use .si() (immutable signatures) so each task's kwargs are
-    # fixed at dispatch time and Celery does not forward the previous
-    # group's return values as positional arguments.
-    ordered_groups = []
-    for content_type in (COURSE, PROGRAM, LEARNER_PATHWAY):
-        content_type_group_tasks = []
-        for batch in batches_by_type[content_type]:
-            summary['dispatched'][content_type]['batches'] += 1
-            summary['dispatched'][content_type]['records'] += len(batch)
-            if dry_run:
-                continue
-            content_type_group_tasks.append(
-                task_by_content_type[content_type].si(
-                    content_keys=batch, force=force, index_name=index_name,
-                ),
-            )
-        if content_type_group_tasks:
-            ordered_groups.append(group(content_type_group_tasks))
-
-    if not dry_run and len(ordered_groups) >= 1:
+    if not dry_run and ordered_groups:
         chain(*ordered_groups).apply_async()
 
     logger.info('dispatch_algolia_indexing summary=%s', summary)
+    return summary
+
+
+@shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
+def dispatch_algolia_indexing_for_catalog_query(
+    self,  # pylint: disable=unused-argument
+    catalog_query_id,
+    dry_run=False,
+    force=False,
+    include_failed=True,
+    index_name=None,
+):
+    """
+    Dispatch incremental Algolia indexing for a single CatalogQuery.
+
+    This diffs the catalog's current membership in the database against what
+    Algolia currently has indexed, so removed content is reindexed and loses
+    stale catalog facets. Additionally, content that is a new member of the given
+    catalog query, but doesn't look stale based on index time, is also reindexed
+    so that the membership facets of such Algolia records are updated.
+    """
+    try:
+        catalog_query = CatalogQuery.objects.get(id=catalog_query_id)
+    except CatalogQuery.DoesNotExist:
+        logger.warning(
+            'dispatch_algolia_indexing_for_catalog_query: CatalogQuery id=%s not found; skipping.',
+            catalog_query_id,
+        )
+        return {}
+
+    # Invalidate on every real (non-dry) run, not just on force=True as Phase 4a does.
+    # This dispatcher is triggered by a catalog refresh, so membership may have changed
+    # and the mappings cache is likely stale regardless of whether force was requested.
+    if not dry_run:
+        invalidate_indexing_mappings_cache()
+    mappings = get_indexing_mappings()
+    algolia_client = get_initialized_algolia_client()
+    batch_size = getattr(settings, 'ALGOLIA_INDEXING_BATCH_SIZE', 10)
+
+    db_content_keys_by_type = _get_catalog_query_content_keys_by_type(catalog_query)
+    db_aggregation_keys = {
+        _aggregation_key_for(content_type, content_key)
+        for content_type, content_keys in db_content_keys_by_type.items()
+        for content_key in content_keys
+    }
+    algolia_aggregation_keys = algolia_client.get_aggregation_keys_for_catalog_query(
+        catalog_query.uuid,
+        index_name=index_name,
+    )
+    removed_aggregation_keys = algolia_aggregation_keys - db_aggregation_keys
+    removed_content_keys_by_type = _group_aggregation_keys_by_content_type(removed_aggregation_keys)
+    # Content added to this catalog query since the last Algolia index run:
+    # present in the DB but not yet facet-tagged in Algolia. These must be
+    # dispatched regardless of staleness so the new catalog-query facet is written.
+    added_aggregation_keys = db_aggregation_keys - algolia_aggregation_keys
+    added_content_keys_by_type = _group_aggregation_keys_by_content_type(added_aggregation_keys)
+
+    # Apply per-type staleness/child-staleness logic to the DB keys, then
+    # union with removed keys (must shed stale facets) and added keys (must
+    # gain new facets) — both bypass the staleness filter.
+    db_keys_to_dispatch = _get_keys_to_dispatch_by_type(
+        content_keys_by_type=db_content_keys_by_type,
+        mappings=mappings,
+        force=force,
+        include_failed=include_failed,
+    )
+    records_to_dispatch = {
+        content_type: sorted(
+            set(db_keys_to_dispatch[content_type])
+            | set(removed_content_keys_by_type.get(content_type, []))
+            | set(added_content_keys_by_type.get(content_type, [])),
+        )
+        for content_type in (COURSE, PROGRAM, LEARNER_PATHWAY)
+    }
+
+    ordered_groups, dispatched_summary = _build_ordered_groups(
+        records_by_type=records_to_dispatch,
+        batch_size=batch_size,
+        force=force,
+        index_name=index_name,
+        dry_run=dry_run,
+    )
+    summary = {
+        'catalog_query_id': catalog_query_id,
+        'force': force,
+        'dry_run': dry_run,
+        'batch_size': batch_size,
+        'index_name': index_name,
+        'db_membership_count': len(db_aggregation_keys),
+        'algolia_membership_count': len(algolia_aggregation_keys),
+        'removed_count': len(removed_aggregation_keys),
+        'added_count': len(added_aggregation_keys),
+        'dispatched': dispatched_summary,
+    }
+
+    if not dry_run and ordered_groups:
+        chain(*ordered_groups).apply_async()
+
+    logger.info('dispatch_algolia_indexing_for_catalog_query summary=%s', summary)
     return summary
 
 
@@ -628,6 +736,84 @@ def _get_course_keys_for_dispatch(
     return keys_to_dispatch
 
 
+def _get_catalog_query_content_keys_by_type(catalog_query: CatalogQuery) -> dict[str, list[str]]:
+    """
+    Return current catalog membership grouped by content type.
+    """
+    content_keys_by_type = {
+        COURSE: [],
+        PROGRAM: [],
+        LEARNER_PATHWAY: [],
+    }
+    queryset = catalog_query.contentmetadata_set.filter(
+        content_type__in=(COURSE, PROGRAM, LEARNER_PATHWAY),
+    ).values_list(
+        'content_type', 'content_key',
+    ).order_by(
+        'content_type', 'content_key',
+    )
+
+    for content_type, content_key in queryset:
+        content_keys_by_type[content_type].append(content_key)
+    return content_keys_by_type
+
+
+def _get_keys_to_dispatch_by_type(
+    content_keys_by_type: dict[str, list[str]],
+    mappings: IndexingMappings,
+    force: bool,
+    include_failed: bool,
+) -> dict[str, list[str]]:
+    """
+    Apply the correct per-type staleness/failure/child-staleness logic to each
+    content type and return the keys that should be dispatched.
+
+    Courses are filtered by ``ContentMetadata.modified`` vs ``last_indexed_at``.
+    Programs add a child-staleness check: re-dispatch when any member course was
+    indexed more recently than the program itself.
+    Pathways add an analogous check against their child programs.
+    """
+    return {
+        COURSE: _get_course_keys_for_dispatch(
+            content_keys=content_keys_by_type.get(COURSE, []),
+            force=force,
+            include_failed=include_failed,
+        ),
+        PROGRAM: _get_program_keys_for_dispatch(
+            content_keys=content_keys_by_type.get(PROGRAM, []),
+            program_to_course_keys=mappings.program_to_course_keys,
+            force=force,
+            include_failed=include_failed,
+        ),
+        LEARNER_PATHWAY: _get_pathway_keys_for_dispatch(
+            content_keys=content_keys_by_type.get(LEARNER_PATHWAY, []),
+            pathway_to_program_course_keys=mappings.pathway_to_program_course_keys,
+            force=force,
+            include_failed=include_failed,
+        ),
+    }
+
+
+def _group_aggregation_keys_by_content_type(aggregation_keys):
+    """
+    Split aggregation keys into content-type buckets.
+    """
+    grouped_keys = {
+        COURSE: [],
+        PROGRAM: [],
+        LEARNER_PATHWAY: [],
+    }
+    for aggregation_key in aggregation_keys:
+        content_type, content_key = _partition_aggregation_key(aggregation_key)
+        try:
+            grouped_keys[content_type].append(content_key)
+        except KeyError:
+            logger.warning(
+                'Ignoring unsupported content_type=%s for aggregation key=%s', content_type, aggregation_key,
+            )
+    return grouped_keys
+
+
 def _get_program_keys_for_dispatch(
     content_keys: list[str],
     program_to_course_keys: dict[str, set[str]],
@@ -636,10 +822,15 @@ def _get_program_keys_for_dispatch(
 ) -> list[str]:
     """
     Return the program content_keys that the dispatcher should enqueue.
+
+    A program is considered stale if its own ``ContentMetadata.modified``
+    timestamp has advanced past ``last_indexed_at``, OR if any of its child
+    courses was indexed more recently than the program itself.
     """
     if force:
         return list(content_keys)
 
+    content_modified_by_key = _get_content_modified_by_key(content_keys, PROGRAM)
     state_by_key = _get_indexing_state_by_key(content_keys)
     all_child_course_keys = {
         child_key
@@ -655,6 +846,9 @@ def _get_program_keys_for_dispatch(
             keys_to_dispatch.append(content_key)
             continue
         if _should_retry_failed_record(state_by_key, content_key, include_failed):
+            keys_to_dispatch.append(content_key)
+            continue
+        if content_modified_by_key.get(content_key) > state['last_indexed_at']:
             keys_to_dispatch.append(content_key)
             continue
         if _has_newer_child_index(
@@ -674,10 +868,15 @@ def _get_pathway_keys_for_dispatch(
 ) -> list[str]:
     """
     Return the learner pathway content_keys that the dispatcher should enqueue.
+
+    A pathway is considered stale if its own ``ContentMetadata.modified``
+    timestamp has advanced past ``last_indexed_at``, OR if any of its child
+    programs was indexed more recently than the pathway itself.
     """
     if force:
         return list(content_keys)
 
+    content_modified_by_key = _get_content_modified_by_key(content_keys, LEARNER_PATHWAY)
     state_by_key = _get_indexing_state_by_key(content_keys)
     child_program_keys_by_pathway = {
         pathway_key: _extract_program_keys(
@@ -699,6 +898,9 @@ def _get_pathway_keys_for_dispatch(
             keys_to_dispatch.append(content_key)
             continue
         if _should_retry_failed_record(state_by_key, content_key, include_failed):
+            keys_to_dispatch.append(content_key)
+            continue
+        if content_modified_by_key.get(content_key) > state['last_indexed_at']:
             keys_to_dispatch.append(content_key)
             continue
         if _has_newer_child_index(
@@ -864,7 +1066,16 @@ def _resolve_indexing_decision(
                 ),
             )
 
-        if not force and state.last_indexed_at and state.last_indexed_at >= content.modified:
+        # We can skip reindexing (by early-returning) this content if:
+        # 1. We're not explicitly forcing a re-index operation, and
+        # 2. the content has been been indexed at least once and not recently modified
+        # 3. The last re-indexing attempt on this content succeeded
+        if (
+            not force
+            and state.last_indexed_at
+            and state.last_indexed_at >= content.modified
+            and not state.last_failure_at
+        ):
             return IndexingDecision.skipped(
                 content_key=content_key, content=content, state=state,
             )

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -17,6 +17,7 @@ from enterprise_catalog.apps.catalog.constants import (
     PROGRAM,
 )
 from enterprise_catalog.apps.catalog.tests.factories import (
+    CatalogQueryFactory,
     ContentMetadataFactory,
 )
 from enterprise_catalog.apps.catalog.utils import localized_utcnow
@@ -32,6 +33,7 @@ from enterprise_catalog.apps.search.tasks import (
     _get_content_modified_by_key,
     _get_indexable_keys_by_content_type,
     _get_indexing_state_by_key,
+    _group_aggregation_keys_by_content_type,
     _has_newer_child_index,
     _index_content_batch,
     _is_uuid_string,
@@ -185,6 +187,25 @@ class TestIndexContentBatch(TestCase):
         self.mock_get_products.return_value = [_algolia_object(content.content_key)]
 
         result = _index_content_batch([content.content_key], COURSE, force=True)
+
+        self.assertEqual(result.indexed, 1)
+        self.algolia_client.save_objects_batch.assert_called_once()
+
+    def test_failed_records_are_retried_even_when_current(self):
+        """
+        A record with a fresh ``last_indexed_at`` but a recorded failure should
+        be reprocessed so catalog-query retries can unstick it.
+        """
+        content = ContentMetadataFactory(content_type=COURSE, content_key='course-retry-failed')
+        ContentMetadataIndexingStateFactory(
+            content_metadata=content,
+            last_indexed_at=content.modified + timedelta(seconds=60),
+            last_failure_at=localized_utcnow(),
+        )
+        self._set_indexable(content.content_key)
+        self.mock_get_products.return_value = [_algolia_object(content.content_key)]
+
+        result = _index_content_batch([content.content_key], COURSE, force=False)
 
         self.assertEqual(result.indexed, 1)
         self.algolia_client.save_objects_batch.assert_called_once()
@@ -526,6 +547,27 @@ class TestIndexContentBatch(TestCase):
         self.assertEqual(result.failed, 1)
         self.assertEqual(result.failed_keys, ['course-missing'])
 
+    def test_unexpected_exception_in_resolve_decision_counts_as_failed(self):
+        """
+        If an unexpected exception escapes inside ``_resolve_indexing_decision``
+        (e.g. a DB error from ``get_or_create_for_content``), the record is
+        counted as failed and the rest of the batch is unaffected. This covers
+        the broad-except guard in ``_resolve_indexing_decision``.
+        """
+        content = ContentMetadataFactory(content_type=COURSE, content_key='course-exploding-state')
+        self._set_indexable(content.content_key)
+        self.mock_get_products.return_value = [_algolia_object(content.content_key)]
+
+        with mock.patch.object(
+            ContentMetadataIndexingState,
+            'get_or_create_for_content',
+            side_effect=RuntimeError('unexpected db error'),
+        ):
+            result = _index_content_batch([content.content_key], COURSE)
+
+        self.assertEqual(result.failed, 1)
+        self.assertEqual(result.failed_keys, [content.content_key])
+
     def test_indexed_record_orphan_delete_failure_mutates_outcome_to_failed(self):
         """
         A single record's save succeeds but its orphan delete fails (both
@@ -855,6 +897,67 @@ class TestDispatchAlgoliaIndexing(TestCase):
             index_name=None,
         )
 
+    def test_programs_dispatched_on_child_staleness_when_own_metadata_current(self):
+        """
+        A program whose own metadata is current (last_indexed_at > modified) is
+        still dispatched when a child course was indexed more recently than the
+        program itself. This exercises the child-staleness branch in
+        ``_get_program_keys_for_dispatch`` that is bypassed when
+        ``modified > last_indexed_at`` fires first.
+        """
+        child_course = ContentMetadataFactory(content_type=COURSE, content_key='course-newer-child')
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        # Program's own metadata is fresh — last_indexed_at is ahead of modified.
+        program_state = ContentMetadataIndexingStateFactory(
+            content_metadata=program,
+            last_indexed_at=program.modified + timedelta(hours=1),
+        )
+        # Child course was indexed after the program.
+        ContentMetadataIndexingStateFactory(
+            content_metadata=child_course,
+            last_indexed_at=program_state.last_indexed_at + timedelta(hours=1),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[child_course.content_key, program.content_key],
+            program_to_course_keys={program.content_key: {child_course.content_key}},
+        )
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'][PROGRAM], {'records': 1, 'batches': 1})
+        self.mock_program_si.assert_called_once()
+
+    def test_pathways_dispatched_on_child_staleness_when_own_metadata_current(self):
+        """
+        A pathway whose own metadata is current (last_indexed_at > modified) is
+        still dispatched when a child program was indexed more recently. This
+        exercises the child-staleness branch in ``_get_pathway_keys_for_dispatch``
+        that is bypassed when ``modified > last_indexed_at`` fires first.
+        """
+        child_program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='pathway-fresh-own')
+        # Pathway's own metadata is fresh.
+        pathway_state = ContentMetadataIndexingStateFactory(
+            content_metadata=pathway,
+            last_indexed_at=pathway.modified + timedelta(hours=1),
+        )
+        # Child program was indexed after the pathway.
+        ContentMetadataIndexingStateFactory(
+            content_metadata=child_program,
+            last_indexed_at=pathway_state.last_indexed_at + timedelta(hours=1),
+        )
+        self._set_mappings(
+            all_indexable_content_keys=[child_program.content_key, pathway.content_key],
+            pathway_to_program_course_keys={
+                pathway.content_key: {child_program.content_key},
+            },
+        )
+
+        result = dispatch_algolia_indexing(force=False)
+
+        self.assertEqual(result['dispatched'][LEARNER_PATHWAY], {'records': 1, 'batches': 1})
+        self.mock_pathway_si.assert_called_once()
+
     def test_batching_uses_configured_batch_size(self):
         courses = [
             ContentMetadataFactory(content_type=COURSE, content_key=f'course-batch-{index}')
@@ -1087,6 +1190,269 @@ class TestDispatchAlgoliaIndexingHelpers(TestCase):
             1234,
             None,
         ]), [program_key])
+
+    def test_group_aggregation_keys_skips_malformed_keys(self):
+        """
+        Keys with no ``':'`` separator are logged and excluded from all buckets.
+        """
+        result = _group_aggregation_keys_by_content_type({'malformed-key-no-colon'})
+        self.assertEqual(result, {COURSE: [], PROGRAM: [], LEARNER_PATHWAY: []})
+
+    def test_group_aggregation_keys_skips_unknown_content_types(self):
+        """
+        Keys whose content-type prefix is not one of the known types are
+        logged and excluded.
+        """
+        result = _group_aggregation_keys_by_content_type({'video:video-key-123'})
+        self.assertEqual(result, {COURSE: [], PROGRAM: [], LEARNER_PATHWAY: []})
+
+
+@override_settings(ALGOLIA_INDEXING_BATCH_SIZE=2)
+class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
+    """
+    Tests for the catalog-query-specific dispatcher task.
+    """
+    # pylint: disable=no-value-for-parameter
+
+    def setUp(self):
+        self.algolia_client = mock.MagicMock(name='algolia_client')
+        client_patcher = mock.patch.object(
+            search_tasks, 'get_initialized_algolia_client', return_value=self.algolia_client,
+        )
+        client_patcher.start()
+        self.addCleanup(client_patcher.stop)
+
+        self.mock_invalidate_cache = mock.patch.object(
+            search_tasks, 'invalidate_indexing_mappings_cache',
+        ).start()
+        self.mock_course_si = mock.patch.object(
+            search_tasks.index_courses_batch_in_algolia, 'si',
+        ).start()
+        self.mock_program_si = mock.patch.object(
+            search_tasks.index_programs_batch_in_algolia, 'si',
+        ).start()
+        self.mock_pathway_si = mock.patch.object(
+            search_tasks.index_pathways_batch_in_algolia, 'si',
+        ).start()
+        self.mock_group = mock.patch.object(search_tasks, 'group').start()
+        self.mock_chain = mock.patch.object(search_tasks, 'chain').start()
+        self.addCleanup(mock.patch.stopall)
+
+        self.algolia_client.get_aggregation_keys_for_catalog_query.return_value = set()
+
+    def _create_catalog_membership(
+        self,
+        content_type,
+        content_key,
+        *,
+        catalog_query=None,
+        last_indexed_at=None,
+        last_failure_at=None,
+    ):
+        content = ContentMetadataFactory(content_type=content_type, content_key=content_key)
+        catalog_query = catalog_query or CatalogQueryFactory()
+        content.catalog_queries.add(catalog_query)
+        if last_indexed_at is not None or last_failure_at is not None:
+            ContentMetadataIndexingStateFactory(
+                content_metadata=content,
+                last_indexed_at=last_indexed_at,
+                last_failure_at=last_failure_at,
+            )
+        return content, catalog_query
+
+    def _set_catalog_query_diff(self, catalog_query, *extra_removed_aggregation_keys):
+        db_keys = set(
+            catalog_query.contentmetadata_set.values_list('content_type', 'content_key')
+            .order_by('content_type', 'content_key')
+        )
+        aggregation_keys = {
+            f'{content_type}:{content_key}'
+            for content_type, content_key in db_keys
+        }
+        aggregation_keys.update(extra_removed_aggregation_keys)
+        self.algolia_client.get_aggregation_keys_for_catalog_query.return_value = aggregation_keys
+
+    def test_dry_run_returns_summary_without_dispatching(self):
+        catalog_query = CatalogQueryFactory()
+        _current_content, catalog_query = self._create_catalog_membership(
+            COURSE, 'course-current',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+        )
+        self._create_catalog_membership(
+            COURSE, 'course-stale',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+        )
+        self._create_catalog_membership(
+            COURSE, 'course-failed',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+            last_failure_at=localized_utcnow(),
+        )
+        self._create_catalog_membership(
+            PROGRAM, _program_content_key(),
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+        )
+        self._create_catalog_membership(LEARNER_PATHWAY, 'pathway-new', catalog_query=catalog_query)
+        self._set_catalog_query_diff(catalog_query, f'{COURSE}:course-removed')
+
+        result = search_tasks.dispatch_algolia_indexing_for_catalog_query(
+            catalog_query.id,
+            dry_run=True,
+            force=False,
+            include_failed=True,
+            index_name='enterprise_catalog_v2',
+        )
+
+        self.assertEqual(result, {
+            'catalog_query_id': catalog_query.id,
+            'force': False,
+            'dry_run': True,
+            'batch_size': 2,
+            'index_name': 'enterprise_catalog_v2',
+            'db_membership_count': 5,
+            'algolia_membership_count': 6,
+            'removed_count': 1,
+            'added_count': 0,
+            'dispatched': {
+                COURSE: {'records': 3, 'batches': 2},
+                PROGRAM: {'records': 1, 'batches': 1},
+                LEARNER_PATHWAY: {'records': 1, 'batches': 1},
+            },
+        })
+        self.mock_invalidate_cache.assert_not_called()
+        self.algolia_client.get_aggregation_keys_for_catalog_query.assert_called_once_with(
+            catalog_query.uuid,
+            index_name='enterprise_catalog_v2',
+        )
+        self.mock_course_si.assert_not_called()
+        self.mock_program_si.assert_not_called()
+        self.mock_pathway_si.assert_not_called()
+
+    def test_force_false_excludes_failed_records_when_requested(self):
+        catalog_query = CatalogQueryFactory()
+        self._create_catalog_membership(
+            COURSE, 'course-current',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+        )
+        _failed_content, catalog_query = self._create_catalog_membership(
+            COURSE, 'course-failed-only',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+            last_failure_at=localized_utcnow(),
+        )
+        self._set_catalog_query_diff(catalog_query)
+
+        result = search_tasks.dispatch_algolia_indexing_for_catalog_query(
+            catalog_query.id,
+            force=False,
+            include_failed=False,
+        )
+
+        self.assertEqual(result['dispatched'][COURSE], {'records': 0, 'batches': 0})
+        self.mock_course_si.assert_not_called()
+
+    def test_added_content_dispatched_even_when_last_indexed_at_is_current(self):
+        """
+        Content that is in the DB membership but NOT currently facet-tagged in
+        Algolia (added to the catalog since the last index run) must be
+        dispatched even if its own ``last_indexed_at`` is current (i.e. the
+        staleness filter would otherwise skip it).
+
+        This is the symmetric case to removed content:
+        ``added = db_aggregation_keys - algolia_aggregation_keys``.
+        """
+        catalog_query = CatalogQueryFactory()
+        # course-current is already indexed and fully up-to-date — normally skipped.
+        self._create_catalog_membership(
+            COURSE, 'course-current',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+        )
+        # course-added is also "current" but Algolia has never written the
+        # catalog-query facet for it. Must be dispatched to gain the new facet.
+        self._create_catalog_membership(
+            COURSE, 'course-added',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+        )
+        # Algolia only knows about course-current for this catalog query.
+        self.algolia_client.get_aggregation_keys_for_catalog_query.return_value = {
+            f'{COURSE}:course-current',
+        }
+
+        result = search_tasks.dispatch_algolia_indexing_for_catalog_query(
+            catalog_query.id,
+            force=False,
+            include_failed=False,
+        )
+
+        self.assertEqual(result['added_count'], 1)
+        self.assertEqual(result['dispatched'][COURSE], {'records': 1, 'batches': 1})
+        self.mock_course_si.assert_called_once_with(
+            content_keys=['course-added'],
+            force=False,
+            index_name=None,
+        )
+
+    def test_force_true_dispatches_everything_in_the_catalog(self):
+        catalog_query = CatalogQueryFactory()
+        _current_content, catalog_query = self._create_catalog_membership(
+            COURSE, 'course-current',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+        )
+        self._create_catalog_membership(
+            COURSE, 'course-stale',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() - timedelta(hours=1),
+        )
+        self._create_catalog_membership(
+            COURSE, 'course-failed',
+            catalog_query=catalog_query,
+            last_indexed_at=localized_utcnow() + timedelta(hours=1),
+            last_failure_at=localized_utcnow(),
+        )
+        removed_course_aggregation_key = f'{COURSE}:course-removed'
+        self._set_catalog_query_diff(catalog_query, removed_course_aggregation_key)
+
+        result = search_tasks.dispatch_algolia_indexing_for_catalog_query(
+            catalog_query.id,
+            force=True,
+            index_name='enterprise_catalog_v2',
+        )
+
+        self.assertEqual(result['dispatched'][COURSE], {'records': 4, 'batches': 2})
+        self.mock_invalidate_cache.assert_called_once_with()
+        self.assertEqual(self.mock_course_si.call_count, 2)
+        self.assertEqual(
+            [call.kwargs['content_keys'] for call in self.mock_course_si.call_args_list],
+            [
+                ['course-current', 'course-failed'],
+                ['course-removed', 'course-stale'],
+            ],
+        )
+        self.assertEqual(
+            [call.kwargs['index_name'] for call in self.mock_course_si.call_args_list],
+            ['enterprise_catalog_v2', 'enterprise_catalog_v2'],
+        )
+
+    def test_catalog_query_not_found_returns_empty_summary(self):
+        """
+        If the CatalogQuery doesn't exist at execution time (e.g. deleted
+        between enqueue and run), the task logs a warning and returns ``{}``
+        without touching Algolia or dispatching any batch tasks.
+        """
+        result = search_tasks.dispatch_algolia_indexing_for_catalog_query(
+            catalog_query_id=999999,
+        )
+        self.assertEqual(result, {})
+        self.algolia_client.get_aggregation_keys_for_catalog_query.assert_not_called()
+        self.mock_course_si.assert_not_called()
+        self.mock_invalidate_cache.assert_not_called()
 
 
 class TestRecordOutcome(TestCase):


### PR DESCRIPTION
## Summary

Adds `dispatch_algolia_indexing_for_catalog_query`, the second of two Phase 4 dispatcher tasks. Where the Phase 4a dispatcher (`dispatch_algolia_indexing`) handles scheduled bulk reindexing across all enterprise catalogs, this task handles **targeted, catalog-query-scoped reindexing** triggered by membership changes.
 
 ## What it does
 
1. **Diffs DB membership vs Algolia** - fetches the catalog query's current content from the DB and its current aggregation keys from Algolia, then identifies content that has been *removed* from the catalog (needs reindexing to shed stale catalog facets).
2. **Staleness filtering** - for content still in the DB, applies the same stale/failed/never-indexed logic as the Phase 4a dispatcher.
3. **Ordered dispatch via `chain`/`group`** - batches are dispatched as `chain(group(courses), group(programs), group(pathways))` using immutable `.si()` signatures, guaranteeing courses finish before programs are evaluated and programs finish before pathways - the same ordering required for correct child-staleness propagation.
 
 ## New helpers
 
 - `_get_catalog_query_content_keys_by_type` — bulk-loads catalog membership grouped by content type
 - `_get_content_keys_for_dispatch` — staleness/failure filtering for a single content type
 - `_group_aggregation_keys_by_content_type` — splits Algolia aggregation keys back into per-type buckets
 
 ## What will trigger this task (not yet wired)
This task is designed to be called in the future from the `EnterpriseCatalogRefreshDataFromDiscovery` view (aka an API catalog refresh), after syncing membership changes from Discovery, will dispatch this task per affected `CatalogQuery` so Algolia reflects the updated membership immediately.

https://2u-internal.atlassian.net/browse/ENT-11692

built on top of https://github.com/edx/enterprise-catalog/pull/100

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
