### PR TITLE
feat: route backend Algolia reads to v2, retire incremental indexing flag

### DIFF
--- a/docs/algolia-reindexing/plans/v1-decommission-plan.md
+++ b/docs/algolia-reindexing/plans/v1-decommission-plan.md
@@ -4,100 +4,84 @@
 
 The v1→v2 Algolia migration is far along in prod: v2 writes are enabled
 (`ENABLE_INCREMENTAL_ALGOLIA_INDEXING` on, `INCREMENTAL_INDEX_NAME` set to the v2 index) and
-all frontends already read v2. Two loose ends remain in `enterprise-catalog` before v1 can be
+all frontends already read v2. Two loose ends remained in `enterprise-catalog` before v1 can be
 removed from `ALLOWED_INDEX_NAMES` and deleted:
 
 1. **Legacy writes still hit v1.** `index_enterprise_catalog_in_algolia_task` →
-   `_reindex_algolia` → `replace_all_objects` writes the primary (v1) index. It fires from the
-   `reindex_algolia` cron and from the refresh API view. These keep costing write ops on a
-   soon-dead index.
-2. **Backend reads still hit v1.** Every server-side Algolia read uses
+   `_reindex_algolia` → `replace_all_objects` wrote the primary (v1) index. It fired from the
+   `reindex_algolia` cron and from the refresh API view.
+2. **Backend reads still hit v1.** Every server-side Algolia read used
    `algolia_client.algolia_index` (primary = v1), via the admin `API_KEY`, which
-   `ALLOWED_INDEX_NAMES` does not gate. Frontends moved; the backend did not. These serve stale
-   data (v1 no longer written incrementally) and hard-break when v1 is deleted.
+   `ALLOWED_INDEX_NAMES` does not gate. These served stale data and hard-break when v1 is deleted.
 
-Rollout order: stop legacy writes first, then move backend reads, then retire v1.
+## What was implemented (PR #146)
 
-## Read accessor design: reuse `INCREMENTAL_INDEX_NAME`
+### Read routing: update `algolia_index_name`, not call sites
 
-Add one property to `AlgoliaSearchClient` (`enterprise_catalog/apps/api_client/algolia.py`,
-near the index-name properties around line 47):
+Rather than adding a new `search_index` accessor and updating 10 call sites, we updated the
+`algolia_index_name` property in `AlgoliaSearchClient` to resolve to `INCREMENTAL_INDEX_NAME`
+when configured, falling back to `INDEX_NAME`:
 
 ```python
 @property
-def search_index(self):
-    """
-    Algolia index object for backend read/search paths.
-
-    Resolves to the incremental (v2) index when INCREMENTAL_INDEX_NAME is set, else
-    falls back to the primary index. Reads follow writes onto v2 once the incremental
-    pipeline is configured.
-    """
-    return self._get_index(settings.ALGOLIA.get('INCREMENTAL_INDEX_NAME'))
+def algolia_index_name(self):
+    return settings.ALGOLIA.get('INCREMENTAL_INDEX_NAME') or settings.ALGOLIA.get('INDEX_NAME')
 ```
 
-Reuses `_get_index()` (`algolia.py:141`): `None` returns the primary index
-(dev/test/pre-cutover, a no-op); a v2 name returns `_client.init_index(v2)`. No new setting.
-Read cutover is coupled to the write config, which is fine here: writes and frontend reads are
-already on v2, so backend reads should follow.
+Because `init_index()` uses `self.algolia_index_name` to initialize `self.algolia_index`, the
+primary index object now points to v2 in prod. Every call site that uses
+`algolia_client.algolia_index` (CSV/workbook export, AI curation, default catalog results,
+academy tag facets) routes to v2 without any renaming. Test mocks on `.algolia_index` remain
+valid. `_get_index()` also benefits: callers passing `INCREMENTAL_INDEX_NAME` now return the
+cached primary object instead of creating a duplicate.
 
-## Step 1: decommission legacy writes (do first)
+### API trigger and management command: drop the flag entirely
 
-- **API-trigger** (`api/v1/views/enterprise_catalog_refresh_data_from_discovery.py`): in the
-  `ENABLE_INCREMENTAL_ALGOLIA_INDEXING` branch (lines 41-51), drop
-  `index_enterprise_catalog_in_algolia_task.si()` from the `group`, leaving only
-  `dispatch_algolia_indexing_for_catalog_query.si(catalog_query_id)`. The group collapses to a
-  single chained step. Leave the `else` branch (lines 52-58) untouched: it is the flag-off
-  rollback path that restores legacy v1 writes. Drop the now-unused
-  `index_enterprise_catalog_in_algolia_task` import if nothing else references it.
-- **Cron** (`reindex_algolia`): ops/config change outside this repo. Remove the schedule. Keep
-  the `reindex_algolia` command and `index_enterprise_catalog_in_algolia_task` intact as the
-  documented rollback tool (tech-spec Phase 8f, "re-enable old cron if needed").
+`ENABLE_INCREMENTAL_ALGOLIA_INDEXING` is removed from `settings/base.py`. The flag had no
+meaningful off-state: frontends already read v2, and `base.py` had it `False` (prod depended on
+an env override to enable it at all).
 
-## Step 2: move backend reads to v2
+`EnterpriseCatalogRefreshDataFromDiscovery.post` previously branched on the flag. The `else`
+branch (legacy chain with `index_enterprise_catalog_in_algolia_task`) is gone. The view now
+always chains:
 
-Add the `search_index` accessor, then replace `algolia_client.algolia_index` with
-`algolia_client.search_index` at the 10 backend read call sites:
+```python
+chain(
+    update_catalog_metadata_task.si(catalog_query_id),
+    update_full_content_metadata_task.si(),
+    dispatch_algolia_indexing_for_catalog_query.si(catalog_query_id),
+)
+```
 
-- `api/v1/views/catalog_csv.py:66,96` — `.search()`
-- `api/v1/views/catalog_csv_data.py:70,99` — `.search()`
-- `api/v1/views/catalog_workbook.py:79,134` — `.search()`
-- `ai_curation/utils/algolia_utils.py:99,124` — `.search('')`
-- `api/v1/views/default_catalog_results.py:96` — `.search('')`
-- `api/v1/serializers.py:544` — `.search_for_facet_values('academy_tags', ...)`
+`update_content_metadata` (the cron management command) previously guarded
+`dispatch_algolia_indexing` behind the same flag. The guard is removed; the dispatch is now
+unconditional.
 
-Test-mock updates (they mock `.algolia_index.search` today; change to `.search_index.search`):
-- `ai_curation/tests/test_utils.py:59`
-- `api/v1/tests/test_views.py`
-- `api_client/tests/test_algolia.py`
+Removed across both files: `index_enterprise_catalog_in_algolia_task`, `group`, `settings`,
+and all `ENABLE_INCREMENTAL_ALGOLIA_INDEXING` references.
 
-Parity checks before relying on v2 for these reads (validation, not code):
-1. `search_for_facet_values('academy_tags', ...)` needs `academy_tags` declared searchable in
-   v2's `attributesForFaceting`. Confirm v2 index settings match v1.
-2. v2 carries the facets/attributes these readers use: `enterprise_catalog_query_titles`,
-   `learning_type`/`learning_type_v2`, `course_type`, `availability`, `academy_uuids`,
-   `enterprise_customer_uuids`, `aggregation_key`, and the export attribute set.
+## Remaining: Step 3 (ops + cleanup)
 
-## Step 3: retire v1 (ops)
-
-Remove v1 from `ALLOWED_INDEX_NAMES`; delete the v1 index and replica once Steps 1-2 are live
-and verified. Legacy reader/writer helpers on the client (`replace_all_objects`, the browse and
-delete methods, `get_all_objects_associated_with_aggregation_key`) become dead code, removable
-afterward.
+1. **Cron** (`reindex_algolia`): remove the schedule from ops config. The command and
+   `index_enterprise_catalog_in_algolia_task` remain in code as a documented rollback tool
+   (tech-spec Phase 8f).
+2. **`ALLOWED_INDEX_NAMES`**: remove v1 from the list once cron is confirmed stopped and
+   PR #146 is deployed and verified.
+3. **Delete v1 index**: delete the v1 index and replica in the Algolia dashboard.
+4. **Dead code cleanup**: after v1 is deleted, remove the legacy reader/writer helpers on the
+   client (`replace_all_objects`, browse/delete methods,
+   `get_all_objects_associated_with_aggregation_key`) and `index_enterprise_catalog_in_algolia_task`.
 
 ## Verification
 
-Accessor unit test (`api_client/tests/test_algolia.py`), both branches:
-- `INCREMENTAL_INDEX_NAME` unset → `search_index` returns the primary index (same object as
-  `algolia_index`).
-- `INCREMENTAL_INDEX_NAME='enterprise_catalog_v2'` → `search_index` calls
-  `_client.init_index('enterprise_catalog_v2')` (assert against the mocked client).
+After PR #146 deploys:
+- CSV/workbook export, AI curation, default catalog results, and academy tag facets return v2 data.
+- No v1 write ops in the Algolia dashboard after a refresh-API call.
+- After cron removal: no v1 write ops in the Algolia dashboard across the cron window.
+
+`algolia_index_name` unit tests (both branches) run in `api_client/tests/test_algolia.py`:
 
 ```
 docker exec -e DJANGO_SETTINGS_MODULE=enterprise_catalog.settings.test enterprise.catalog.app \
   pytest enterprise_catalog/apps/api_client/tests/test_algolia.py -q
 ```
-
-After Step 1, confirm no v1 write ops in the Algolia dashboard following a refresh-API call and
-after the cron window. After Step 2, confirm backend read paths (CSV/workbook export, AI
-curation, default catalog results, academy tag facets) return results from v2.

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1873,33 +1873,29 @@ class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):
     )
     @mock.patch(
         'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'index_enterprise_catalog_in_algolia_task'
+        'dispatch_algolia_indexing_for_catalog_query'
     )
     def test_refresh_catalog(
         self,
-        mock_index_task,
+        mock_dispatch_algolia,
         mock_update_full_metadata_task,
         mock_update_metadata_task,
         mock_chain,
     ):
         """
-        Verify the refresh_metadata endpoint correctly calls the chain of updating/indexing tasks.
+        Verify the refresh_metadata endpoint chains update, full_update, and incremental dispatch.
         """
-        # Mock the submitted task id for proper rendering
         mock_chain().apply_async().id = 1
-        # Reset the call count since it was called in the above mock
         mock_chain.reset_mock()
 
         url = reverse('api:v1:update-enterprise-catalog', kwargs={'uuid': self.enterprise_catalog.uuid})
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-        # Note that since we're mocking celery's chain, the return values from the previous task don't get passed to
-        # the next one, although we do use that functionality in the real view
         mock_chain.assert_called_once_with(
             mock_update_metadata_task.si(self.catalog_query.id),
             mock_update_full_metadata_task.si(),
-            mock_index_task.si(),
+            mock_dispatch_algolia.si(self.catalog_query.id),
         )
 
     def test_refresh_catalog_on_get_returns_405_not_allowed(self):
@@ -1918,95 +1914,6 @@ class EnterpriseCatalogRefreshDataFromDiscoveryTests(APITestMixin):
         url = reverse('api:v1:update-enterprise-catalog', kwargs={'uuid': random_uuid})
         response = self.client.post(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-
-    @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=False)
-    @mock.patch('enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.chain')
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'update_catalog_metadata_task'
-    )
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'update_full_content_metadata_task'
-    )
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'index_enterprise_catalog_in_algolia_task'
-    )
-    def test_refresh_catalog_incremental_indexing_disabled(
-        self,
-        mock_index_task,
-        mock_update_full_metadata_task,
-        mock_update_metadata_task,
-        mock_chain,
-    ):
-        """
-        Verify the refresh_metadata endpoint uses legacy chain when incremental indexing is disabled.
-        """
-        mock_chain().apply_async().id = 1
-        mock_chain.reset_mock()
-
-        url = reverse('api:v1:update-enterprise-catalog', kwargs={'uuid': self.enterprise_catalog.uuid})
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        # Legacy chain should have only three tasks: update -> full_update -> index
-        mock_chain.assert_called_once_with(
-            mock_update_metadata_task.si(self.catalog_query.id),
-            mock_update_full_metadata_task.si(),
-            mock_index_task.si(),
-        )
-
-    @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=True)
-    @mock.patch('enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.chain')
-    @mock.patch('enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.group')
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'update_catalog_metadata_task'
-    )
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'update_full_content_metadata_task'
-    )
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'index_enterprise_catalog_in_algolia_task'
-    )
-    @mock.patch(
-        'enterprise_catalog.apps.api.v1.views.enterprise_catalog_refresh_data_from_discovery.'
-        'dispatch_algolia_indexing_for_catalog_query'
-    )
-    def test_refresh_catalog_incremental_indexing_enabled(
-        self,
-        mock_dispatch_algolia,
-        mock_index_task,
-        mock_update_full_metadata_task,
-        mock_update_metadata_task,
-        mock_group,
-        mock_chain,
-    ):
-        """
-        Verify the refresh_metadata endpoint uses group with both indexing tasks when incremental indexing is enabled.
-        """
-        mock_chain().apply_async().id = 1
-        mock_chain.reset_mock()
-
-        url = reverse('api:v1:update-enterprise-catalog', kwargs={'uuid': self.enterprise_catalog.uuid})
-        response = self.client.post(url)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-
-        # Chain should have three parts: update, full_update, and a group with both indexing tasks
-        mock_chain.assert_called_once()
-        call_args = mock_chain.call_args[0]
-        self.assertEqual(len(call_args), 3)
-        # First two should be the update tasks
-        self.assertEqual(call_args[0], mock_update_metadata_task.si(self.catalog_query.id))
-        self.assertEqual(call_args[1], mock_update_full_metadata_task.si())
-        # Third should be the group
-        mock_group.assert_called_once_with(
-            mock_index_task.si(),
-            mock_dispatch_algolia.si(self.catalog_query.id),
-        )
 
 
 @ddt.ddt

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_refresh_data_from_discovery.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_refresh_data_from_discovery.py
@@ -1,12 +1,10 @@
-from celery import chain, group
-from django.conf import settings
+from celery import chain
 from django.shortcuts import get_object_or_404
 from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 from rest_framework.views import APIView
 
 from enterprise_catalog.apps.api.tasks import (
-    index_enterprise_catalog_in_algolia_task,
     update_catalog_metadata_task,
     update_full_content_metadata_task,
 )
@@ -38,24 +36,11 @@ class EnterpriseCatalogRefreshDataFromDiscovery(BaseViewSet, APIView):
         catalog_query_id = enterprise_catalog.catalog_query.id
 
         # Use immutable signatures so task results from a parent task are not passed as arguments to a child task.
-        if settings.ENABLE_INCREMENTAL_ALGOLIA_INDEXING:
-            # When incremental indexing is enabled, both the legacy task and the new dispatcher must run.
-            # Both wait for update_full_content_metadata_task to complete, then run in parallel via a group.
-            async_update_metadata_chain = chain(
-                update_catalog_metadata_task.si(catalog_query_id),
-                update_full_content_metadata_task.si(),
-                group(
-                    index_enterprise_catalog_in_algolia_task.si(),
-                    dispatch_algolia_indexing_for_catalog_query.si(catalog_query_id),
-                ),
-            )
-        else:
-            # Legacy chain: keep v1 fresh until frontend cuts over.
-            async_update_metadata_chain = chain(
-                update_catalog_metadata_task.si(catalog_query_id),
-                update_full_content_metadata_task.si(),
-                index_enterprise_catalog_in_algolia_task.si(),
-            )
+        async_update_metadata_chain = chain(
+            update_catalog_metadata_task.si(catalog_query_id),
+            update_full_content_metadata_task.si(),
+            dispatch_algolia_indexing_for_catalog_query.si(catalog_query_id),
+        )
         async_task = async_update_metadata_chain.apply_async()
 
         return Response({'async_task_id': async_task.id}, status=HTTP_200_OK)

--- a/enterprise_catalog/apps/api_client/algolia.py
+++ b/enterprise_catalog/apps/api_client/algolia.py
@@ -40,7 +40,7 @@ class AlgoliaSearchClient:
 
     @property
     def algolia_index_name(self):
-        return settings.ALGOLIA.get('INDEX_NAME')
+        return settings.ALGOLIA.get('INCREMENTAL_INDEX_NAME') or settings.ALGOLIA.get('INDEX_NAME')
 
     @property
     def algolia_replica_index_name(self):

--- a/enterprise_catalog/apps/api_client/tests/test_algolia.py
+++ b/enterprise_catalog/apps/api_client/tests/test_algolia.py
@@ -42,6 +42,25 @@ class TestAlgoliaSearchClientBatchMethods(TestCase):
         self.addCleanup(patcher.stop)
         return client
 
+    def test_algolia_index_name_returns_incremental_when_set(self):
+        """
+        ``algolia_index_name`` returns ``INCREMENTAL_INDEX_NAME`` when configured,
+        so ``init_index()`` and ``_get_index()`` both target v2 without extra wiring.
+        """
+        algolia_settings = {'INDEX_NAME': self.PRIMARY_INDEX_NAME, 'INCREMENTAL_INDEX_NAME': self.ALT_INDEX_NAME}
+        with self.settings(ALGOLIA=algolia_settings):
+            client = AlgoliaSearchClient()
+            self.assertEqual(client.algolia_index_name, self.ALT_INDEX_NAME)
+
+    def test_algolia_index_name_falls_back_to_index_name(self):
+        """
+        When ``INCREMENTAL_INDEX_NAME`` is absent (or None), falls back to ``INDEX_NAME``.
+        """
+        algolia_settings = {'INDEX_NAME': self.PRIMARY_INDEX_NAME, 'INCREMENTAL_INDEX_NAME': None}
+        with self.settings(ALGOLIA=algolia_settings):
+            client = AlgoliaSearchClient()
+            self.assertEqual(client.algolia_index_name, self.PRIMARY_INDEX_NAME)
+
     def test_get_index_defaults_to_primary(self):
         """
         ``_get_index()`` returns the primary index when no name is given.

--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from django.core.management import call_command
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from enterprise_catalog.apps.api.tasks import TaskRecentlyRunError
 from enterprise_catalog.apps.catalog.models import (
@@ -45,6 +45,7 @@ class UpdateContentMetadataCommandTests(TestCase):
 
         self.command_config_mock.stop()
 
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(
@@ -53,7 +54,8 @@ class UpdateContentMetadataCommandTests(TestCase):
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
     def test_update_content_metadata_for_all_queries(
-        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway, mock_fetch_missing_course
+        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway,
+        mock_fetch_missing_course, mock_dispatch
     ):
         """
         Verify that the job creates an update task for every catalog query
@@ -68,6 +70,7 @@ class UpdateContentMetadataCommandTests(TestCase):
         ])
         mock_full_metadata_task.si.assert_called_once_with(force=False, dry_run=False)
 
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(
@@ -76,7 +79,8 @@ class UpdateContentMetadataCommandTests(TestCase):
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
     def test_update_content_metadata_for_filtered_queries(
-        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway, mock_fetch_missing_course
+        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway,
+        mock_fetch_missing_course, mock_dispatch
     ):
         """
         Verify that the job creates an update task for every catalog query that is used by
@@ -95,6 +99,7 @@ class UpdateContentMetadataCommandTests(TestCase):
         ])
         mock_full_metadata_task.si.assert_called_once_with(force=False, dry_run=False)
 
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(
@@ -103,7 +108,8 @@ class UpdateContentMetadataCommandTests(TestCase):
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
     def test_force_update_content_metadata(
-        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway, mock_fetch_missing_course
+        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway,
+        mock_fetch_missing_course, mock_dispatch
     ):
         """
         Verify that the job creates an update task for every catalog query
@@ -116,6 +122,7 @@ class UpdateContentMetadataCommandTests(TestCase):
         ])
         mock_full_metadata_task.si.assert_called_once_with(force=True, dry_run=False)
 
+    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(
@@ -124,7 +131,8 @@ class UpdateContentMetadataCommandTests(TestCase):
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
     def test_update_content_metadata_no_async(
-        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway, mock_fetch_missing_course
+        self, mock_full_metadata_task, mock_catalog_task, mock_group, mock_fetch_missing_pathway,
+        mock_fetch_missing_course, mock_dispatch
     ):
         """
         Verify that the tasks are executed synchronously when --no-async flag is set
@@ -138,7 +146,6 @@ class UpdateContentMetadataCommandTests(TestCase):
         ])
         mock_full_metadata_task.apply.assert_called_once_with(kwargs={"force": True, "dry_run": False})
 
-    @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=False)
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(
@@ -147,37 +154,16 @@ class UpdateContentMetadataCommandTests(TestCase):
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
-    def test_incremental_indexing_disabled(
+    def test_dispatch_algolia_indexing_async(
         self, mock_dispatch, mock_full_metadata_task, mock_catalog_task, mock_group,
         mock_fetch_missing_pathway, mock_fetch_missing_course
     ):
         """
-        Verify that dispatch_algolia_indexing is NOT called when flag is disabled
-        """
-        call_command(self.command_name)
-        mock_dispatch.si.assert_not_called()
-        mock_dispatch.apply.assert_not_called()
-
-    @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=True)
-    @mock.patch(
-        'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
-    @mock.patch(
-        'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_pathway_metadata_task')
-    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.group')
-    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
-    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
-    @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
-    def test_incremental_indexing_enabled_async(
-        self, mock_dispatch, mock_full_metadata_task, mock_catalog_task, mock_group,
-        mock_fetch_missing_pathway, mock_fetch_missing_course
-    ):
-        """
-        Verify that dispatch_algolia_indexing is called with force=False when flag is enabled (async)
+        Verify that dispatch_algolia_indexing is called with force=False (async)
         """
         call_command(self.command_name)
         mock_dispatch.si.assert_called_once_with(force=False, dry_run=False, use_apply=False)
 
-    @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=True)
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(
@@ -186,17 +172,16 @@ class UpdateContentMetadataCommandTests(TestCase):
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_catalog_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.update_full_content_metadata_task')
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
-    def test_incremental_indexing_enabled_no_async(
+    def test_dispatch_algolia_indexing_no_async(
         self, mock_dispatch, mock_full_metadata_task, mock_catalog_task, mock_group,
         mock_fetch_missing_pathway, mock_fetch_missing_course
     ):
         """
-        Verify that dispatch_algolia_indexing is called with force=False and use_apply=True when flag is enabled (no-async)
+        Verify that dispatch_algolia_indexing is called with use_apply=True (no-async)
         """
         call_command(self.command_name, no_async=True)
         mock_dispatch.apply.assert_called_once_with(kwargs={'force': False, 'dry_run': False, 'use_apply': True})
 
-    @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=True)
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(
@@ -215,7 +200,6 @@ class UpdateContentMetadataCommandTests(TestCase):
         mock_dispatch.si.return_value.apply_async.return_value.get.side_effect = TaskRecentlyRunError('dedup')
         call_command(self.command_name)  # must not raise
 
-    @override_settings(ENABLE_INCREMENTAL_ALGOLIA_INDEXING=True)
     @mock.patch(
         'enterprise_catalog.apps.catalog.management.commands.update_content_metadata.fetch_missing_course_metadata_task')
     @mock.patch(

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -1,7 +1,6 @@
 import logging
 
 from celery import group
-from django.conf import settings
 from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api.tasks import (
@@ -11,7 +10,7 @@ from enterprise_catalog.apps.api.tasks import (
     update_catalog_metadata_task,
     update_full_content_metadata_task,
 )
-from enterprise_catalog.apps.catalog.constants import COURSE, TASK_TIMEOUT
+from enterprise_catalog.apps.catalog.constants import TASK_TIMEOUT
 from enterprise_catalog.apps.catalog.models import CatalogQuery
 from enterprise_catalog.apps.search.tasks import dispatch_algolia_indexing
 
@@ -180,26 +179,24 @@ class Command(BaseCommand):
                 'and was thus skipped during the execution of this command.'
             )
 
-        # Trigger incremental Algolia indexing if feature flag is enabled.
-        if settings.ENABLE_INCREMENTAL_ALGOLIA_INDEXING:
-            dry_run = flags.get('dry_run', False)
-            try:
-                force = flags.get('force', False)
-                if no_async:
-                    dispatch_algolia_indexing.apply(
-                        kwargs={'force': force, 'dry_run': dry_run, 'use_apply': True}
-                    )
-                    logger.info('Finished incremental Algolia indexing.')
-                else:
-                    dispatch_algolia_indexing.si(
-                        force=force, dry_run=dry_run, use_apply=False
-                    ).apply_async().get(
-                        timeout=TASK_TIMEOUT,
-                        propagate=True,
-                    )
-                    logger.info('Dispatched incremental Algolia indexing to workers.')
-            except TaskRecentlyRunError:
-                logger.info(
-                    'dispatch_algolia_indexing was recently run prior to this command, '
-                    'and was thus skipped during the execution of this command.'
+        dry_run = flags.get('dry_run', False)
+        try:
+            force = flags.get('force', False)
+            if no_async:
+                dispatch_algolia_indexing.apply(
+                    kwargs={'force': force, 'dry_run': dry_run, 'use_apply': True}
                 )
+                logger.info('Finished incremental Algolia indexing.')
+            else:
+                dispatch_algolia_indexing.si(
+                    force=force, dry_run=dry_run, use_apply=False
+                ).apply_async().get(
+                    timeout=TASK_TIMEOUT,
+                    propagate=True,
+                )
+                logger.info('Dispatched incremental Algolia indexing to workers.')
+        except TaskRecentlyRunError:
+            logger.info(
+                'dispatch_algolia_indexing was recently run prior to this command, '
+                'and was thus skipped during the execution of this command.'
+            )

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -465,10 +465,6 @@ ALGOLIA_INDEXING_CHUNK_SIZE = 100
 # indexing task it fans out to Celery workers.
 ALGOLIA_INDEXING_BATCH_SIZE = 10
 
-# Gates incremental Algolia indexing via dispatch_algolia_indexing in both
-# the daily cron chain and the API refresh endpoint.
-ENABLE_INCREMENTAL_ALGOLIA_INDEXING = False
-
 # Which fields should be plucked from the /search/all course-discovery API
 # response in `update_catalog_metadata_task` for course content metadata?
 COURSE_FIELDS_TO_PLUCK_FROM_SEARCH_ALL = os.environ.get(


### PR DESCRIPTION
  ## Summary

  Routes all backend Algolia reads to the v2 (incremental) index and removes
  `ENABLE_INCREMENTAL_ALGOLIA_INDEXING` entirely.

  **Read routing** (`api_client/algolia.py`): `algolia_index_name` now returns
  `INCREMENTAL_INDEX_NAME` when configured, falling back to `INDEX_NAME`. Because
  `init_index()` uses this property, `self.algolia_index` targets v2 in prod with no
  call-site changes. All server-side reads (CSV/workbook export, AI curation, default
  catalog results, academy tag facets) route to v2 automatically.

  **API trigger** (`api/v1/views/enterprise_catalog_refresh_data_from_discovery.py`):
  flag branch removed. The view always chains update_catalog_metadata_task ->
  update_full_content_metadata_task -> dispatch_algolia_indexing_for_catalog_query.
  The legacy index_enterprise_catalog_in_algolia_task path is gone.

  **Management command** (`catalog/management/commands/update_content_metadata.py`):
  dispatch_algolia_indexing is now unconditional. The if-flag guard and the setting
  definition in settings/base.py are removed.

  Test changes: two new algolia_index_name unit tests; one consolidated refresh-view
  test replaces three flag-branching tests; dispatch mock added to four
  management-command tests; flag-off test deleted; @override_settings dropped from
  remaining dispatch tests.

  ## Remaining: Step 3 (ops, separate from this PR)

  1. Remove reindex_algolia cron from ops config
  2. Remove v1 from ALLOWED_INDEX_NAMES once cron is confirmed stopped and this PR is deployed
  3. Delete v1 index and replica in the Algolia dashboard
  4. Dead code cleanup: replace_all_objects, browse/delete helpers, index_enterprise_catalog_in_algolia_task

  ## Test plan

  - [ ] After deploy: CSV/workbook export, AI curation, default catalog results return v2 data
  - [ ] After deploy: no v1 write ops in Algolia dashboard after a refresh-API call