### PR TITLE
feat: add incremental_reindex_algolia management command (Phase 5)

### DIFF
--- a/enterprise_catalog/apps/search/indexing_mappings.py
+++ b/enterprise_catalog/apps/search/indexing_mappings.py
@@ -98,8 +98,15 @@ def _compute_indexing_mappings():
     )
     all_indexable_content_keys = set(indexable_courses) | set(indexable_programs) | set(pathway_keys)
 
+    # Ensure every indexable pathway key has an entry in the mapping, even if
+    # it has no associated children. The legacy _get_algolia_products_for_batch
+    # does a bare dict lookup (not .get()) and raises KeyError for missing keys.
+    pathway_to_program_course_keys = dict(pathway_to_programs_courses)
+    for pk in pathway_keys:
+        pathway_to_program_course_keys.setdefault(pk, set())
+
     return IndexingMappings(
         program_to_course_keys=dict(program_to_courses),
-        pathway_to_program_course_keys=dict(pathway_to_programs_courses),
+        pathway_to_program_course_keys=pathway_to_program_course_keys,
         all_indexable_content_keys=all_indexable_content_keys,
     )

--- a/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
+++ b/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
@@ -1,0 +1,144 @@
+"""
+Management command for manual or scheduled incremental Algolia reindexing.
+
+Invokes ``dispatch_algolia_indexing`` (Phase 4a) with configurable parameters
+and prints a summary of dispatched tasks.
+"""
+import logging
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+
+from enterprise_catalog.apps.catalog.constants import (
+    COURSE,
+    LEARNER_PATHWAY,
+    PROGRAM,
+)
+from enterprise_catalog.apps.search.tasks import dispatch_algolia_indexing
+
+
+logger = logging.getLogger(__name__)
+
+_ALL_CONTENT_TYPES = [COURSE, PROGRAM, LEARNER_PATHWAY]
+
+
+class Command(BaseCommand):
+    help = 'Run incremental Algolia reindexing via the Phase 4a dispatcher'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--content-type',
+            dest='content_types',
+            choices=_ALL_CONTENT_TYPES,
+            nargs='+',
+            metavar='TYPE',
+            help=(
+                f'Limit reindexing to one or more content types: '
+                f'{", ".join(_ALL_CONTENT_TYPES)}. Defaults to all types.'
+            ),
+        )
+        parser.add_argument(
+            '--index-name',
+            dest='index_name',
+            default=None,
+            help='Target an alternate Algolia index (e.g. for v2 testing).',
+        )
+        parser.add_argument(
+            '--force-all',
+            dest='force_all',
+            action='store_true',
+            default=False,
+            help='Reindex all indexable content regardless of staleness.',
+        )
+        parser.add_argument(
+            '--dry-run',
+            dest='dry_run',
+            action='store_true',
+            default=False,
+            help='Log what would be dispatched without issuing any Algolia writes.',
+        )
+        parser.add_argument(
+            '--no-async',
+            dest='no_async',
+            action='store_true',
+            default=False,
+            help='Run the dispatcher synchronously (blocks until complete; useful for debugging).',
+        )
+
+    def handle(self, *args, **options):
+        content_types = options['content_types']  # None means all types
+        index_name = options['index_name']
+        force_all = options['force_all']
+        dry_run = options['dry_run']
+        no_async = options['no_async']
+
+        # Safety guard: block writes to the primary production index.
+        # Remove this check as part of the incremental-reindexing cutover.
+        primary_index = settings.ALGOLIA.get('INDEX_NAME')
+        resolved_index = index_name or primary_index
+        if resolved_index and resolved_index == primary_index:
+            raise CommandError(
+                f"Refusing to run against the primary Algolia index '{primary_index}'. "
+                "Pass --index-name targeting a non-primary index. "
+                "Remove this guard when cutting over to incremental reindexing."
+            )
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING('[DRY-RUN] No Algolia writes will be made.'))
+        self.stdout.write(f'Content types: {", ".join(content_types) if content_types else "all"}')
+        self.stdout.write(f'Target index:  {resolved_index or "(not configured)"}')
+        self.stdout.write(f'Force all:     {force_all}')
+        self.stdout.write('')
+
+        task_kwargs = {
+            'force': force_all,
+            'dry_run': dry_run,
+            'index_name': index_name,
+            'content_types': content_types,
+            'use_apply': no_async,
+        }
+
+        if no_async:
+            self.stdout.write('Running synchronously...')
+            result = dispatch_algolia_indexing.apply(kwargs=task_kwargs).get()
+        else:
+            self.stdout.write('Dispatching via Celery...')
+            result = dispatch_algolia_indexing.apply_async(kwargs=task_kwargs).get()
+
+        self._print_summary(result)
+
+    def _print_summary(self, result):
+        """Print the dispatcher summary returned by dispatch_algolia_indexing."""
+        if not result:
+            self.stdout.write(self.style.WARNING('No summary returned from dispatcher.'))
+            return
+
+        dispatched = result.get('dispatched', {})
+
+        self.stdout.write('')
+        self.stdout.write('=' * 60)
+        self.stdout.write('DISPATCH SUMMARY')
+        self.stdout.write('=' * 60)
+        self.stdout.write(f'{"Content Type":<20} {"Records":<10} {"Batches":<10}')
+        self.stdout.write('-' * 60)
+
+        total_records = 0
+        total_batches = 0
+        for content_type in _ALL_CONTENT_TYPES:
+            counts = dispatched.get(content_type, {})
+            records = counts.get('records', 0)
+            batches = counts.get('batches', 0)
+            total_records += records
+            total_batches += batches
+            self.stdout.write(f'{content_type:<20} {records:<10} {batches:<10}')
+
+        self.stdout.write('-' * 60)
+        self.stdout.write(f'{"TOTAL":<20} {total_records:<10} {total_batches:<10}')
+        self.stdout.write('=' * 60)
+
+        if result.get('dry_run'):
+            self.stdout.write(self.style.WARNING('(dry-run — nothing was indexed)'))
+        elif total_records == 0:
+            self.stdout.write(self.style.SUCCESS('Nothing to index — all content is up to date.'))
+        else:
+            self.stdout.write(self.style.SUCCESS(f'Dispatched {total_records} records in {total_batches} batches.'))

--- a/enterprise_catalog/apps/search/management/commands/tests/test_incremental_reindex_algolia.py
+++ b/enterprise_catalog/apps/search/management/commands/tests/test_incremental_reindex_algolia.py
@@ -1,0 +1,234 @@
+"""
+Unit tests for the incremental_reindex_algolia management command.
+"""
+from io import StringIO
+from unittest import mock
+
+import ddt
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase, override_settings
+
+from enterprise_catalog.apps.catalog.constants import (
+    COURSE,
+    LEARNER_PATHWAY,
+    PROGRAM,
+)
+
+
+TASK_PATH = (
+    'enterprise_catalog.apps.search.management.commands'
+    '.incremental_reindex_algolia.dispatch_algolia_indexing'
+)
+
+_SAMPLE_SUMMARY = {
+    'force': False,
+    'dry_run': False,
+    'batch_size': 10,
+    'index_name': None,
+    'dispatched': {
+        COURSE: {'records': 5, 'batches': 1},
+        PROGRAM: {'records': 2, 'batches': 1},
+        LEARNER_PATHWAY: {'records': 0, 'batches': 0},
+    },
+}
+
+
+@ddt.ddt
+class IncrementalReindexAlgoliaCommandTests(TestCase):
+    command_name = 'incremental_reindex_algolia'
+
+    def _call(self, *args, **kwargs):
+        out = StringIO()
+        call_command(self.command_name, *args, stdout=out, **kwargs)
+        return out.getvalue()
+
+    # ------------------------------------------------------------------
+    # Default (no-arg) invocation
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_default_invocation_uses_apply_async(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call()
+        mock_task.apply_async.assert_called_once_with(
+            kwargs={
+                'force': False,
+                'dry_run': False,
+                'index_name': None,
+                'content_types': None,
+                'use_apply': False,
+            }
+        )
+        mock_task.apply.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # --no-async
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_no_async_uses_apply(self, mock_task):
+        mock_task.apply.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--no-async')
+        mock_task.apply.assert_called_once_with(
+            kwargs={
+                'force': False,
+                'dry_run': False,
+                'index_name': None,
+                'content_types': None,
+                'use_apply': True,
+            }
+        )
+        mock_task.apply_async.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # --force-all
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_force_all_passes_force_true(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--force-all')
+        _, kwargs = mock_task.apply_async.call_args
+        assert kwargs['kwargs']['force'] is True
+
+    # ------------------------------------------------------------------
+    # --dry-run
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_dry_run_passes_dry_run_true(self, mock_task):
+        dry_run_summary = {**_SAMPLE_SUMMARY, 'dry_run': True}
+        mock_task.apply_async.return_value.get.return_value = dry_run_summary
+        output = self._call('--dry-run')
+        _, kwargs = mock_task.apply_async.call_args
+        assert kwargs['kwargs']['dry_run'] is True
+        assert 'DRY-RUN' in output
+
+    @mock.patch(TASK_PATH)
+    def test_dry_run_summary_note(self, mock_task):
+        dry_run_summary = {**_SAMPLE_SUMMARY, 'dry_run': True}
+        mock_task.apply_async.return_value.get.return_value = dry_run_summary
+        output = self._call('--dry-run')
+        assert 'dry-run' in output.lower()
+
+    # ------------------------------------------------------------------
+    # --index-name
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_index_name_passed_through(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--index-name', 'enterprise_catalog_v2')
+        _, kwargs = mock_task.apply_async.call_args
+        assert kwargs['kwargs']['index_name'] == 'enterprise_catalog_v2'
+
+    @mock.patch(TASK_PATH)
+    def test_index_name_always_shown_in_output(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        output = self._call('--index-name', 'enterprise_catalog_v2')
+        assert 'enterprise_catalog_v2' in output
+
+    @override_settings(ALGOLIA={'INDEX_NAME': 'enterprise_catalog'})
+    @mock.patch(TASK_PATH)
+    def test_resolved_index_shown_when_no_index_name_flag(self, mock_task):
+        """The primary index name from settings is printed even without --index-name."""
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        output = self._call('--index-name', 'other_index')
+        assert 'other_index' in output
+
+    # ------------------------------------------------------------------
+    # --content-type
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_single_content_type(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--content-type', COURSE)
+        _, kwargs = mock_task.apply_async.call_args
+        assert kwargs['kwargs']['content_types'] == [COURSE]
+
+    @mock.patch(TASK_PATH)
+    def test_multiple_content_types(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--content-type', COURSE, PROGRAM)
+        _, kwargs = mock_task.apply_async.call_args
+        assert set(kwargs['kwargs']['content_types']) == {COURSE, PROGRAM}
+
+    @mock.patch(TASK_PATH)
+    def test_no_content_type_passes_none(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call()
+        _, kwargs = mock_task.apply_async.call_args
+        assert kwargs['kwargs']['content_types'] is None
+
+    @ddt.data(COURSE, PROGRAM, LEARNER_PATHWAY)
+    @mock.patch(TASK_PATH)
+    def test_valid_content_type_accepted(self, content_type, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--content-type', content_type)
+        _, kwargs = mock_task.apply_async.call_args
+        assert kwargs['kwargs']['content_types'] == [content_type]
+
+    # ------------------------------------------------------------------
+    # Summary output
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_summary_shows_record_counts(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        output = self._call()
+        assert 'DISPATCH SUMMARY' in output
+        assert COURSE in output
+        assert PROGRAM in output
+        assert LEARNER_PATHWAY in output
+        assert '5' in output  # course record count
+        assert '2' in output  # program record count
+
+    @mock.patch(TASK_PATH)
+    def test_summary_shows_nothing_to_index_when_zero_records(self, mock_task):
+        empty_summary = {
+            'force': False,
+            'dry_run': False,
+            'batch_size': 10,
+            'index_name': None,
+            'dispatched': {
+                COURSE: {'records': 0, 'batches': 0},
+                PROGRAM: {'records': 0, 'batches': 0},
+                LEARNER_PATHWAY: {'records': 0, 'batches': 0},
+            },
+        }
+        mock_task.apply_async.return_value.get.return_value = empty_summary
+        output = self._call()
+        assert 'up to date' in output
+
+    @mock.patch(TASK_PATH)
+    def test_summary_warns_when_no_result_returned(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = None
+        output = self._call()
+        assert 'No summary' in output
+
+    # ------------------------------------------------------------------
+    # Primary-index guard (remove at cutover)
+    # ------------------------------------------------------------------
+
+    @override_settings(ALGOLIA={'INDEX_NAME': 'enterprise_catalog'})
+    def test_guard_blocks_default_invocation_against_primary_index(self):
+        """No --index-name defaults to the primary index, which must be blocked."""
+        with self.assertRaises(CommandError) as ctx:
+            self._call()
+        assert 'enterprise_catalog' in str(ctx.exception)
+
+    @override_settings(ALGOLIA={'INDEX_NAME': 'enterprise_catalog'})
+    def test_guard_blocks_explicit_primary_index_name(self):
+        """--index-name matching the primary index is also blocked."""
+        with self.assertRaises(CommandError):
+            self._call('--index-name', 'enterprise_catalog')
+
+    @override_settings(ALGOLIA={'INDEX_NAME': 'enterprise_catalog'})
+    @mock.patch(TASK_PATH)
+    def test_guard_allows_non_primary_index_name(self, mock_task):
+        """--index-name pointing to a different index bypasses the guard."""
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        output = self._call('--index-name', 'enterprise_catalog_v2')
+        assert 'enterprise_catalog_v2' in output

--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -79,6 +79,8 @@ from enterprise_catalog.apps.search.models import ContentMetadataIndexingState
 
 logger = logging.getLogger(__name__)
 
+_SUPPORTED_CONTENT_TYPES = frozenset({COURSE, PROGRAM, LEARNER_PATHWAY})
+
 # TypeVar for the generic _chunked helper.
 _T = TypeVar('_T')
 
@@ -252,6 +254,8 @@ def dispatch_algolia_indexing(
     dry_run=False,
     include_failed=True,
     index_name=None,
+    content_types=None,
+    use_apply=False,
 ):
     """
     Dispatch Phase 4a incremental Algolia indexing batch tasks.
@@ -259,6 +263,10 @@ def dispatch_algolia_indexing(
     When ``force=True``, dispatch every currently-indexable record. Otherwise,
     dispatch only records that have never been indexed, are stale, or have a
     recorded failure that should be retried.
+
+    ``content_types`` is an optional list of content type strings (e.g.
+    ``['course', 'program']``) that restricts which types are dispatched.
+    Defaults to all three types (course, program, learnerpathway).
 
     **Dispatch ordering matters for child-staleness propagation.**
 
@@ -285,6 +293,15 @@ def dispatch_algolia_indexing(
         mappings.all_indexable_content_keys,
     )
 
+    if content_types is not None:
+        unknown = set(content_types) - _SUPPORTED_CONTENT_TYPES
+        if unknown:
+            raise ValueError(
+                f"Unsupported content_types: {sorted(unknown)}. "
+                f"Must be one of {sorted(_SUPPORTED_CONTENT_TYPES)}."
+            )
+        indexable_keys_by_type = {k: v for k, v in indexable_keys_by_type.items() if k in content_types}
+
     content_keys_to_dispatch = _get_keys_to_dispatch_by_type(
         content_keys_by_type=indexable_keys_by_type,
         mappings=mappings,
@@ -308,7 +325,10 @@ def dispatch_algolia_indexing(
     }
 
     if not dry_run and ordered_groups:
-        chain(*ordered_groups).apply_async()
+        if use_apply:
+            chain(*ordered_groups).apply()
+        else:
+            chain(*ordered_groups).apply_async()
 
     logger.info('dispatch_algolia_indexing summary=%s', summary)
     return summary

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -714,6 +714,7 @@ class TestIndexContentBatch(TestCase):
 
 
 @override_settings(ALGOLIA_INDEXING_BATCH_SIZE=2)
+@ddt.ddt
 class TestDispatchAlgoliaIndexing(TestCase):
     """
     Tests for the Phase 4a dispatcher task.
@@ -1111,6 +1112,95 @@ class TestDispatchAlgoliaIndexing(TestCase):
 
         self.assertEqual(result['dispatched'][LEARNER_PATHWAY], {'records': 0, 'batches': 0})
         self.mock_pathway_si.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # content_types filtering
+    # ------------------------------------------------------------------
+
+    def test_content_types_unknown_value_raises(self):
+        """Passing an unrecognised content type raises ValueError immediately."""
+        with self.assertRaises(ValueError, msg='bogus_type'):
+            dispatch_algolia_indexing(content_types=['bogus_type'])
+
+    # Each tuple: (content_types, exp_courses, exp_programs, exp_pathways)
+    # exp_* == expected record count AND expected .si() call count (1 record per type, batch_size=2)
+    @ddt.data(
+        (None, 1, 1, 1),
+        ([COURSE], 1, 0, 0),
+        ([PROGRAM], 0, 1, 0),
+        ([LEARNER_PATHWAY], 0, 0, 1),
+        ([COURSE, PROGRAM], 1, 1, 0),
+    )
+    @ddt.unpack
+    def test_content_types_filter(self, content_types, exp_courses, exp_programs, exp_pathways):
+        """
+        content_types restricts which content type batches are dispatched.
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='ct-course')
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='ct-pathway')
+        self._set_mappings(
+            all_indexable_content_keys=[course.content_key, program.content_key, pathway.content_key],
+            pathway_to_program_course_keys={pathway.content_key: {program.content_key}},
+        )
+
+        result = dispatch_algolia_indexing(force=True, content_types=content_types)
+
+        self.assertEqual(result['dispatched'][COURSE]['records'], exp_courses)
+        self.assertEqual(result['dispatched'][PROGRAM]['records'], exp_programs)
+        self.assertEqual(result['dispatched'][LEARNER_PATHWAY]['records'], exp_pathways)
+        self.assertEqual(self.mock_course_si.call_count, exp_courses)
+        self.assertEqual(self.mock_program_si.call_count, exp_programs)
+        self.assertEqual(self.mock_pathway_si.call_count, exp_pathways)
+
+    def test_content_types_dry_run_filters_summary_without_dispatching(self):
+        """
+        dry_run=True with content_types set reports zero for excluded types and never calls .si().
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='ct-dry-course')
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key=_program_content_key())
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='ct-dry-pathway')
+        self._set_mappings(
+            all_indexable_content_keys=[course.content_key, program.content_key, pathway.content_key],
+        )
+
+        result = dispatch_algolia_indexing(force=True, dry_run=True, content_types=[COURSE])
+
+        self.assertEqual(result['dispatched'][COURSE], {'records': 1, 'batches': 1})
+        self.assertEqual(result['dispatched'][PROGRAM], {'records': 0, 'batches': 0})
+        self.assertEqual(result['dispatched'][LEARNER_PATHWAY], {'records': 0, 'batches': 0})
+        self.mock_course_si.assert_not_called()
+        self.mock_program_si.assert_not_called()
+        self.mock_pathway_si.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # use_apply
+    # ------------------------------------------------------------------
+
+    def test_use_apply_calls_chain_apply(self):
+        """
+        use_apply=True causes the dispatched chain to be executed via .apply()
+        rather than .apply_async(), making downstream tasks run synchronously.
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='ua-course')
+        self._set_mappings(all_indexable_content_keys=[course.content_key])
+
+        dispatch_algolia_indexing(force=True, use_apply=True)
+
+        self.mock_chain.return_value.apply.assert_called_once()
+        self.mock_chain.return_value.apply_async.assert_not_called()
+
+    def test_use_apply_false_calls_chain_apply_async(self):
+        """
+        use_apply=False (default) dispatches via .apply_async().
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='ua-async-course')
+        self._set_mappings(all_indexable_content_keys=[course.content_key])
+
+        dispatch_algolia_indexing(force=True, use_apply=False)
+
+        self.mock_chain.return_value.apply_async.assert_called_once()
+        self.mock_chain.return_value.apply.assert_not_called()
 
 
 @ddt.ddt


### PR DESCRIPTION
## Summary

- Adds `content_types` filter parameter to `dispatch_algolia_indexing` so callers can limit reindexing to a subset of content types (course, program, learnerpathway)
- Adds `incremental_reindex_algolia` management command (Phase 5) wrapping the Phase 4a dispatcher with CLI flags: `--content-type`, `--index-name`, `--force-all`, `--dry-run`, `--no-async`
- Includes a primary-index safety guard that blocks the command from running against the production Algolia index until we are ready to cut over (guard is marked for removal at cutover)

Why add a content_type filter parameter?
1. The expected usage *during rollout* is pointing it at a v2/staging index, and being able to target a single content type lets you validate courses are indexing correctly before running programs and pathways, which can simplify debugging.
2. if a specific content type gets into a bad state post-cutover (e.g. a pathway staleness bug), you can reindex just pathways without touching the already-healthy courses and programs.

On the other hand, it feels a little YAGNI, so I'm fine yanking the `content-type` argument out if people have feelings.

## Test plan

- [x] `pytest enterprise_catalog/apps/search/tests/test_tasks.py::TestDispatchAlgoliaIndexing` — 21 tests including 5 ddt-parameterized `content_types` filter cases
- [x] `pytest enterprise_catalog/apps/search/management/commands/tests/test_incremental_reindex_algolia.py` — 19 tests covering all flags, summary output, and primary-index guard
- [x] `make quality` — passes clean (pycodestyle, isort, pylint)
- [x] Restart celery worker container to pick up new tasks, then run `./manage.py incremental_reindex_algolia --content-type=program --index-name=dusenbery-dev-2`. Ensure index is updated in dev algolia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
