### PR TITLE
feat: add ALGOLIA[INCREMENTAL_INDEX_NAME] setting and wire into dispatcher tasks

### DIFF
--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -405,6 +405,8 @@ def dispatch_algolia_indexing(
     until every task in the current group has completed.  Empty groups are
     omitted from the chain.
     """
+    index_name = index_name or settings.ALGOLIA.get('INCREMENTAL_INDEX_NAME')
+
     if force:
         invalidate_indexing_mappings_cache()
 
@@ -478,6 +480,8 @@ def dispatch_algolia_indexing_for_catalog_query(
     catalog query, but doesn't look stale based on index time, is also reindexed
     so that the membership facets of such Algolia records are updated.
     """
+    index_name = index_name or settings.ALGOLIA.get('INCREMENTAL_INDEX_NAME')
+
     try:
         catalog_query = CatalogQuery.objects.get(id=catalog_query_id)
     except CatalogQuery.DoesNotExist:

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -1293,6 +1293,18 @@ class TestDispatchAlgoliaIndexing(TestCase):
         self.mock_chain.return_value.apply_async.assert_called_once()
         self.mock_chain.return_value.apply.assert_not_called()
 
+    @override_settings(ALGOLIA={'INCREMENTAL_INDEX_NAME': 'v2-incremental'})
+    def test_incremental_index_name_from_settings_when_not_passed(self):
+        """
+        When no index_name is passed, the task falls back to ALGOLIA['INCREMENTAL_INDEX_NAME'].
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='incr-name-course')
+        self._set_mappings(all_indexable_content_keys=[course.content_key])
+
+        result = dispatch_algolia_indexing(force=True, dry_run=True)
+
+        self.assertEqual(result['index_name'], 'v2-incremental')
+
 
 @ddt.ddt
 class TestDispatchAlgoliaIndexingHelpers(TestCase):
@@ -1635,6 +1647,26 @@ class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
         self.algolia_client.get_aggregation_keys_for_catalog_query.assert_not_called()
         self.mock_course_si.assert_not_called()
         self.mock_invalidate_cache.assert_not_called()
+
+    @override_settings(ALGOLIA={'INCREMENTAL_INDEX_NAME': 'v2-incremental'})
+    def test_incremental_index_name_from_settings_when_not_passed(self):
+        """
+        When no index_name is passed, the task falls back to ALGOLIA['INCREMENTAL_INDEX_NAME']
+        and passes it to the Algolia client.
+        """
+        _content, catalog_query = self._create_catalog_membership(COURSE, 'incr-cq-course')
+
+        result = search_tasks.dispatch_algolia_indexing_for_catalog_query(
+            catalog_query.id,
+            dry_run=True,
+            force=True,
+        )
+
+        self.assertEqual(result['index_name'], 'v2-incremental')
+        self.algolia_client.get_aggregation_keys_for_catalog_query.assert_called_once_with(
+            catalog_query.uuid,
+            index_name='v2-incremental',
+        )
 
 
 class TestGetVideoPksForDispatch(TestCase):

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -437,6 +437,7 @@ ALGOLIA = {
     'REPLICA_INDEX_NAME': '',
     'APPLICATION_ID': '',
     'API_KEY': '',
+    'INCREMENTAL_INDEX_NAME': None,
 }
 
 # How long to cache the precomputed program/pathway membership mappings


### PR DESCRIPTION
## Summary

- Adds `ALGOLIA['INCREMENTAL_INDEX_NAME']` (default `None`) to `settings.ALGOLIA` in `base.py`
- Both `dispatch_algolia_indexing` and `dispatch_algolia_indexing_for_catalog_query` now fall back to this key when no explicit `index_name` argument is passed, so the v2 index can be configured once in settings rather than threaded through every call site
- Adds two tests covering the settings-based resolution path for each dispatcher

## Test plan

- [ ] `pytest enterprise_catalog/apps/search/tests/test_tasks.py -k "incremental_index_name_from_settings"` passes (2 tests)
- [ ] Full search task suite: `pytest enterprise_catalog/apps/search/tests/test_tasks.py` — 96 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)