### PR TITLE
feat: add catalogquery.title to admin form list display

### DIFF
--- a/enterprise_catalog/apps/catalog/admin.py
+++ b/enterprise_catalog/apps/catalog/admin.py
@@ -224,12 +224,14 @@ class CatalogQueryAdmin(UnchangeableMixin):
     )
     readonly_fields = ('uuid', 'get_content_count')
     list_display = (
+        'title',
         'uuid',
         'content_filter_hash',
         'get_content_filter',
     )
     search_fields = (
         'content_filter_hash',
+        'title',
     )
 
     @admin.display(description='Content Filter')


### PR DESCRIPTION
Internal quality-of-life improvement to more easily find catalog query records (notably, those associated with Academies) by title.

<img width="1915" height="778" alt="image" src="https://github.com/user-attachments/assets/07a8d9db-e68d-4833-80a1-3487dcf6ed01" />

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
