### PR TITLE
feat: add Algolia translation_languages support from ai_languages

### DIFF
--- a/enterprise_catalog/apps/catalog/algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/algolia_utils.py
@@ -140,6 +140,7 @@ ALGOLIA_FIELDS = [
     'avg_course_rating',
     'course_bayesian_average',
     'transcript_languages',
+    'translation_languages',
     'is_new_content',
 ]
 
@@ -190,6 +191,7 @@ ALGOLIA_INDEX_SETTINGS = {
         'learning_type',
         'learning_type_v2',
         'transcript_languages',
+        'translation_languages',
         'is_new_content',
     ],
     'unretrievableAttributes': [
@@ -534,6 +536,21 @@ def get_course_transcript_languages(course):
 
     transcript_languages = advertised_course_run.get('transcript_languages_search_facet_names')
     return transcript_languages
+
+
+def get_course_translation_languages(course):
+    """
+    Gets human-readable AI translation languages associated with a course.
+
+    Arguments:
+        course (dict): a dict representing course metadata
+
+    Returns:
+        list: a list of human-readable AI translation language labels.
+    """
+    ai_languages = course.get('ai_languages') or {}
+    translation_languages = ai_languages.get('translation_languages') or []
+    return [language.get('label') for language in translation_languages if language.get('label')]
 
 
 def get_course_availability(course):
@@ -1616,6 +1633,7 @@ def _algolia_object_from_product(product, algolia_fields):
             'avg_course_rating': get_avg_course_rating(searchable_product),
             'course_bayesian_average': get_course_bayesian_average(searchable_product),
             'transcript_languages': get_course_transcript_languages(searchable_product),
+            'translation_languages': get_course_translation_languages(searchable_product),
             'metadata_language': searchable_product.get('metadata_language', 'en'),
             'is_new_content': is_course_new_content(searchable_product),
         })

--- a/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
+++ b/enterprise_catalog/apps/catalog/tests/test_algolia_utils.py
@@ -1719,6 +1719,56 @@ class AlgoliaUtilsTests(TestCase):
     @ddt.data(
         (
             {
+                'ai_languages': {
+                    'translation_languages': [
+                        {'code': 'ar', 'label': 'Arabic'},
+                        {'code': 'en', 'label': 'English'},
+                        {'code': 'es-419', 'label': 'Spanish (Latin America)'},
+                    ],
+                },
+            },
+            ['Arabic', 'English', 'Spanish (Latin America)'],
+        ),
+        (
+            {
+                'ai_languages': {
+                    'translation_languages': [
+                        {'code': 'ar'},
+                        {'label': 'English'},
+                        {},
+                    ],
+                },
+            },
+            ['English'],
+        ),
+        (
+            {
+                'ai_languages': None,
+            },
+            [],
+        ),
+        (
+            {
+                'ai_languages': {},
+            },
+            [],
+        ),
+        (
+            {},
+            [],
+        ),
+    )
+    @ddt.unpack
+    def test_get_course_translation_languages(self, course_metadata, expected_translation_languages):
+        """
+        Assert correct parsing of ``translation_languages`` from ``ai_languages``.
+        """
+        translation_languages = utils.get_course_translation_languages(course_metadata)
+        assert translation_languages == expected_translation_languages
+
+    @ddt.data(
+        (
+            {
                 'course_runs': [{
                     'key': 'course-v1:org+course+1T2021',
                     'uuid': ADVERTISED_COURSE_RUN_UUID,


### PR DESCRIPTION
JIRA ticket :https://2u-internal.atlassian.net/browse/ENT-11917

## Summary

Expose the `translation_languages` field from the course metadata's `ai_languages` object to Algolia, enabling faceted search based on AI-translated language availability.

## Changes

* Added `translation_languages` to:

  * `ALGOLIA_FIELDS`
  * `ALGOLIA_INDEX_SETTINGS` (as a facetable attribute)
* Implemented `get_course_translation_languages(course)` utility to:

  * Read `ai_languages.translation_languages`
  * Extract human-readable language labels
  * Filter out entries that do not contain a valid `label`
* Updated `_algolia_object_from_product` to include `translation_languages` during Algolia indexing.
* Added parameterized unit tests (`@ddt`) covering:

  * Valid translation language data
  * Entries missing a `code`
  * Entries missing a `label`
  * Empty `ai_languages` data
  * Courses without an `ai_languages` field

## Testing

Added `test_get_course_translation_languages` in `test_algolia_utils.py` to validate all supported scenarios and edge cases.
<img width="672" height="480" alt="image" src="https://github.com/user-attachments/assets/b05d7c16-71fc-4ad8-be3c-59b9c1aefcbc" />
