### PR TITLE
fix: ensure every indexable program/pathway key has an entry in the mapping

### DIFF
--- a/enterprise_catalog/apps/search/indexing_mappings.py
+++ b/enterprise_catalog/apps/search/indexing_mappings.py
@@ -98,15 +98,20 @@ def _compute_indexing_mappings():
     )
     all_indexable_content_keys = set(indexable_courses) | set(indexable_programs) | set(pathway_keys)
 
-    # Ensure every indexable pathway key has an entry in the mapping, even if
-    # it has no associated children. The legacy _get_algolia_products_for_batch
-    # does a bare dict lookup (not .get()) and raises KeyError for missing keys.
+    # Ensure every indexable program/pathway key has an entry in the mapping,
+    # even if it has no associated children. The legacy
+    # _get_algolia_products_for_batch does a bare dict lookup (not .get()) and
+    # raises KeyError for missing keys.
+    all_programs_to_course_keys = dict(program_to_courses)
+    for pk in indexable_programs:
+        all_programs_to_course_keys.setdefault(pk, set())
+
     pathway_to_program_course_keys = dict(pathway_to_programs_courses)
     for pk in pathway_keys:
         pathway_to_program_course_keys.setdefault(pk, set())
 
     return IndexingMappings(
-        program_to_course_keys=dict(program_to_courses),
+        program_to_course_keys=all_programs_to_course_keys,
         pathway_to_program_course_keys=pathway_to_program_course_keys,
         all_indexable_content_keys=all_indexable_content_keys,
     )

--- a/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
+++ b/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
@@ -9,6 +9,12 @@ import logging
 from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 
+from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
+from enterprise_catalog.apps.catalog.algolia_utils import (
+    ALGOLIA_INDEX_SETTINGS,
+    ALGOLIA_REPLICA_INDEX_SETTINGS,
+    new_search_client_or_error,
+)
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
     LEARNER_PATHWAY,
@@ -41,7 +47,16 @@ class Command(BaseCommand):
             '--index-name',
             dest='index_name',
             default=None,
-            help='Target an alternate Algolia index (e.g. for v2 testing).',
+            help='Target Algolia index name.',
+        )
+        parser.add_argument(
+            '--replica-name',
+            dest='replica_index_name',
+            default=None,
+            help=(
+                'Algolia replica index name. '
+                'Defaults to the index name suffixed with "_repl".'
+            ),
         )
         parser.add_argument(
             '--force-all',
@@ -68,6 +83,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         content_types = options['content_types']  # None means all types
         index_name = options['index_name']
+        replica_index_name = options['replica_index_name']
         force_all = options['force_all']
         dry_run = options['dry_run']
         no_async = options['no_async']
@@ -85,6 +101,17 @@ class Command(BaseCommand):
 
         if dry_run:
             self.stdout.write(self.style.WARNING('[DRY-RUN] No Algolia writes will be made.'))
+        else:
+            self.stdout.write('Configuring Algolia index settings...')
+            replica_name = replica_index_name or f'{index_name}_repl'
+            sdk_client = new_search_client_or_error()
+            algolia_client = AlgoliaSearchClient()
+            algolia_client.algolia_index = sdk_client.init_index(index_name)
+            algolia_client.replica_index = sdk_client.init_index(replica_name)
+            primary_settings = {**ALGOLIA_INDEX_SETTINGS, 'replicas': [f'virtual({replica_name})']}
+            algolia_client.set_index_settings(primary_settings)
+            algolia_client.set_index_settings(ALGOLIA_REPLICA_INDEX_SETTINGS, primary_index=False)
+
         self.stdout.write(f'Content types: {", ".join(content_types) if content_types else "all"}')
         self.stdout.write(f'Target index:  {resolved_index or "(not configured)"}')
         self.stdout.write(f'Force all:     {force_all}')

--- a/enterprise_catalog/apps/search/management/commands/tests/test_incremental_reindex_algolia.py
+++ b/enterprise_catalog/apps/search/management/commands/tests/test_incremental_reindex_algolia.py
@@ -16,10 +16,10 @@ from enterprise_catalog.apps.catalog.constants import (
 )
 
 
-TASK_PATH = (
-    'enterprise_catalog.apps.search.management.commands'
-    '.incremental_reindex_algolia.dispatch_algolia_indexing'
-)
+_CMD = 'enterprise_catalog.apps.search.management.commands.incremental_reindex_algolia'
+TASK_PATH = f'{_CMD}.dispatch_algolia_indexing'
+NEW_SDK_CLIENT_PATH = f'{_CMD}.new_search_client_or_error'
+ALGOLIA_CLIENT_PATH = f'{_CMD}.AlgoliaSearchClient'
 
 _SAMPLE_SUMMARY = {
     'force': False,
@@ -37,6 +37,15 @@ _SAMPLE_SUMMARY = {
 @ddt.ddt
 class IncrementalReindexAlgoliaCommandTests(TestCase):
     command_name = 'incremental_reindex_algolia'
+
+    def setUp(self):
+        super().setUp()
+        patcher_sdk = mock.patch(NEW_SDK_CLIENT_PATH)
+        patcher_cls = mock.patch(ALGOLIA_CLIENT_PATH)
+        self.mock_new_sdk_client = patcher_sdk.start()
+        self.mock_algolia_cls = patcher_cls.start()
+        self.addCleanup(patcher_sdk.stop)
+        self.addCleanup(patcher_cls.stop)
 
     def _call(self, *args, **kwargs):
         out = StringIO()
@@ -169,6 +178,45 @@ class IncrementalReindexAlgoliaCommandTests(TestCase):
         self._call('--content-type', content_type)
         _, kwargs = mock_task.apply_async.call_args
         assert kwargs['kwargs']['content_types'] == [content_type]
+
+    # ------------------------------------------------------------------
+    # Index configuration
+    # ------------------------------------------------------------------
+
+    @mock.patch(TASK_PATH)
+    def test_configure_index_called_before_dispatch(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--index-name', 'enterprise_catalog_v2')
+        sdk = self.mock_new_sdk_client.return_value
+        algolia_instance = self.mock_algolia_cls.return_value
+        # Both primary and replica indices are initialized
+        sdk.init_index.assert_any_call('enterprise_catalog_v2')
+        sdk.init_index.assert_any_call('enterprise_catalog_v2_repl')
+        # set_index_settings called twice: primary (with replicas overridden) then replica
+        assert algolia_instance.set_index_settings.call_count == 2
+        primary_call_kwargs = algolia_instance.set_index_settings.call_args_list[0]
+        primary_settings = primary_call_kwargs[0][0]
+        assert primary_settings['replicas'] == ['virtual(enterprise_catalog_v2_repl)']
+        replica_call = algolia_instance.set_index_settings.call_args_list[1]
+        assert replica_call[1].get('primary_index') is False
+
+    @mock.patch(TASK_PATH)
+    def test_explicit_replica_name_used(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
+        self._call('--index-name', 'enterprise_catalog_v2', '--replica-name', 'my_replica')
+        sdk = self.mock_new_sdk_client.return_value
+        sdk.init_index.assert_any_call('enterprise_catalog_v2')
+        sdk.init_index.assert_any_call('my_replica')
+        algolia_instance = self.mock_algolia_cls.return_value
+        primary_settings = algolia_instance.set_index_settings.call_args_list[0][0][0]
+        assert primary_settings['replicas'] == ['virtual(my_replica)']
+
+    @mock.patch(TASK_PATH)
+    def test_configure_index_skipped_on_dry_run(self, mock_task):
+        mock_task.apply_async.return_value.get.return_value = {**_SAMPLE_SUMMARY, 'dry_run': True}
+        self._call('--index-name', 'enterprise_catalog_v2', '--dry-run')
+        self.mock_new_sdk_client.assert_not_called()
+        self.mock_algolia_cls.assert_not_called()
 
     # ------------------------------------------------------------------
     # Summary output

--- a/enterprise_catalog/apps/search/tests/test_indexing_mappings.py
+++ b/enterprise_catalog/apps/search/tests/test_indexing_mappings.py
@@ -136,3 +136,55 @@ class TestComputeIndexingMappings(TestCase):
         )
         # Nonindexable courses must NOT be in the indexable set.
         self.assertNotIn('course-skipped', result.all_indexable_content_keys)
+
+    @mock.patch.object(mappings_module, 'ContentMetadata')
+    @mock.patch.object(mappings_module, 'partition_program_keys_for_indexing')
+    @mock.patch.object(mappings_module, 'partition_course_keys_for_indexing')
+    @mock.patch.object(mappings_module, '_precalculate_content_mappings')
+    def test_childless_program_gets_empty_course_set(
+        self,
+        mock_precalc,
+        mock_partition_courses,
+        mock_partition_programs,
+        mock_content_metadata,
+    ):
+        """
+        A program that has no course associations in _precalculate_content_mappings
+        (because it has no children) must still get an entry in program_to_course_keys
+        so that _get_algolia_products_for_batch doesn't raise KeyError.
+        """
+        # program-orphan is indexable but absent from _precalculate result
+        mock_precalc.return_value = ({}, {})
+        mock_partition_courses.return_value = ([], [])
+        mock_partition_programs.return_value = (['program-orphan'], [])
+        mock_content_metadata.objects.filter.return_value.values_list.return_value = []
+
+        result = mappings_module._compute_indexing_mappings()
+
+        self.assertIn('program-orphan', result.program_to_course_keys)
+        self.assertEqual(result.program_to_course_keys['program-orphan'], set())
+
+    @mock.patch.object(mappings_module, 'ContentMetadata')
+    @mock.patch.object(mappings_module, 'partition_program_keys_for_indexing')
+    @mock.patch.object(mappings_module, 'partition_course_keys_for_indexing')
+    @mock.patch.object(mappings_module, '_precalculate_content_mappings')
+    def test_childless_pathway_gets_empty_program_course_set(
+        self,
+        mock_precalc,
+        mock_partition_courses,
+        mock_partition_programs,
+        mock_content_metadata,
+    ):
+        """
+        A pathway absent from _precalculate_content_mappings (no children) must
+        still appear in pathway_to_program_course_keys with an empty set.
+        """
+        mock_precalc.return_value = ({}, {})
+        mock_partition_courses.return_value = ([], [])
+        mock_partition_programs.return_value = ([], [])
+        mock_content_metadata.objects.filter.return_value.values_list.return_value = ['pathway-orphan']
+
+        result = mappings_module._compute_indexing_mappings()
+
+        self.assertIn('pathway-orphan', result.pathway_to_program_course_keys)
+        self.assertEqual(result.pathway_to_program_course_keys['pathway-orphan'], set())


### PR DESCRIPTION
## Summary

- `_precalculate_content_mappings()` only populates mapping entries for programs/pathways that have ContentMetadata associations, so childless programs and pathways were absent from the dict
- `_get_algolia_products_for_batch` does a bare `dict[key]` lookup (not `.get()`), causing `KeyError` on any program or pathway with no children
- Fixes both cases with `setdefault(pk, set())` after converting the `defaultdict` to a plain `dict`
- Adds regression tests for childless-program and childless-pathway cases
- Configures the incremental index with same settings as the primary index.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)