### PR TITLE
feat: add ALGOLIA[ALLOWED_INDEX_NAMES] for secured API key index restriction (Phase 8a)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ tx
 # claude code personalization
 .claude/settings.local.json
 prompts.db
+.claude/worktrees/
 
 # Ralph
 .ralph/.*

--- a/docs/algolia-reindexing/tech-spec.md
+++ b/docs/algolia-reindexing/tech-spec.md
@@ -978,7 +978,7 @@ The catalog-query-specific dispatcher task must handle membership removals (see 
 
 **Scope**:
 - Keep legacy `reindex_algolia` cron running (writes to v1)
-- Enable `ENABLE_INCREMENTAL_ALGOLIA_INDEXING` flag with `INDEX_NAME` set to v2
+- Enable `ENABLE_INCREMENTAL_ALGOLIA_INDEXING` flag with `INCREMENTAL_INDEX_NAME` set to the v2 index name
 - Configure stragglers cron for `dispatch_algolia_indexing` (writes to v2)
 - Both indices are now being updated in parallel
 - Deploy enterprise-catalog

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -46,6 +46,10 @@ class AlgoliaSearchClient:
     def algolia_replica_index_name(self):
         return settings.ALGOLIA.get('REPLICA_INDEX_NAME')
 
+    @property
+    def algolia_allowed_index_names(self):
+        return settings.ALGOLIA.get('ALLOWED_INDEX_NAMES')
+
     def init_index(self):
         """
         Initializes an index within Algolia. Initializing an index will create it if it doesn't exist.
@@ -418,14 +422,11 @@ class AlgoliaSearchClient:
             'userToken': user_id,
         }
 
-        # Determine indices to restrict
-        indices = []
-        if self.algolia_index_name:
-            indices.append(self.algolia_index_name)
-        if self.algolia_replica_index_name:
-            indices.append(self.algolia_replica_index_name)
-        if indices:
-            restrictions |= {'restrictIndices': indices}
+        # Determine indices to restrict.  ALLOWED_INDEX_NAMES overrides the
+        # default [INDEX_NAME, REPLICA_INDEX_NAME] pair so that during cutover
+        # frontends can access both the v1 and v2 indices with a single key.
+        indices = self.algolia_allowed_index_names or [self.algolia_index_name, self.algolia_replica_index_name]
+        restrictions |= {'restrictIndices': indices}
 
         # Generate secured api key
         logger.info('[AlgoliaSearchClient.generate_secured_api_key] restrictions: %s', restrictions)

--- a/enterprise_catalog/apps/api_client/tests/test_algolia.py
+++ b/enterprise_catalog/apps/api_client/tests/test_algolia.py
@@ -364,3 +364,53 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
         client = AlgoliaSearchClient()
         with self.assertRaises(ImproperlyConfigured):
             client.get_object_ids_for_aggregation_key('course:edx-abc')
+
+
+class TestAlgoliaSearchClientGenerateSecuredApiKey(TestCase):
+    """
+    Tests for ``generate_secured_api_key`` -- specifically the ``restrictIndices`` logic.
+    """
+    SEARCH_API_KEY = 'test-search-api-key'
+    INDEX_NAME = 'enterprise_catalog'
+    REPLICA_INDEX_NAME = 'enterprise_catalog_replica'
+    V2_INDEX_NAME = 'enterprise_catalog_v2'
+
+    def _build_client(self, allowed_index_names=None):
+        client = AlgoliaSearchClient()
+        patcher_index = mock.patch.object(
+            AlgoliaSearchClient, 'algolia_index_name',
+            new_callable=mock.PropertyMock, return_value=self.INDEX_NAME,
+        )
+        patcher_replica = mock.patch.object(
+            AlgoliaSearchClient, 'algolia_replica_index_name',
+            new_callable=mock.PropertyMock, return_value=self.REPLICA_INDEX_NAME,
+        )
+        patcher_allowed = mock.patch.object(
+            AlgoliaSearchClient, 'algolia_allowed_index_names',
+            new_callable=mock.PropertyMock, return_value=allowed_index_names,
+        )
+        patcher_search_key = mock.patch.object(
+            AlgoliaSearchClient, 'algolia_search_api_key',
+            new_callable=mock.PropertyMock, return_value=self.SEARCH_API_KEY,
+        )
+        for p in (patcher_index, patcher_replica, patcher_allowed, patcher_search_key):
+            p.start()
+            self.addCleanup(p.stop)
+        return client
+
+    @mock.patch('enterprise_catalog.apps.api_client.algolia.SearchClient.generate_secured_api_key')
+    def test_falls_back_to_primary_and_replica_when_allowed_not_set(self, mock_gen):
+        mock_gen.return_value = 'key'
+        client = self._build_client(allowed_index_names=None)
+        client.generate_secured_api_key('user-1', ['cq-uuid-1'])
+        restrictions = mock_gen.call_args[0][1]
+        self.assertEqual(restrictions['restrictIndices'], [self.INDEX_NAME, self.REPLICA_INDEX_NAME])
+
+    @mock.patch('enterprise_catalog.apps.api_client.algolia.SearchClient.generate_secured_api_key')
+    def test_uses_allowed_index_names_when_set(self, mock_gen):
+        mock_gen.return_value = 'key'
+        allowed = [self.INDEX_NAME, self.REPLICA_INDEX_NAME, self.V2_INDEX_NAME]
+        client = self._build_client(allowed_index_names=allowed)
+        client.generate_secured_api_key('user-1', ['cq-uuid-1'])
+        restrictions = mock_gen.call_args[0][1]
+        self.assertEqual(restrictions['restrictIndices'], allowed)

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -438,6 +438,12 @@ ALGOLIA = {
     'APPLICATION_ID': '',
     'API_KEY': '',
     'INCREMENTAL_INDEX_NAME': None,
+    # Explicit allowlist for restrictIndices in secured API keys.  Set to a list
+    # of index names when frontends need to read from more than one index (e.g.
+    # during v1->v2 cutover: ['enterprise_catalog', 'enterprise_catalog_replica',
+    # 'enterprise_catalog_v2', 'enterprise_catalog_v2_replica']).  When None,
+    # generate_secured_api_key() falls back to [INDEX_NAME, REPLICA_INDEX_NAME].
+    'ALLOWED_INDEX_NAMES': None,
 }
 
 # How long to cache the precomputed program/pathway membership mappings

--- a/scripts/check_secured_api_key.py
+++ b/scripts/check_secured_api_key.py
@@ -1,0 +1,88 @@
+"""
+Integration check for ALLOWED_INDEX_NAMES / generate_secured_api_key.
+
+Generates a secured API key via the Django client (respecting your private
+settings) and then uses it to search each index in ALLOWED_INDEX_NAMES.
+Optionally confirms the key is blocked on an out-of-scope index.
+
+Requires a running Django environment with real Algolia credentials.
+
+Usage:
+    DJANGO_SETTINGS_MODULE=enterprise_catalog.settings.private \\
+        python scripts/check_secured_api_key.py
+
+Optional env vars:
+    CATALOG_QUERY_UUIDS   comma-separated UUIDs to include in the key filter
+                          (defaults to empty, which returns all hits in the index)
+    BLOCKED_INDEX_NAME    index name expected to be blocked by the key;
+                          omit to skip the block check
+"""
+import os
+import sys
+
+import django
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+django.setup()
+
+from algoliasearch.search_client import SearchClient  # noqa: E402
+from django.conf import settings  # noqa: E402
+
+from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient  # noqa: E402
+
+
+def ok(label, detail=''):
+    print(f'[OK  ] {label}' + (f': {detail}' if detail else ''))
+
+
+def fail(label, detail=''):
+    print(f'[FAIL] {label}' + (f': {detail}' if detail else ''))
+
+
+def main():
+    algolia = settings.ALGOLIA
+    print('ALGOLIA settings:')
+    for key in ('INDEX_NAME', 'REPLICA_INDEX_NAME', 'INCREMENTAL_INDEX_NAME', 'ALLOWED_INDEX_NAMES'):
+        print(f'  {key}: {algolia.get(key)!r}')
+    print()
+
+    catalog_query_uuids = [
+        u.strip() for u in os.environ.get('CATALOG_QUERY_UUIDS', '').split(',') if u.strip()
+    ]
+
+    client = AlgoliaSearchClient()
+    client.init_index()
+
+    result = client.generate_secured_api_key(
+        user_id='check-secured-api-key-script',
+        enterprise_catalog_query_uuids=catalog_query_uuids,
+    )
+    secured_key = result['secured_api_key']
+
+    allowed = algolia.get('ALLOWED_INDEX_NAMES') or [
+        algolia.get('INDEX_NAME'),
+        algolia.get('REPLICA_INDEX_NAME'),
+    ]
+    allowed = [n for n in allowed if n]
+
+    search_client = SearchClient.create(algolia.get('APPLICATION_ID'), secured_key)
+
+    for index_name in allowed:
+        try:
+            hits = search_client.init_index(index_name).search('', {'hitsPerPage': 1})
+            ok(f'search on {index_name!r}', f'{hits["nbHits"]} hits')
+        except Exception as exc:
+            fail(f'search on {index_name!r}', str(exc))
+
+    blocked = os.environ.get('BLOCKED_INDEX_NAME')
+    if blocked:
+        print()
+        try:
+            search_client.init_index(blocked).search('', {'hitsPerPage': 1})
+            fail(f'block check on {blocked!r}', 'expected IndexNotAllowedError but search succeeded')
+        except Exception as exc:
+            ok(f'block check on {blocked!r}', f'correctly blocked ({type(exc).__name__})')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Adds `ALGOLIA['ALLOWED_INDEX_NAMES']` (default `None`) to `settings/base.py` as an explicit allowlist for `restrictIndices` in secured Algolia API keys.
- Updates `generate_secured_api_key()` to use it when set, falling back to `[INDEX_NAME, REPLICA_INDEX_NAME]` when `None` — no behavior change for existing deployments.
- During v1->v2 cutover (Phase 8c), operators set this to all four indices so frontends can read from both index generations with a single key, enabling instant rollback via flag flip without re-issuing keys.
- Corrects Phase 8c in the tech spec: `INCREMENTAL_INDEX_NAME`, not `INDEX_NAME`, is the setting that points incremental tasks at the v2 index.