### PR TITLE
chore: upgrade codecov-action to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         docker exec -e TOXENV=py312-${{ matrix.django-version }} -u root enterprise.catalog.app /edx/app/enterprise_catalog/enterprise_catalog/validate.sh
     - name: Code Coverage
       if: matrix.python-version == '3.12' && matrix.django-version=='django52'
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         fail_ci_if_error: false


### PR DESCRIPTION
[ENT-11952](https://2u-internal.atlassian.net/browse/ENT-11952)

Branch order : feature-->master

## Summary

Upgrade `codecov/codecov-action` in CI from `v5` to `v7` to address intermittent Codecov upload failures caused by the older uploader verification path.

## Changes

- update `.github/workflows/ci.yml`
- upgrade `codecov/codecov-action` from `v5` to `v7`

