### PR TITLE
Fix DataError from overlong translated subtitle in populate_spanish_translations

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/populate_spanish_translations.py
+++ b/enterprise_catalog/apps/catalog/management/commands/populate_spanish_translations.py
@@ -54,6 +54,24 @@ class Command(BaseCommand):
     """
     help = 'Pre-populate Spanish translations for content metadata'
 
+    @staticmethod
+    def _truncate_to_model_field_max_length(model_class, field_name, value):
+        """
+        Truncate string values to the target model field's max_length.
+
+        This prevents database-level DataError exceptions when translated text is
+        longer than the destination CharField allows.
+        """
+        if value is None or not isinstance(value, str):
+            return value
+
+        model_field = model_class._meta.get_field(field_name)
+        max_length = getattr(model_field, 'max_length', None)
+        if max_length and len(value) > max_length:
+            return value[:max_length]
+
+        return value
+
     def add_arguments(self, parser):
         parser.add_argument(
             '--content-keys',
@@ -260,10 +278,32 @@ class Command(BaseCommand):
         )
 
         # Update translation fields
-        translation.title = translated_data.get('title')
+        raw_title = translated_data.get('title')
+        translation.title = self._truncate_to_model_field_max_length(
+            ContentTranslation,
+            'title',
+            raw_title,
+        )
+        if translation.title != raw_title:
+            logger.warning(
+                'Truncated translated title for content %s to %s characters',
+                content.content_key,
+                ContentTranslation._meta.get_field('title').max_length,
+            )
         translation.short_description = translated_data.get('short_description')
         translation.full_description = translated_data.get('full_description')
-        translation.subtitle = translated_data.get('subtitle')
+        raw_subtitle = translated_data.get('subtitle')
+        translation.subtitle = self._truncate_to_model_field_max_length(
+            ContentTranslation,
+            'subtitle',
+            raw_subtitle,
+        )
+        if translation.subtitle != raw_subtitle:
+            logger.warning(
+                'Truncated translated subtitle for content %s to %s characters',
+                content.content_key,
+                ContentTranslation._meta.get_field('subtitle').max_length,
+            )
         translation.source_hash = source_hash
 
         # Save if not dry run

--- a/enterprise_catalog/apps/catalog/tests/test_populate_spanish_translations.py
+++ b/enterprise_catalog/apps/catalog/tests/test_populate_spanish_translations.py
@@ -243,6 +243,44 @@ class PopulateSpanishTranslationsCommandTests(TestCase):
 
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.'
+        'populate_spanish_translations.translate_object_fields'
+    )
+    def test_command_truncates_title_to_field_limit(self, mock_translate):
+        """Test that overlong translated titles are truncated to avoid DB DataError."""
+        max_title_length = ContentTranslation._meta.get_field('title').max_length
+        too_long_title = 't' * (max_title_length + 50)
+        mock_translate.return_value = {
+            'title': too_long_title,
+            'subtitle': 'Subtítulo',
+        }
+
+        call_command('populate_spanish_translations', all=True)
+
+        translation = ContentTranslation.objects.get(content_metadata=self.content1)
+        self.assertEqual(len(translation.title), max_title_length)
+        self.assertEqual(translation.title, too_long_title[:max_title_length])
+
+    @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.'
+        'populate_spanish_translations.translate_object_fields'
+    )
+    def test_command_truncates_subtitle_to_field_limit(self, mock_translate):
+        """Test that overlong translated subtitles are truncated to avoid DB DataError."""
+        max_subtitle_length = ContentTranslation._meta.get_field('subtitle').max_length
+        too_long_subtitle = 's' * (max_subtitle_length + 50)
+        mock_translate.return_value = {
+            'title': 'Título',
+            'subtitle': too_long_subtitle,
+        }
+
+        call_command('populate_spanish_translations', all=True)
+
+        translation = ContentTranslation.objects.get(content_metadata=self.content1)
+        self.assertEqual(len(translation.subtitle), max_subtitle_length)
+        self.assertEqual(translation.subtitle, too_long_subtitle[:max_subtitle_length])
+
+    @mock.patch(
+        'enterprise_catalog.apps.catalog.management.commands.'
         'populate_spanish_translations._should_index_course'
     )
     @mock.patch(


### PR DESCRIPTION
## Summary
Fixes MySQL `DataError (1406): Data too long for column 'subtitle'` seen during `populate_spanish_translations`.
JIRA ticket : https://2u-internal.atlassian.net/browse/ENT-11821
### What changed
- Added field-aware truncation helper in `populate_spanish_translations` command.
- Truncate translated `title`/`subtitle` to the destination `ContentTranslation` CharField `max_length` before save.
- Added warning logs when truncation occurs.
- Added regression test that verifies overlong translated `subtitle` is truncated to model limit.

## Root cause
Translated strings from Xpert AI can exceed DB column limits (`ContentTranslation.subtitle` is a CharField), and save attempted to persist unbounded text.

## Validation
- Ran targeted regression test:
  - `pytest enterprise_catalog/apps/catalog/tests/test_populate_spanish_translations.py -q -k truncates_subtitle_to_field_limit`
  - Result: **passed**

<img width="663" height="311" alt="image" src="https://github.com/user-attachments/assets/596e4a85-6ff9-4d24-9faa-4ed07ac570cc" />
