### PR TITLE
feat: add Video support to incremental Algolia reindex pipeline

### DIFF
--- a/docs/algolia-reindexing/tech-spec.md
+++ b/docs/algolia-reindexing/tech-spec.md
@@ -690,6 +690,10 @@ Instead of updating each frontend's `ALGOLIA_INDEX_NAME` env var and deploying s
 
 **Summary**: Create Celery tasks for indexing batches of each content type (courses, programs, pathways).
 
+> **Note**: Video indexing was not part of the original Phase 3 scope. It was added during Phase 7
+> validation when a ~36k record gap was discovered. See [`docs/algolia-reindexing/videos.md`](videos.md)
+> for the full design.
+
 **Scope**:
 - Create `index_courses_batch_in_algolia` task
 - Create `index_programs_batch_in_algolia` task
@@ -897,13 +901,20 @@ The catalog-query-specific dispatcher task must handle membership removals (see 
 - Document any discrepancies and resolve
 
 **Artifacts**:
-- `scripts/compare_algolia_indices.py` — comparison script (exists in prototype branch)
+- `scripts/validate_algolia_indices.py` — fetches facet distributions and objectID sets from both
+  indices and produces a set-difference report; see script docstring for usage. The script lives on
+  the `aed/algolia-validation` branch (PR #121) and is not merged into this repo yet.
+
+**Findings**:
+- First validation run revealed a ~36k record gap: all `video` content type, none of the other
+  types. Videos come from the `Video` model (not `ContentMetadata`) and were not handled by the
+  incremental pipeline. See [`docs/algolia-reindexing/videos.md`](videos.md) for the fix design.
 
 **Acceptance Criteria**:
 - [ ] v2 index created with identical settings to v1
 - [ ] Full incremental reindex completes successfully
-- [ ] Comparison script reports record count match
-- [ ] Comparison script reports no content discrepancies (or discrepancies are understood/acceptable)
+- [ ] Validation script reports record count match (including videos once implemented)
+- [ ] Validation script reports no content discrepancies (or discrepancies are understood/acceptable)
 - [ ] Search behavior validated in staging environment
 
 **Verification**:

--- a/docs/algolia-reindexing/videos.md
+++ b/docs/algolia-reindexing/videos.md
@@ -1,0 +1,188 @@
+# Video Indexing in the Incremental Reindex Pipeline
+
+## Background
+
+Videos in Algolia come from the `Video` model (`video_catalog` app), not from `ContentMetadata`.
+The monolithic reindex handles them inside `_get_algolia_products_for_batch` via
+`add_video_to_algolia_objects`. The incremental pipeline (`dispatch_algolia_indexing` and its
+batch tasks) was built for `ContentMetadata`-backed content types only, which produced a ~36k
+record gap in the v2 index during Phase 7 validation.
+
+This document describes the design for adding video support to the incremental pipeline.
+
+## Data Model
+
+```
+Video
+  └─ parent_content_metadata (FK → ContentMetadata, course-run type)
+       └─ parent_content_key → content_key of the parent course ContentMetadata
+                                    └─ ContentMetadataIndexingState.last_indexed_at
+```
+
+Production counts (as of Phase 7 validation):
+
+| Entity | Count |
+|--------|-------|
+| `Video` rows | 893 |
+| `VideoSkill` rows | ~5,000 |
+| Algolia records (including enterprise-customer and Spanish duplicates) | ~36,500 |
+
+## Staleness Semantics
+
+A video is treated as stale when its **parent course** is stale. There is no separate
+`ContentMetadataIndexingState` row for `Video` records — the parent course's state acts as
+the proxy.
+
+- `force=True`: all videos are dispatched.
+- `force=False`: only videos whose `parent_content_metadata__parent_content_key` appears in
+  the stale-course set (as computed by `_get_course_keys_for_dispatch`) are dispatched.
+
+After a video batch task runs, **no state row is written**. The parent course's state row
+(updated by `index_courses_batch_in_algolia` when the course itself is indexed in the same
+dispatcher pass) covers it.
+
+**Edge case**: a `--content-type video`-only run leaves the parent course's
+`ContentMetadataIndexingState` unchanged, so those videos will appear stale again on the next
+run and be re-indexed redundantly. This is acceptable at the current scale (893 videos).
+
+## Dispatch Ordering
+
+Videos slot as a fourth group at the end of the existing chain:
+
+```
+courses (parallel group)
+    ↓  [Celery chain barrier — all course tasks complete]
+programs (parallel group)
+    ↓
+pathways (parallel group)
+    ↓
+videos (parallel group)
+```
+
+Videos have no ordering dependency on programs or pathways (their catalog membership is
+derived from DB joins at task execution time, not from Algolia state). The barrier before
+the video group costs nothing and keeps the chain structure uniform.
+
+## Batch Size
+
+**20 video PKs per task** (module-level constant `VIDEO_BATCH_SIZE = 20`). Not pulled from
+settings — the fixed small scale doesn't justify a configurable knob.
+
+~893 videos ÷ 20 = ~45 tasks per full-force run.
+
+## Implementation Plan
+
+### `enterprise_catalog/apps/search/tasks.py`
+
+**New imports**
+
+```python
+from enterprise_catalog.apps.catalog.constants import VIDEO
+from enterprise_catalog.apps.video_catalog.models import Video
+from enterprise_catalog.apps.api.tasks import add_video_to_algolia_objects
+```
+
+**`_SUPPORTED_CONTENT_TYPES`** — add `VIDEO`.
+
+**New constant**
+
+```python
+VIDEO_BATCH_SIZE = 20
+```
+
+**New helper: `_get_video_pks_for_dispatch(stale_course_keys, force) -> list[str]`**
+
+Takes the already-computed stale course key list from `_get_keys_to_dispatch_by_type` rather
+than re-deriving it. This avoids duplicating the staleness DB query and keeps `include_failed`
+logic in one place.
+
+```python
+def _get_video_pks_for_dispatch(stale_course_keys: list[str], force: bool) -> list[str]:
+    if force:
+        return list(Video.objects.values_list('edx_video_id', flat=True))
+    return list(
+        Video.objects.filter(
+            parent_content_metadata__parent_content_key__in=stale_course_keys
+        ).values_list('edx_video_id', flat=True)
+    )
+```
+
+**`_get_keys_to_dispatch_by_type`** — compute courses first, then pass the result into the
+video helper:
+
+```python
+dispatched_course_keys = _get_course_keys_for_dispatch(...)
+...
+VIDEO: _get_video_pks_for_dispatch(
+    stale_course_keys=dispatched_course_keys,
+    force=force,
+),
+```
+
+**`_build_ordered_groups`** — append a video group after pathways. The video group uses
+`video_pks` instead of `content_keys` to reflect the different primary key type.
+
+**New helper: `_get_catalog_membership_by_key(course_keys) -> tuple[dict, dict, dict]`**
+
+Extracted from the monolithic `_get_algolia_products_for_batch` pattern. Returns
+`(customer_uuids_by_key, catalog_uuids_by_key, catalog_queries_by_key)` for the given
+course content keys. Used by `index_videos_batch_in_algolia`; may be useful for other
+future non-`ContentMetadata` content types.
+
+**New task: `index_videos_batch_in_algolia(self, video_pks, index_name=None)`**
+
+Does **not** use `_index_content_batch` (which is `ContentMetadata`-only and manages
+`ContentMetadataIndexingState`). Simpler flow:
+
+1. `Video.objects.filter(edx_video_id__in=video_pks).select_related('parent_content_metadata')`
+2. Collect unique parent course keys via `video.parent_content_metadata.parent_content_key`
+3. Call `_get_catalog_membership_by_key(parent_course_keys)` to get the three membership dicts
+4. For each video, call `add_video_to_algolia_objects(video, customer_uuids, catalog_uuids, catalog_queries)` to produce Algolia objects
+5. `algolia_client.save_objects_batch(all_objects, index_name=index_name)`
+6. Log and return a plain dict summary — no `ContentMetadataIndexingState` writes
+
+**`dispatch_algolia_indexing`** — no structural changes; the `_get_keys_to_dispatch_by_type`
+and `_build_ordered_groups` updates above wire it in. The `dispatched_summary` dict gains a
+`video` key.
+
+**`dispatch_algolia_indexing_for_catalog_query`** — after the existing course/program/pathway
+fan-out, dispatch video tasks for videos whose parent course is among the catalog query's
+course membership. Video tasks are not chained with courses here (no ordering dependency).
+
+### `enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py`
+
+- Add `VIDEO` to `_ALL_CONTENT_TYPES`
+- Add `VIDEO` to `--content-type` choices
+
+### Tests
+
+**`search/tests/test_tasks.py`**
+
+- `TestIndexVideoBatchInAlgolia`
+  - Happy path: videos loaded, catalog membership queried, `save_objects_batch` called with correct objects
+  - Empty batch: no Algolia calls made
+  - Unknown video PKs: handled gracefully (empty queryset)
+
+- `TestGetVideoPksForDispatch`
+  - `force=True` returns all video PKs regardless of parent course staleness
+  - `force=False` returns only videos whose parent course is stale
+  - `force=False` with no stale courses returns an empty list
+
+- `TestDispatchAlgoliaIndexing` — existing suite extended:
+  - `VIDEO` appears in `dispatched_summary`
+  - Video tasks appear as a fourth group after pathways in the dispatched chain
+
+- `TestDispatchAlgoliaIndexingForCatalogQuery` — existing suite extended:
+  - Video tasks are dispatched when the catalog query has matching courses
+
+**`search/management/commands/tests/test_incremental_reindex_algolia.py`**
+
+- `VIDEO` accepted as a `--content-type` value
+- `VIDEO` appears in dispatch summary output
+
+## Out of Scope
+
+- `ContentMetadataIndexingState` rows for `Video` records (can be added later if
+  video-specific staleness tracking — e.g. responding to `fetch_video_skills` runs — is needed)
+- Video deletion from Algolia when a `Video` row is removed (follows the existing
+  content-removal pattern; deferred to a follow-up)

--- a/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
+++ b/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
@@ -19,13 +19,14 @@ from enterprise_catalog.apps.catalog.constants import (
     COURSE,
     LEARNER_PATHWAY,
     PROGRAM,
+    VIDEO,
 )
 from enterprise_catalog.apps.search.tasks import dispatch_algolia_indexing
 
 
 logger = logging.getLogger(__name__)
 
-_ALL_CONTENT_TYPES = [COURSE, PROGRAM, LEARNER_PATHWAY]
+_ALL_CONTENT_TYPES = [COURSE, PROGRAM, LEARNER_PATHWAY, VIDEO]
 
 
 class Command(BaseCommand):

--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -54,18 +54,24 @@ from celery import chain, group, shared_task
 from celery_utils.logged_task import LoggedTask
 from django.conf import settings
 from django.db import IntegrityError
+from django.db.models import Prefetch, Q
 from django.db.utils import OperationalError
 from requests.exceptions import ConnectionError as RequestsConnectionError
 
-from enterprise_catalog.apps.api.tasks import _get_algolia_products_for_batch
+from enterprise_catalog.apps.api.tasks import (
+    _get_algolia_products_for_batch,
+    add_video_to_algolia_objects,
+)
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.catalog.algolia_utils import (
     get_initialized_algolia_client,
 )
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
+    COURSE_RUN,
     LEARNER_PATHWAY,
     PROGRAM,
+    VIDEO,
 )
 from enterprise_catalog.apps.catalog.models import CatalogQuery, ContentMetadata
 from enterprise_catalog.apps.catalog.utils import _partition_aggregation_key
@@ -75,11 +81,14 @@ from enterprise_catalog.apps.search.indexing_mappings import (
     invalidate_indexing_mappings_cache,
 )
 from enterprise_catalog.apps.search.models import ContentMetadataIndexingState
+from enterprise_catalog.apps.video_catalog.models import Video
 
 
 logger = logging.getLogger(__name__)
 
-_SUPPORTED_CONTENT_TYPES = frozenset({COURSE, PROGRAM, LEARNER_PATHWAY})
+_SUPPORTED_CONTENT_TYPES = frozenset({COURSE, PROGRAM, LEARNER_PATHWAY, VIDEO})
+
+VIDEO_BATCH_SIZE = 20
 
 # TypeVar for the generic _chunked helper.
 _T = TypeVar('_T')
@@ -152,6 +161,7 @@ class _LoggedTaskWithRetry(LoggedTask):  # pylint: disable=abstract-method
     boundary.
     """
     autoretry_for = (
+        AlgoliaException,
         RequestsConnectionError,
         IntegrityError,
         OperationalError,
@@ -202,6 +212,83 @@ def index_pathways_batch_in_algolia(
     return asdict(_index_content_batch(content_keys, LEARNER_PATHWAY, index_name=index_name, force=force))
 
 
+@shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
+def index_videos_batch_in_algolia(
+    self,  # pylint: disable=unused-argument
+    video_pks,
+    index_name=None,
+):
+    """
+    Index a batch of Video records into Algolia.
+
+    Unlike the ContentMetadata-backed tasks, this does not write
+    ContentMetadataIndexingState rows — video staleness is proxied through
+    the parent course's state.
+    """
+    if not video_pks:
+        logger.info('index_videos_batch_in_algolia: empty video_pks; skipping.')
+        return {'content_type': VIDEO, 'indexed': 0, 'skipped': 0}
+
+    videos = list(
+        Video.objects.filter(edx_video_id__in=video_pks)
+        .select_related('parent_content_metadata')
+    )
+    if not videos:
+        logger.info('index_videos_batch_in_algolia: no Video rows found for pks=%s', video_pks)
+        return {'content_type': VIDEO, 'indexed': 0, 'skipped': len(video_pks)}
+
+    # PKs dispatched but absent from the DB are skipped from the start so the
+    # returned counts stay consistent with the dispatcher's dispatched totals.
+    skipped = len(video_pks) - len(videos)
+
+    parent_course_keys = list({
+        v.parent_content_metadata.parent_content_key
+        for v in videos
+        if v.parent_content_metadata
+    })
+    customer_uuids_by_key, catalog_uuids_by_key, catalog_queries_by_key = (
+        _get_catalog_membership_by_key(parent_course_keys)
+    )
+
+    algolia_products_by_object_id = {}
+    for video in videos:
+        if not video.parent_content_metadata:
+            logger.warning(
+                'index_videos_batch_in_algolia: video %s has no parent_content_metadata; skipping.',
+                video.edx_video_id,
+            )
+            skipped += 1
+            continue
+        course_key = video.parent_content_metadata.parent_content_key
+        before = len(algolia_products_by_object_id)
+        add_video_to_algolia_objects(
+            video,
+            algolia_products_by_object_id,
+            customer_uuids_by_key[course_key],
+            catalog_uuids_by_key[course_key],
+            catalog_queries_by_key[course_key],
+        )
+        if len(algolia_products_by_object_id) == before:
+            skipped += 1
+
+    algolia_objects = list(algolia_products_by_object_id.values())
+    if not algolia_objects:
+        logger.info(
+            'index_videos_batch_in_algolia: no Algolia objects generated for pks=%s', video_pks,
+        )
+        return {'content_type': VIDEO, 'indexed': 0, 'skipped': len(video_pks)}
+
+    algolia_client = get_initialized_algolia_client()
+    algolia_client.save_objects_batch(algolia_objects, index_name=index_name)
+
+    indexed = len(video_pks) - skipped
+    logger.info(
+        'index_videos_batch_in_algolia: indexed=%d videos, skipped=%d, objects=%d',
+        indexed, skipped, len(algolia_objects),
+    )
+    return {'content_type': VIDEO, 'indexed': indexed, 'skipped': skipped}
+
+
 def _build_ordered_groups(
     records_by_type: dict[str, list[str]],
     batch_size: int,
@@ -211,7 +298,7 @@ def _build_ordered_groups(
 ) -> tuple[list, dict]:
     """
     Materialize per-type content-key batches into an ordered list of Celery
-    ``group``\\s (courses → programs → pathways) and a summary count dict.
+    ``group``\\s (courses → programs → pathways → videos) and a summary count dict.
 
     Tasks use ``.si()`` (immutable signatures) so each task's kwargs are fixed
     at dispatch time and Celery does not forward the previous group's return
@@ -220,7 +307,7 @@ def _build_ordered_groups(
 
     Returns:
         ordered_groups: list of ``group`` objects, one per non-empty content
-            type, in courses → programs → pathways order.
+            type, in courses → programs → pathways → videos order.
         dispatched_summary: ``{content_type: {'records': int, 'batches': int}}``
     """
     task_by_content_type = {
@@ -244,6 +331,21 @@ def _build_ordered_groups(
         dispatched_summary[content_type] = {'records': record_count, 'batches': batch_count}
         if tasks:
             ordered_groups.append(group(tasks))
+
+    # Video group — appended after pathways. Uses edx_video_id PKs, not content_keys,
+    # and its own fixed batch size since scale is independent of the general batch size.
+    video_tasks, video_batch_count, video_record_count = [], 0, 0
+    for batch in _chunked(records_by_type.get(VIDEO, []), VIDEO_BATCH_SIZE):
+        video_batch_count += 1
+        video_record_count += len(batch)
+        if not dry_run:
+            video_tasks.append(
+                index_videos_batch_in_algolia.si(video_pks=batch, index_name=index_name)
+            )
+    dispatched_summary[VIDEO] = {'records': video_record_count, 'batches': video_batch_count}
+    if video_tasks:
+        ordered_groups.append(group(video_tasks))
+
     return ordered_groups, dispatched_summary
 
 
@@ -300,7 +402,6 @@ def dispatch_algolia_indexing(
                 f"Unsupported content_types: {sorted(unknown)}. "
                 f"Must be one of {sorted(_SUPPORTED_CONTENT_TYPES)}."
             )
-        indexable_keys_by_type = {k: v for k, v in indexable_keys_by_type.items() if k in content_types}
 
     content_keys_to_dispatch = _get_keys_to_dispatch_by_type(
         content_keys_by_type=indexable_keys_by_type,
@@ -308,6 +409,12 @@ def dispatch_algolia_indexing(
         force=force,
         include_failed=include_failed,
     )
+
+    # Filter to requested content types AFTER computing dispatch sets so that
+    # video staleness (which piggybacks on course staleness) is always derived
+    # from the full stale-course set, even during video-only runs.
+    if content_types is not None:
+        content_keys_to_dispatch = {k: v for k, v in content_keys_to_dispatch.items() if k in content_types}
 
     ordered_groups, dispatched_summary = _build_ordered_groups(
         records_by_type=content_keys_to_dispatch,
@@ -405,6 +512,16 @@ def dispatch_algolia_indexing_for_catalog_query(
         )
         for content_type in (COURSE, PROGRAM, LEARNER_PATHWAY)
     }
+    # Videos are dispatched for any course being reindexed in this run,
+    # including added/removed-membership courses, since catalog facets change.
+    # Always scope to this catalog query's courses — force=True is not passed
+    # because _get_video_pks_for_dispatch(force=True) returns ALL videos, which
+    # would escape the catalog-query boundary. records_to_dispatch[COURSE] already
+    # contains the full course set when force=True.
+    records_to_dispatch[VIDEO] = _get_video_pks_for_dispatch(
+        stale_course_keys=records_to_dispatch[COURSE],
+        force=False,
+    )
 
     ordered_groups, dispatched_summary = _build_ordered_groups(
         records_by_type=records_to_dispatch,
@@ -756,6 +873,69 @@ def _get_course_keys_for_dispatch(
     return keys_to_dispatch
 
 
+def _get_video_pks_for_dispatch(stale_course_keys: list[str], force: bool) -> list[str]:
+    """
+    Return edx_video_id PKs for Video records that should be dispatched.
+
+    With ``force=True`` every Video row is returned. Otherwise, only videos
+    whose parent course content_key appears in ``stale_course_keys`` are
+    returned — video staleness is proxied through the parent course's state.
+    """
+    if force:
+        return list(Video.objects.values_list('edx_video_id', flat=True))
+    if not stale_course_keys:
+        return []
+    return list(
+        Video.objects.filter(
+            parent_content_metadata__parent_content_key__in=stale_course_keys
+        ).values_list('edx_video_id', flat=True)
+    )
+
+
+def _get_catalog_membership_by_key(
+    course_keys: list[str],
+) -> tuple[dict, dict, dict]:
+    """
+    Return ``(customer_uuids_by_key, catalog_uuids_by_key, catalog_queries_by_key)``
+    for the given course content_keys.
+
+    Membership is accumulated from both the course ContentMetadata record and
+    all of its course-run children, matching the lookup pattern used by
+    ``add_video_to_algolia_objects`` in the monolithic reindex path.
+    """
+    customer_uuids_by_key: dict = defaultdict(set)
+    catalog_uuids_by_key: dict = defaultdict(set)
+    catalog_queries_by_key: dict = defaultdict(set)
+
+    if not course_keys:
+        return customer_uuids_by_key, catalog_uuids_by_key, catalog_queries_by_key
+
+    metadata_qs = ContentMetadata.objects.filter(
+        Q(content_key__in=course_keys, content_type=COURSE)
+        | Q(parent_content_key__in=course_keys, content_type=COURSE_RUN)
+    ).prefetch_related(
+        Prefetch(
+            'catalog_queries',
+            queryset=CatalogQuery.objects.prefetch_related('enterprise_catalogs'),
+        )
+    )
+    for metadata in metadata_qs:
+        course_key = (
+            metadata.content_key
+            if metadata.content_type == COURSE
+            else metadata.parent_content_key
+        )
+        for catalog_query in metadata.catalog_queries.all():
+            catalog_queries_by_key[course_key].add(
+                (str(catalog_query.uuid), catalog_query.title)
+            )
+            for catalog in catalog_query.enterprise_catalogs.all():
+                catalog_uuids_by_key[course_key].add(str(catalog.uuid))
+                customer_uuids_by_key[course_key].add(str(catalog.enterprise_uuid))
+
+    return customer_uuids_by_key, catalog_uuids_by_key, catalog_queries_by_key
+
+
 def _get_catalog_query_content_keys_by_type(catalog_query: CatalogQuery) -> dict[str, list[str]]:
     """
     Return current catalog membership grouped by content type.
@@ -793,12 +973,13 @@ def _get_keys_to_dispatch_by_type(
     indexed more recently than the program itself.
     Pathways add an analogous check against their child programs.
     """
+    course_keys = _get_course_keys_for_dispatch(
+        content_keys=content_keys_by_type.get(COURSE, []),
+        force=force,
+        include_failed=include_failed,
+    )
     return {
-        COURSE: _get_course_keys_for_dispatch(
-            content_keys=content_keys_by_type.get(COURSE, []),
-            force=force,
-            include_failed=include_failed,
-        ),
+        COURSE: course_keys,
         PROGRAM: _get_program_keys_for_dispatch(
             content_keys=content_keys_by_type.get(PROGRAM, []),
             program_to_course_keys=mappings.program_to_course_keys,
@@ -810,6 +991,10 @@ def _get_keys_to_dispatch_by_type(
             pathway_to_program_course_keys=mappings.pathway_to_program_course_keys,
             force=force,
             include_failed=include_failed,
+        ),
+        VIDEO: _get_video_pks_for_dispatch(
+            stale_course_keys=course_keys,
+            force=force,
         ),
     }
 

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -13,9 +13,12 @@ from django.test.utils import override_settings
 
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
+    COURSE_RUN,
     LEARNER_PATHWAY,
     PROGRAM,
+    VIDEO,
 )
+from enterprise_catalog.apps.catalog.models import EnterpriseCatalog
 from enterprise_catalog.apps.catalog.tests.factories import (
     CatalogQueryFactory,
     ContentMetadataFactory,
@@ -28,11 +31,15 @@ from enterprise_catalog.apps.search.tasks import (
     BatchSummary,
     IndexingDecision,
     RecordOutcome,
+    _build_objects_by_content_key,
     _chunked,
     _extract_program_keys,
+    _finalize_decision,
+    _get_catalog_membership_by_key,
     _get_content_modified_by_key,
     _get_indexable_keys_by_content_type,
     _get_indexing_state_by_key,
+    _get_video_pks_for_dispatch,
     _group_aggregation_keys_by_content_type,
     _has_newer_child_index,
     _index_content_batch,
@@ -46,6 +53,7 @@ from enterprise_catalog.apps.search.tasks import (
 from enterprise_catalog.apps.search.tests.factories import (
     ContentMetadataIndexingStateFactory,
 )
+from enterprise_catalog.apps.video_catalog.tests.factories import VideoFactory
 
 
 def _algolia_object(content_key, content_type=COURSE, shard_index=0):
@@ -737,6 +745,9 @@ class TestDispatchAlgoliaIndexing(TestCase):
         self.mock_pathway_si = mock.patch.object(
             search_tasks.index_pathways_batch_in_algolia, 'si',
         ).start()
+        self.mock_video_si = mock.patch.object(
+            search_tasks.index_videos_batch_in_algolia, 'si',
+        ).start()
         # Prevent actual Celery chain/group dispatch
         self.mock_group = mock.patch.object(search_tasks, 'group').start()
         self.mock_chain = mock.patch.object(search_tasks, 'chain').start()
@@ -774,12 +785,33 @@ class TestDispatchAlgoliaIndexing(TestCase):
                 COURSE: {'records': 1, 'batches': 1},
                 PROGRAM: {'records': 1, 'batches': 1},
                 LEARNER_PATHWAY: {'records': 1, 'batches': 1},
+                VIDEO: {'records': 0, 'batches': 0},
             },
         })
         self.mock_invalidate_cache.assert_called_once_with()
         self.mock_course_si.assert_not_called()
         self.mock_program_si.assert_not_called()
         self.mock_pathway_si.assert_not_called()
+
+    def test_dry_run_with_video_records_does_not_dispatch_video_tasks(self):
+        """
+        dry_run=True with video records in the DB reports the correct summary
+        but never calls index_videos_batch_in_algolia.si(). Covers the
+        ``if not dry_run:`` False branch in _build_ordered_groups for videos.
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='course-video-dryrun')
+        course_run = ContentMetadataFactory(
+            content_type=COURSE_RUN,
+            parent_content_key=course.content_key,
+        )
+        VideoFactory(parent_content_metadata=course_run)
+        self._set_mappings(all_indexable_content_keys=[course.content_key])
+
+        result = dispatch_algolia_indexing(force=True, dry_run=True)
+
+        self.assertEqual(result['dispatched'][VIDEO]['records'], 1)
+        self.assertEqual(result['dispatched'][VIDEO]['batches'], 1)
+        self.mock_video_si.assert_not_called()
 
     def test_force_false_does_not_invalidate_cache(self):
         course = ContentMetadataFactory(content_type=COURSE, content_key='course-no-force')
@@ -993,6 +1025,7 @@ class TestDispatchAlgoliaIndexing(TestCase):
             COURSE: {'records': 0, 'batches': 0},
             PROGRAM: {'records': 0, 'batches': 0},
             LEARNER_PATHWAY: {'records': 0, 'batches': 0},
+            VIDEO: {'records': 0, 'batches': 0},
         })
         self.mock_course_si.assert_not_called()
         self.mock_program_si.assert_not_called()
@@ -1172,6 +1205,63 @@ class TestDispatchAlgoliaIndexing(TestCase):
         self.mock_course_si.assert_not_called()
         self.mock_program_si.assert_not_called()
         self.mock_pathway_si.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # video dispatch wiring
+    # ------------------------------------------------------------------
+
+    def test_videos_dispatched_as_fourth_group_on_force(self):
+        """
+        ``force=True`` dispatches every Video as a fourth group after pathways,
+        keyed by ``edx_video_id`` (not content_key), regardless of whether the
+        parent course is otherwise stale. Pins the ``_build_ordered_groups``
+        video-group wiring at the dispatcher level.
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='course-with-video')
+        course_run = ContentMetadataFactory(
+            content_type=COURSE_RUN, parent_content_key=course.content_key,
+        )
+        video = VideoFactory(parent_content_metadata=course_run)
+        self._set_mappings(all_indexable_content_keys=[course.content_key])
+
+        result = dispatch_algolia_indexing(force=True)
+
+        self.assertEqual(result['dispatched'][VIDEO], {'records': 1, 'batches': 1})
+        self.mock_video_si.assert_called_once_with(
+            video_pks=[video.edx_video_id],
+            index_name=None,
+        )
+
+    def test_video_only_run_still_derives_videos_from_stale_courses(self):
+        """
+        A ``content_types=['video']`` run with ``force=False`` must still
+        compute course staleness and dispatch the videos whose parent course is
+        stale — even though COURSE itself is filtered out of the dispatch set.
+
+        This pins the reason the ``content_types`` filter is applied *after*
+        ``_get_keys_to_dispatch_by_type``: video staleness piggybacks on the
+        full stale-course set, so filtering COURSE out beforehand would starve
+        the video derivation and dispatch nothing.
+        """
+        # A never-indexed (therefore stale) course, its run, and a video.
+        course = ContentMetadataFactory(content_type=COURSE, content_key='course-stale-for-video')
+        course_run = ContentMetadataFactory(
+            content_type=COURSE_RUN, parent_content_key=course.content_key,
+        )
+        video = VideoFactory(parent_content_metadata=course_run)
+        self._set_mappings(all_indexable_content_keys=[course.content_key])
+
+        result = dispatch_algolia_indexing(force=False, content_types=[VIDEO])
+
+        # COURSE is filtered out of dispatch, but its staleness still drove the
+        # video derivation.
+        self.assertEqual(result['dispatched'][COURSE], {'records': 0, 'batches': 0})
+        self.assertEqual(result['dispatched'][VIDEO], {'records': 1, 'batches': 1})
+        self.mock_course_si.assert_not_called()
+        self.mock_video_si.assert_called_once_with(
+            video_pks=[video.edx_video_id],
+            index_name=None,
+        )
 
     # ------------------------------------------------------------------
     # use_apply
@@ -1410,6 +1500,7 @@ class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
                 COURSE: {'records': 3, 'batches': 2},
                 PROGRAM: {'records': 1, 'batches': 1},
                 LEARNER_PATHWAY: {'records': 1, 'batches': 1},
+                VIDEO: {'records': 0, 'batches': 0},
             },
         })
         self.mock_invalidate_cache.assert_not_called()
@@ -1545,6 +1636,236 @@ class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
         self.mock_invalidate_cache.assert_not_called()
 
 
+class TestGetVideoPksForDispatch(TestCase):
+    """
+    Tests for ``_get_video_pks_for_dispatch``.
+    """
+
+    def setUp(self):
+        # A course-run ContentMetadata with parent_content_key pointing to a course.
+        self.course_key = 'course-v1:Org+Course+Run'
+        self.course_run = ContentMetadataFactory(
+            content_type=COURSE_RUN,
+            parent_content_key=self.course_key,
+        )
+        self.video = VideoFactory(parent_content_metadata=self.course_run)
+
+    def test_force_returns_all_video_pks(self):
+        pks = _get_video_pks_for_dispatch(stale_course_keys=[], force=True)
+        self.assertIn(self.video.edx_video_id, pks)
+
+    def test_force_false_with_matching_stale_course(self):
+        pks = _get_video_pks_for_dispatch(
+            stale_course_keys=[self.course_key],
+            force=False,
+        )
+        self.assertIn(self.video.edx_video_id, pks)
+
+    def test_force_false_with_no_matching_stale_course(self):
+        pks = _get_video_pks_for_dispatch(
+            stale_course_keys=['some-other-course'],
+            force=False,
+        )
+        self.assertNotIn(self.video.edx_video_id, pks)
+
+    def test_force_false_with_empty_stale_courses_returns_empty(self):
+        pks = _get_video_pks_for_dispatch(stale_course_keys=[], force=False)
+        self.assertEqual(pks, [])
+
+
+class TestGetCatalogMembershipByKey(TestCase):
+    """
+    Tests for ``_get_catalog_membership_by_key``.
+    """
+
+    def test_empty_course_keys_returns_empty_dicts(self):
+        customer_uuids, catalog_uuids, catalog_queries = _get_catalog_membership_by_key([])
+        self.assertEqual(dict(customer_uuids), {})
+        self.assertEqual(dict(catalog_uuids), {})
+        self.assertEqual(dict(catalog_queries), {})
+
+    def test_course_with_catalog_membership_is_resolved(self):
+        catalog_query = CatalogQueryFactory()
+        enterprise_catalog = EnterpriseCatalog.objects.create(
+            enterprise_uuid=uuid4(),
+            catalog_query=catalog_query,
+            title='Test Catalog',
+        )
+
+        course_key = 'course-v1:Org+Membership+2024'
+        course = ContentMetadataFactory(content_type='course', content_key=course_key)
+        course.catalog_queries.set([catalog_query])
+
+        customer_uuids, catalog_uuids, catalog_queries = _get_catalog_membership_by_key(
+            [course_key]
+        )
+
+        self.assertIn(str(enterprise_catalog.enterprise_uuid), customer_uuids[course_key])
+        self.assertIn(str(enterprise_catalog.uuid), catalog_uuids[course_key])
+        expected_query_tuple = (str(catalog_query.uuid), catalog_query.title)
+        self.assertIn(expected_query_tuple, catalog_queries[course_key])
+
+    def test_course_run_membership_accumulates_under_parent_course_key(self):
+        """
+        Membership attached to a COURSE_RUN record (not the course itself) is
+        accumulated under the parent course's content_key. This is the branch
+        that actually matters for videos: a video's parent is always a
+        course-run, and catalog queries may be associated at the run level.
+
+        Exercises the ``Q(parent_content_key__in=..., content_type=COURSE_RUN)``
+        leg of ``_get_catalog_membership_by_key``, which the course-level test
+        above does not touch.
+        """
+        catalog_query = CatalogQueryFactory()
+        enterprise_catalog = EnterpriseCatalog.objects.create(
+            enterprise_uuid=uuid4(),
+            catalog_query=catalog_query,
+            title='Run-Level Catalog',
+        )
+
+        course_key = 'course-v1:Org+RunMembership+2024'
+        # No COURSE record carries the query — only the course-run does.
+        course_run = ContentMetadataFactory(
+            content_type=COURSE_RUN,
+            parent_content_key=course_key,
+        )
+        course_run.catalog_queries.set([catalog_query])
+
+        customer_uuids, catalog_uuids, catalog_queries = _get_catalog_membership_by_key(
+            [course_key]
+        )
+
+        # Membership keyed by the parent course, sourced entirely from the run.
+        self.assertIn(str(enterprise_catalog.enterprise_uuid), customer_uuids[course_key])
+        self.assertIn(str(enterprise_catalog.uuid), catalog_uuids[course_key])
+        self.assertIn(
+            (str(catalog_query.uuid), catalog_query.title),
+            catalog_queries[course_key],
+        )
+
+
+class TestIndexVideoBatchInAlgolia(TestCase):
+    """
+    Tests for ``index_videos_batch_in_algolia``.
+    """
+    # pylint: disable=no-value-for-parameter
+
+    def setUp(self):
+        self.course_key = 'course-v1:Org+Video+2024'
+        self.course_run = ContentMetadataFactory(
+            content_type=COURSE_RUN,
+            parent_content_key=self.course_key,
+        )
+        self.video = VideoFactory(parent_content_metadata=self.course_run)
+
+        self.mock_algolia_client = mock.MagicMock()
+        self.mock_membership = mock.patch(
+            'enterprise_catalog.apps.search.tasks._get_catalog_membership_by_key',
+            return_value=(
+                {self.course_key: {'customer-uuid-1'}},
+                {self.course_key: {'catalog-uuid-1'}},
+                {self.course_key: {('query-uuid-1', 'Query Title')}},
+            ),
+        )
+        self.mock_add_video = mock.patch(
+            'enterprise_catalog.apps.search.tasks.add_video_to_algolia_objects',
+            side_effect=lambda v, products, *a, **kw: products.update(
+                {f'{v.edx_video_id}-obj': {'objectID': f'{v.edx_video_id}-obj'}}
+            ),
+        )
+        self.mock_get_client = mock.patch(
+            'enterprise_catalog.apps.search.tasks.get_initialized_algolia_client',
+            return_value=self.mock_algolia_client,
+        )
+
+    def test_happy_path_calls_save_objects_batch(self):
+        with self.mock_membership, self.mock_add_video, self.mock_get_client:
+            result = search_tasks.index_videos_batch_in_algolia(
+                video_pks=[self.video.edx_video_id],
+                index_name='test-index',
+            )
+
+        self.assertEqual(result['indexed'], 1)
+        self.assertEqual(result['skipped'], 0)
+        self.mock_algolia_client.save_objects_batch.assert_called_once()
+        _, call_kwargs = self.mock_algolia_client.save_objects_batch.call_args
+        self.assertEqual(call_kwargs['index_name'], 'test-index')
+
+    def test_empty_video_pks_returns_early_without_db_query(self):
+        with mock.patch(
+            'enterprise_catalog.apps.search.tasks._get_catalog_membership_by_key'
+        ) as mock_membership:
+            result = search_tasks.index_videos_batch_in_algolia(video_pks=[])
+
+        self.assertEqual(result['indexed'], 0)
+        mock_membership.assert_not_called()
+
+    def test_unknown_video_pks_returns_without_algolia_call(self):
+        with self.mock_membership, self.mock_get_client:
+            result = search_tasks.index_videos_batch_in_algolia(
+                video_pks=['nonexistent-video-id'],
+            )
+
+        self.assertEqual(result['indexed'], 0)
+        self.assertEqual(result['skipped'], 1)
+        self.mock_algolia_client.save_objects_batch.assert_not_called()
+
+    def test_video_with_no_parent_content_metadata_is_skipped(self):
+        """
+        A video whose parent_content_metadata is None (dangling FK via DO_NOTHING)
+        is counted as skipped and does not call add_video_to_algolia_objects.
+        The valid sibling in the same batch still produces an Algolia object.
+        """
+        mock_orphan = mock.MagicMock()
+        mock_orphan.edx_video_id = 'orphan-vid'
+        mock_orphan.parent_content_metadata = None
+
+        mock_valid = mock.MagicMock()
+        mock_valid.edx_video_id = self.video.edx_video_id
+        mock_valid.parent_content_metadata = self.course_run
+
+        with mock.patch.object(search_tasks.Video, 'objects') as mock_mgr:
+            mock_mgr.filter.return_value.select_related.return_value = [mock_orphan, mock_valid]
+            with self.mock_membership, self.mock_add_video, self.mock_get_client:
+                result = search_tasks.index_videos_batch_in_algolia(
+                    video_pks=['orphan-vid', self.video.edx_video_id],
+                )
+
+        self.assertEqual(result['skipped'], 1)
+        self.assertEqual(result['indexed'], 1)
+        self.mock_algolia_client.save_objects_batch.assert_called_once()
+
+    def test_no_algolia_objects_generated_returns_early(self):
+        """
+        When add_video_to_algolia_objects produces no objects (e.g. the video
+        has no catalog membership), the task returns early without calling
+        save_objects_batch.
+        """
+        with self.mock_membership, mock.patch(
+            'enterprise_catalog.apps.search.tasks.add_video_to_algolia_objects',
+        ):
+            result = search_tasks.index_videos_batch_in_algolia(
+                video_pks=[self.video.edx_video_id],
+            )
+
+        self.assertEqual(result['indexed'], 0)
+        self.assertEqual(result['skipped'], 1)  # len(video_pks)
+        self.mock_algolia_client.save_objects_batch.assert_not_called()
+
+    def test_algolia_exception_propagates_for_retry(self):
+        """
+        ``AlgoliaException`` from ``save_objects_batch`` propagates out of the
+        task so that ``_LoggedTaskWithRetry.autoretry_for`` can catch it and
+        schedule a retry.
+        """
+        self.mock_algolia_client.save_objects_batch.side_effect = AlgoliaException('algolia boom')
+        with self.mock_membership, self.mock_add_video, self.mock_get_client:
+            with self.assertRaises(AlgoliaException):
+                search_tasks.index_videos_batch_in_algolia(
+                    video_pks=[self.video.edx_video_id],
+                )
+
+
 class TestRecordOutcome(TestCase):
     """
     Pinning tests for the ``RecordOutcome`` StrEnum.
@@ -1675,3 +1996,80 @@ class TestIndexingDecisionConstructors(TestCase):
         decision.outcome = RecordOutcome.FAILED
         self.assertEqual(decision.desired_outcome, RecordOutcome.INDEXED)
         self.assertEqual(decision.outcome, RecordOutcome.FAILED)
+
+    def test_explicitly_set_outcome_is_not_overwritten_by_post_init(self):
+        """
+        Constructing IndexingDecision directly with outcome= already set
+        leaves that value untouched — __post_init__ only fills in the default
+        when outcome is None. Covers the ``outcome is not None`` branch.
+        """
+        decision = IndexingDecision(
+            content_key='c-1',
+            desired_outcome=RecordOutcome.INDEXED,
+            outcome=RecordOutcome.FAILED,
+        )
+        self.assertEqual(decision.desired_outcome, RecordOutcome.INDEXED)
+        self.assertEqual(decision.outcome, RecordOutcome.FAILED)
+
+
+class TestBuildObjectsByContentKey(TestCase):
+    """
+    Tests for ``_build_objects_by_content_key``.
+    """
+
+    def test_objects_with_mismatched_aggregation_key_are_dropped(self):
+        """
+        The legacy generator sometimes includes objects for related content
+        (e.g. courses pulled into a program batch). Objects whose
+        aggregation_key doesn't match any of the batch's content keys are
+        silently dropped. Covers the ``agg_key not in aggregation_key_to_content_key``
+        branch.
+        """
+        target_key = 'course-v1:Org+Target+Run'
+        mappings = IndexingMappings(
+            program_to_course_keys={},
+            pathway_to_program_course_keys={},
+            all_indexable_content_keys={target_key},
+        )
+        unrelated_obj = {
+            'objectID': 'unrelated-0',
+            'aggregation_key': 'course:unrelated-key',
+        }
+        target_obj = {
+            'objectID': 'target-0',
+            'aggregation_key': f'course:{target_key}',
+        }
+
+        with mock.patch(
+            'enterprise_catalog.apps.search.tasks._get_algolia_products_for_batch',
+            return_value=[unrelated_obj, target_obj],
+        ):
+            result = _build_objects_by_content_key([target_key], COURSE, mappings)
+
+        self.assertEqual(result[target_key], [target_obj])
+        self.assertNotIn('unrelated-key', result)
+
+
+class TestFinalizeDecision(TestCase):
+    """
+    Direct unit tests for ``_finalize_decision``.
+    """
+
+    def test_unknown_outcome_is_a_silent_noop(self):
+        """
+        ``_finalize_decision`` silently falls through when outcome is not one
+        of the four RecordOutcome members. Covers the False branch of the
+        final ``elif`` (outcome == INDEXED).
+        """
+        results = BatchSummary(content_type=COURSE)
+        decision = IndexingDecision.skipped(
+            content_key='c-1', content=None, state=None,
+        )
+        decision.outcome = 'unexpected'
+
+        _finalize_decision(decision, results)
+
+        self.assertEqual(results.indexed, 0)
+        self.assertEqual(results.skipped, 0)
+        self.assertEqual(results.removed, 0)
+        self.assertEqual(results.failed, 0)


### PR DESCRIPTION
## Summary

- Adds `index_videos_batch_in_algolia` Celery task to index `Video` model records into Algolia via the incremental pipeline
- (Hopefully) Closes the ~36k record gap identified in Phase 7 validation (100% of the v1/v2 delta was `video` content type), see https://github.com/edx/enterprise-catalog/pull/121
- Adds design doc at `docs/algolia-reindexing/videos.md` and updates `tech-spec.md` to reference it
- Note that this PR does not include the work to determine when a video needs to be *removed* from the search index. That's in the scope of this follow-up ticket: https://2u-internal.atlassian.net/browse/ENT-11945

## Background

The incremental reindex pipeline (`dispatch_algolia_indexing`) was built for `ContentMetadata`-backed types only. `Video` records live in the `video_catalog` app and are not `ContentMetadata` — they were never dispatched, leaving the v2 index with 0 video records.

## Design

Videos don't get their own `ContentMetadataIndexingState` row. Instead, a video is treated as stale when its **parent course** is stale. `_get_video_pks_for_dispatch(stale_course_keys, force)` takes the already-computed stale course key list from `_get_keys_to_dispatch_by_type` and queries `Video.parent_content_metadata__parent_content_key__in=stale_course_keys`.

Video tasks slot as a **4th chain group** after pathways (courses → programs → pathways → videos), using a fixed `VIDEO_BATCH_SIZE = 20` (~45 tasks for a full-force run over 893 videos).

Catalog membership (customer UUIDs, catalog UUIDs, catalog query tuples) is resolved per batch by `_get_catalog_membership_by_key`, which replicates the first-pass lookup from the monolithic `_get_algolia_products_for_batch` path that `add_video_to_algolia_objects` expects.

See `docs/algolia-reindexing/videos.md` for full design rationale.

## Changes

- `search/tasks.py` — `index_videos_batch_in_algolia` task + `_get_video_pks_for_dispatch` + `_get_catalog_membership_by_key` helpers; `VIDEO` added to `_SUPPORTED_CONTENT_TYPES`, `_build_ordered_groups`, `_get_keys_to_dispatch_by_type`, and `dispatch_algolia_indexing_for_catalog_query`
- `management/commands/incremental_reindex_algolia.py` — `VIDEO` added to `_ALL_CONTENT_TYPES` / `--content-type` choices
- `search/tests/test_tasks.py` — 9 new tests covering dispatch helpers, catalog membership resolution, and the batch task itself

## Test plan

- [ ] Run `./manage.py incremental_reindex_algolia --index-name enterprise_catalog_v2 --force-all --no-async` and verify video records appear in Algolia
- [ ] Run with `--content-type video --force-all` and confirm only video tasks are dispatched
- [ ] Re-run the validation script and confirm the video gap closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
