### PR TITLE
chore: downgrade `social-auth-*` packages to fix JWT auth failures

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -316,11 +316,11 @@ six==1.17.0
     #   python-dateutil
 sniffio==1.3.1
     # via openai
-social-auth-app-django==6.0.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.in
     #   edx-auth-backends
-social-auth-core==5.0.1
+social-auth-core==4.9.1
     # via
     #   edx-auth-backends
     #   social-auth-app-django

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -32,3 +32,8 @@ openai<=1.13.3
 
 # algoliasearch 4.0 is not backwards compatible with 3.0
 algoliasearch<4
+
+# pinning social-auth-* packages to the latest working versions. Remove these pins
+# when this ticket gets resolved: https://2u-internal.atlassian.net/browse/ENT-12017
+social-auth-app-django>=5.9.0,<6.0.0
+social-auth-core>=4.9.1,<5.0.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -744,12 +744,12 @@ snowballstemmer==3.1.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==6.0.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==5.0.1
+social-auth-core==4.9.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -585,11 +585,11 @@ sniffio==1.3.1
     #   openai
 snowballstemmer==3.1.1
     # via sphinx
-social-auth-app-django==6.0.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==5.0.1
+social-auth-core==4.9.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -420,11 +420,11 @@ sniffio==1.3.1
     # via
     #   -r requirements/base.txt
     #   openai
-social-auth-app-django==6.0.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==5.0.1
+social-auth-core==4.9.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -461,11 +461,11 @@ sniffio==1.3.1
     #   openai
 snowballstemmer==3.1.1
     # via pydocstyle
-social-auth-app-django==6.0.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==5.0.1
+social-auth-core==4.9.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -510,11 +510,11 @@ sniffio==1.3.1
     # via
     #   -r requirements/base.txt
     #   openai
-social-auth-app-django==6.0.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
-social-auth-core==5.0.1
+social-auth-core==4.9.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends

--- a/requirements/validation.txt
+++ b/requirements/validation.txt
@@ -686,12 +686,12 @@ snowballstemmer==3.1.1
     # via
     #   -r requirements/quality.txt
     #   pydocstyle
-social-auth-app-django==6.0.0
+social-auth-app-django==5.9.0
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt
     #   edx-auth-backends
-social-auth-core==5.0.1
+social-auth-core==4.9.1
     # via
     #   -r requirements/quality.txt
     #   -r requirements/test.txt


### PR DESCRIPTION
We don't yet know WHY JWT auth fails, but recent upgrades to these two packages are fully consistent with all the IDAs which have failing JWT auth.

[ENT-12017](https://2u-internal.atlassian.net/browse/ENT-12017)