### PR TITLE
chore: sync AI instruction files from enterprise template

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,12 @@
+# Copilot Instructions
+
+This project's authoritative agent instructions live in `CLAUDE.md` at the
+repository root, with supplementary rules under `.claude/rules/`.
+
+At the start of every session, before doing any other work, read:
+
+- `CLAUDE.md`
+- All files under `.claude/rules/`
+
+Treat their contents as binding project instructions for the remainder of the
+session, equivalent to instructions in this file.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,9 +22,12 @@ Enterprise Catalog is a Django-based microservice within the Open edX ecosystem 
 
 ## Documentation & Institutional Memory
 
-- Document new functionality in `docs/how_to/` or `docs/architecture_overview.rst`
-- When you learn something important about how this codebase works (gotchas, non-obvious patterns, integration quirks), add it to the relevant section in `docs/architecture_overview.rst` or create new documentation in `docs/how_to/`
-- These docs are institutional memory - future sessions (yours or others) will benefit from what you record here
+- Document new functionality in `docs/references/`
+- When you learn something important about how this codebase works (gotchas, non-obvious
+  patterns, integration quirks), capture it in the relevant `docs/references/` file or
+  in `docs/architecture-patterns.md`
+- These docs are institutional memory - future sessions (yours or others) will benefit
+  from what you record here
 
 ## Architecture Overview
 
@@ -90,4 +93,11 @@ Two authorization mechanisms:
 - Uses pytest with Django integration
 - Coverage reporting enabled by default
 - PII annotation checks required for Django models
-- Docker-based test execution via `make app-shell`
+
+## Before opening a PR or pushing a branch
+
+Run a self-check on the diff before creating a PR or pushing:
+1. Compute effective LoC — exclude lockfiles, generated files, snapshots, and vendor code.
+2. Count effective touched files — exclude the above plus one-to-one test pairs.
+3. If effective LoC > 400 or effective files > 10, stop and propose a split before proceeding.
+4. Report the result inline before continuing.


### PR DESCRIPTION
## Summary

Syncs boilerplate sections of `CLAUDE.md` and `.github/copilot-instructions.md` with the latest conventions from [edx/ai-devtools-internal](https://github.com/edx/ai-devtools-internal) `docs/templates/`.

### Changed sections
- Added `## Before opening a PR or pushing a branch`
- Updated `## Documentation & Institutional Memory` (standardized docs path)
- Updated `## Testing Notes` (removed docker-specific line)
- Created `.github/copilot-instructions.md`

### No repo-specific content was modified
Repo-specific sections (`## Overview`, `## Architecture Overview`, etc.) were not touched.

🤖 Generated by the `update-ai-instructions` skill.