### PR TITLE
feat: drop legacy v1 Algolia write from refresh API trigger

### DIFF
--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1959,7 +1959,6 @@ class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):
 
     @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=True)
     @mock.patch('enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.chain')
-    @mock.patch('enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.group')
     @mock.patch(
         'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
         'update_catalog_metadata_task'
@@ -1970,23 +1969,17 @@ class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):
     )
     @mock.patch(
         'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'index_enterprise_catalog_in_algolia_task'
-    )
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
         'dispatch_algolia_indexing_for_catalog_query'
     )
     def test_refresh_catalog_incremental_indexing_enabled(
         self,
         mock_dispatch_algolia,
-        mock_index_task,
         mock_update_full_metadata_task,
         mock_update_metadata_task,
-        mock_group,
         mock_chain,
     ):
         """
-        Verify the refresh_metadata endpoint uses group with both indexing tasks when incremental indexing is enabled.
+        Verify the refresh_metadata endpoint chains only the incremental dispatcher when incremental indexing is enabled.
         """
         mock_chain().apply_async().id = 1
         mock_chain.reset_mock()
@@ -1995,16 +1988,9 @@ class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Chain should have three parts: update, full_update, and a group with both indexing tasks
-        mock_chain.assert_called_once()
-        call_args = mock_chain.call_args[0]
-        self.assertEqual(len(call_args), 3)
-        # First two should be the update tasks
-        self.assertEqual(call_args[0], mock_update_metadata_task.si(self.catalog_query.id))
-        self.assertEqual(call_args[1], mock_update_full_metadata_task.si())
-        # Third should be the group
-        mock_group.assert_called_once_with(
-            mock_index_task.si(),
+        mock_chain.assert_called_once_with(
+            mock_update_metadata_task.si(self.catalog_query.id),
+            mock_update_full_metadata_task.si(),
             mock_dispatch_algolia.si(self.catalog_query.id),
         )
 

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_refresh_data_from_discovery.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_refresh_data_from_discovery.py
@@ -1,4 +1,4 @@
-from celery import chain, group
+from celery import chain
 from django.conf import settings
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
@@ -39,18 +39,13 @@ class EnterpriseCatalogRefreshDataFromDiscovery(BaseViewSet, APIView):
 
         # Use immutable signatures so task results from a parent task are not passed as arguments to a child task.
         if settings.ENABLE_INCREMENTAL_ALGOLIA_INDEXING:
-            # When incremental indexing is enabled, both the legacy task and the new dispatcher must run.
-            # Both wait for update_full_content_metadata_task to complete, then run in parallel via a group.
             async_update_metadata_chain = chain(
                 update_catalog_metadata_task.si(catalog_query_id),
                 update_full_content_metadata_task.si(),
-                group(
-                    index_enterprise_catalog_in_algolia_task.si(),
-                    dispatch_algolia_indexing_for_catalog_query.si(catalog_query_id),
-                ),
+                dispatch_algolia_indexing_for_catalog_query.si(catalog_query_id),
             )
         else:
-            # Legacy chain: keep v1 fresh until frontend cuts over.
+            # Rollback path: restores v1 writes when ENABLE_INCREMENTAL_ALGOLIA_INDEXING is disabled.
             async_update_metadata_chain = chain(
                 update_catalog_metadata_task.si(catalog_query_id),
                 update_full_content_metadata_task.si(),


### PR DESCRIPTION
## Summary

- Removes `index_enterprise_catalog_in_algolia_task` from the `ENABLE_INCREMENTAL_ALGOLIA_INDEXING=True` branch of `EnterpriseCatalogRefreshDataFromDiscovery.post`. The group collapses to a single chained step: `dispatch_algolia_indexing_for_catalog_query`.
- Drops the now-unused `group` import from celery in that view.
- Updates `test_refresh_catalog_incremental_indexing_enabled` to match the simplified chain.
- The `else` branch (flag-off rollback path) is untouched -- `index_enterprise_catalog_in_algolia_task` remains importable and callable for Phase 8f rollback.

Part of the v1 decommission plan: `docs/algolia-reindexing/plans/v1-decommission-plan.md`. This is Step 1 (API-trigger). The `reindex_algolia` cron is a separate ops change. Step 2 (move backend reads to v2 via `search_index` accessor) follows.

## Test plan

- [x] `pytest -k RefreshData` -- 5 tests pass
- [ ] After deploy: confirm no v1 write ops in the Algolia dashboard after a refresh-API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)