### PR TITLE
chore: change the cron schedule to run on friday instead of monday

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -2,7 +2,7 @@ name: Upgrade Python Requirements
 
 on:
   schedule:
-    - cron: "0 2 * * 1"
+    - cron: "0 2 * * 5"
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
