### PR TITLE
feat: GET API to fetch catalog_query_id using catalog_query_uuid

### DIFF
--- a/enterprise_catalog/apps/api/v1/serializers.py
+++ b/enterprise_catalog/apps/api/v1/serializers.py
@@ -124,6 +124,7 @@ class CatalogQuerySerializer(serializers.ModelSerializer):
     class Meta:
         model = CatalogQuery
         fields = [
+            'id',
             'uuid',
             'content_filter',
             'content_filter_hash',

--- a/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
@@ -6,11 +6,11 @@ from rest_framework import status
 
 from enterprise_catalog.apps.api.v1.tests.mixins import APITestMixin
 from enterprise_catalog.apps.catalog.tests.factories import (
+    USER_PASSWORD,
     CatalogQueryFactory,
     EnterpriseCatalogFactory,
-    USER_PASSWORD,
     UserFactory,
- )
+)
 
 
 @ddt.ddt
@@ -22,6 +22,7 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
     def setUp(self):
         """Set up test fixtures."""
         super().setUp()
+        self.user = None
         self.set_up_staff()
         self.catalog_query = CatalogQueryFactory(
             title='Subscription Query',

--- a/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
@@ -75,8 +75,8 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
     # ─────────────────────────────────────────────────────────
     def test_get_by_uuid_malformed_uuid(self):
         """
-        GET /api/v1/catalog-queries/<uuid>/ returns 404
-        because the URL regex won't match a non-UUID string.
+        GET /api/v1/catalog-queries/<uuid>/ returns 404 for an invalid UUID.
+        Note: the <uuid:uuid> route won't match, so this request falls through to the pk-based route and returns 404.
         """
         response = self.client.get('/api/v1/catalog-queries/not-a-valid-uuid/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
@@ -11,7 +11,7 @@ from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
 @ddt.ddt
 class TestCatalogQueryGetByUuidAction(APITestMixin):
     """
-    Tests for GET /api/v1/catalog-queries/by-uuid/{uuid}/
+    Tests for GET /api/v1/catalog-queries/<uuid>/
     """
 
     def setUp(self):
@@ -43,7 +43,7 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
     # ─────────────────────────────────────────────────────────
     def test_get_by_uuid_success(self):
         """
-        GET /api/v1/catalog-queries/by-uuid/{uuid}/ returns 200
+        GET /api/v1/catalog-queries/<uuid>/ returns 200
         with the correct CatalogQuery data.
         """
         response = self.client.get(self.url)
@@ -62,7 +62,7 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
     # ─────────────────────────────────────────────────────────
     def test_get_by_uuid_not_found(self):
         """
-        GET /api/v1/catalog-queries/by-uuid/{non_existent_uuid}/ returns 404.
+        GET /api/v1/catalog-queries/<uuid>/ returns 404.
         """
         non_existent_uuid = str(uuid_lib.uuid4())
         url = self._get_by_uuid_url(non_existent_uuid)
@@ -75,11 +75,10 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
     # ─────────────────────────────────────────────────────────
     def test_get_by_uuid_malformed_uuid(self):
         """
-        GET /api/v1/catalog-queries/by-uuid/not-a-uuid/ returns 404
+        GET /api/v1/catalog-queries/<uuid>/ returns 404
         because the URL regex won't match a non-UUID string.
         """
-        # The url_path regex [0-9a-f-]{36} won't match, so DRF returns 404
-        response = self.client.get('/api/v1/catalog-queries/by-uuid/not-a-valid-uuid/')
+        response = self.client.get('/api/v1/catalog-queries/not-a-valid-uuid/')
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # ─────────────────────────────────────────────────────────
@@ -99,21 +98,6 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['id'], self.catalog_query.id)
         self.assertEqual(response.data['uuid'], str(self.catalog_query.uuid))
-
-    # ─────────────────────────────────────────────────────────
-    # Line 102-118: PK endpoint does NOT accept UUID value
-    # ─────────────────────────────────────────────────────────
-    def test_pk_endpoint_rejects_uuid_string(self):
-        """
-        GET /api/v1/catalog-queries/{uuid_string}/ returns 404,
-        confirming that the PK-based endpoint only accepts integers.
-        This proves backward compat is maintained.
-        """
-        bad_url = f'/api/v1/catalog-queries/{self.catalog_query.uuid}/'
-        response = self.client.get(bad_url)
-
-        # DRF with integer PK will return 404 for a UUID string
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     # ─────────────────────────────────────────────────────────
     # Line 120-137: Multiple queries, correct one returned
@@ -165,6 +149,6 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
     @ddt.data('post', 'put', 'delete')
     def test_get_by_uuid_disallows_methods(self, method_name):
         """
-        POST, PUT, and DELETE /api/v1/catalog-queries/by-uuid/{uuid}/ return 405.
+        POST, PUT, and DELETE /api/v1/catalog-queries/<uuid>/ return 405.
         """
         self._assert_method_not_allowed(method_name)

--- a/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
@@ -1,0 +1,170 @@
+import uuid as uuid_lib
+
+import ddt
+from django.urls import reverse
+from rest_framework import status
+
+from enterprise_catalog.apps.api.v1.tests.mixins import APITestMixin
+from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
+
+
+@ddt.ddt
+class TestCatalogQueryGetByUuidAction(APITestMixin):
+    """
+    Tests for GET /api/v1/catalog-queries/by-uuid/{uuid}/
+    """
+
+    def setUp(self):
+        """Set up test fixtures."""
+        super().setUp()
+        self.set_up_staff()
+        self.catalog_query = CatalogQueryFactory(
+            title='Subscription Query',
+            content_filter={'partner': 'edx', 'content_type': 'course'},
+        )
+        self.url = self._get_by_uuid_url(self.catalog_query.uuid)
+
+    def _get_by_uuid_url(self, query_uuid):
+        return reverse(
+            'api:v1:get-query-by-uuid',
+            kwargs={'uuid': str(query_uuid)},
+        )
+
+    def _assert_method_not_allowed(self, method_name):
+        request = getattr(self.client, method_name)
+        if method_name in {'post', 'put'}:
+            response = request(self.url, data={'title': 'hacked'})
+        else:
+            response = request(self.url)
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    # ─────────────────────────────────────────────────────────
+    # Line 35-52: Success case
+    # ─────────────────────────────────────────────────────────
+    def test_get_by_uuid_success(self):
+        """
+        GET /api/v1/catalog-queries/by-uuid/{uuid}/ returns 200
+        with the correct CatalogQuery data.
+        """
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['uuid'], str(self.catalog_query.uuid))
+        self.assertEqual(response.data['id'], self.catalog_query.id)
+        self.assertEqual(response.data['title'], 'Subscription Query')
+        self.assertEqual(
+            response.data['content_filter'],
+            {'partner': 'edx', 'content_type': 'course'},
+        )
+
+    # ─────────────────────────────────────────────────────────
+    # Line 54-67: 404 for non-existent UUID
+    # ─────────────────────────────────────────────────────────
+    def test_get_by_uuid_not_found(self):
+        """
+        GET /api/v1/catalog-queries/by-uuid/{non_existent_uuid}/ returns 404.
+        """
+        non_existent_uuid = str(uuid_lib.uuid4())
+        url = self._get_by_uuid_url(non_existent_uuid)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # ─────────────────────────────────────────────────────────
+    # Line 69-82: Malformed UUID returns 404 (regex mismatch)
+    # ─────────────────────────────────────────────────────────
+    def test_get_by_uuid_malformed_uuid(self):
+        """
+        GET /api/v1/catalog-queries/by-uuid/not-a-uuid/ returns 404
+        because the URL regex won't match a non-UUID string.
+        """
+        # The url_path regex [0-9a-f-]{36} won't match, so DRF returns 404
+        response = self.client.get('/api/v1/catalog-queries/by-uuid/not-a-valid-uuid/')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # ─────────────────────────────────────────────────────────
+    # Line 84-100: Existing PK-based endpoint still works
+    # ─────────────────────────────────────────────────────────
+    def test_existing_pk_endpoint_unchanged(self):
+        """
+        GET /api/v1/catalog-queries/{pk}/ still works as before,
+        confirming no breaking change to v1 clients.
+        """
+        pk_url = reverse(
+            'api:v1:catalog-queries-detail',
+            kwargs={'pk': self.catalog_query.pk},
+        )
+        response = self.client.get(pk_url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['id'], self.catalog_query.id)
+        self.assertEqual(response.data['uuid'], str(self.catalog_query.uuid))
+
+    # ─────────────────────────────────────────────────────────
+    # Line 102-118: PK endpoint does NOT accept UUID value
+    # ─────────────────────────────────────────────────────────
+    def test_pk_endpoint_rejects_uuid_string(self):
+        """
+        GET /api/v1/catalog-queries/{uuid_string}/ returns 404,
+        confirming that the PK-based endpoint only accepts integers.
+        This proves backward compat is maintained.
+        """
+        bad_url = f'/api/v1/catalog-queries/{self.catalog_query.uuid}/'
+        response = self.client.get(bad_url)
+
+        # DRF with integer PK will return 404 for a UUID string
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    # ─────────────────────────────────────────────────────────
+    # Line 120-137: Multiple queries, correct one returned
+    # ─────────────────────────────────────────────────────────
+    def test_get_by_uuid_returns_correct_instance(self):
+        """
+        When multiple CatalogQuery objects exist, the endpoint
+        returns the one matching the requested UUID.
+        """
+        other_query = CatalogQueryFactory(
+            title='A La Carte Query',
+            content_filter={'partner': 'edx', 'content_type': 'program'},
+        )
+
+        # Fetch the original query by UUID
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['uuid'], str(self.catalog_query.uuid))
+        self.assertNotEqual(response.data['uuid'], str(other_query.uuid))
+
+        # Fetch the other query by UUID
+        other_url = reverse(
+            'api:v1:get-query-by-uuid',
+            kwargs={'uuid': str(other_query.uuid)},
+        )
+        other_response = self.client.get(other_url)
+        self.assertEqual(other_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(other_response.data['uuid'], str(other_query.uuid))
+        self.assertEqual(other_response.data['title'], 'A La Carte Query')
+
+    # ─────────────────────────────────────────────────────────
+    # Line 139-151: Unauthenticated request returns 401/403
+    # ─────────────────────────────────────────────────────────
+    def test_get_by_uuid_unauthenticated(self):
+        """
+        Unauthenticated requests to the UUID endpoint are rejected.
+        """
+        self.client.logout()
+        response = self.client.get(self.url)
+
+        self.assertIn(
+            response.status_code,
+            [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN],
+        )
+
+    # ─────────────────────────────────────────────────────────
+    # Line 153-166: POST, PUT, DELETE methods
+    # ─────────────────────────────────────────────────────────
+    @ddt.data('post', 'put', 'delete')
+    def test_get_by_uuid_disallows_methods(self, method_name):
+        """
+        POST, PUT, and DELETE /api/v1/catalog-queries/by-uuid/{uuid}/ return 405.
+        """
+        self._assert_method_not_allowed(method_name)

--- a/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_catalog_query_get_by_uuid.py
@@ -5,7 +5,12 @@ from django.urls import reverse
 from rest_framework import status
 
 from enterprise_catalog.apps.api.v1.tests.mixins import APITestMixin
-from enterprise_catalog.apps.catalog.tests.factories import CatalogQueryFactory
+from enterprise_catalog.apps.catalog.tests.factories import (
+    CatalogQueryFactory,
+    EnterpriseCatalogFactory,
+    USER_PASSWORD,
+    UserFactory,
+ )
 
 
 @ddt.ddt
@@ -56,6 +61,30 @@ class TestCatalogQueryGetByUuidAction(APITestMixin):
             response.data['content_filter'],
             {'partner': 'edx', 'content_type': 'course'},
         )
+
+    def test_get_by_uuid_success_for_non_staff_catalog_admin(self):
+        """
+        GET /api/v1/catalog-queries/<uuid>/ returns 200 for a non-staff
+        catalog admin using the database-backed permission path.
+        """
+        self.user = UserFactory()
+        self.client.login(username=self.user.username, password=USER_PASSWORD)
+        self.set_up_invalid_jwt_role()
+        self.remove_role_assignments()
+        EnterpriseCatalogFactory(
+            catalog_query=self.catalog_query,
+            enterprise_uuid=self.enterprise_uuid,
+        )
+        self.assign_catalog_admin_feature_role(
+            user=self.user,
+            enterprise_uuids=[self.enterprise_uuid],
+        )
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['uuid'], str(self.catalog_query.uuid))
+        self.assertEqual(response.data['id'], self.catalog_query.id)
 
     # ─────────────────────────────────────────────────────────
     # Line 54-67: 404 for non-existent UUID

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2780,7 +2780,7 @@ class CatalogQueryViewTests(APITestMixin):
             self.enterprise_uuid,
             self.catalog_query_object.enterprise_catalogs.first().enterprise_uuid,
         )
-        url = reverse('api:v1:catalog-queries-detail', kwargs={'uuid': self.catalog_query_object.uuid})
+        url = reverse('api:v1:catalog-queries-detail', kwargs={'pk': self.catalog_query_object.pk})
         response = self.client.get(url)
         response_json = response.json()
         assert response_json.get('uuid') == str(self.catalog_query_object.uuid)
@@ -2789,7 +2789,7 @@ class CatalogQueryViewTests(APITestMixin):
         different_customer_catalog = EnterpriseCatalogFactory()
         # We don't have a jwt token that includes an admin role for the new enterprise so it is
         # essentially hidden to the requester
-        url = reverse('api:v1:catalog-queries-detail', kwargs={'uuid': different_customer_catalog.catalog_query.uuid})
+        url = reverse('api:v1:catalog-queries-detail', kwargs={'pk': different_customer_catalog.catalog_query.pk})
         response = self.client.get(url)
         assert response.status_code == 404
 

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2780,7 +2780,7 @@ class CatalogQueryViewTests(APITestMixin):
             self.enterprise_uuid,
             self.catalog_query_object.enterprise_catalogs.first().enterprise_uuid,
         )
-        url = reverse('api:v1:catalog-queries-detail', kwargs={'pk': self.catalog_query_object.pk})
+        url = reverse('api:v1:catalog-queries-detail', kwargs={'uuid': self.catalog_query_object.uuid})
         response = self.client.get(url)
         response_json = response.json()
         assert response_json.get('uuid') == str(self.catalog_query_object.uuid)
@@ -2788,7 +2788,7 @@ class CatalogQueryViewTests(APITestMixin):
         different_customer_catalog = EnterpriseCatalogFactory()
         # We don't have a jwt token that includes an admin role for the new enterprise so it is
         # essentially hidden to the requester
-        url = reverse('api:v1:catalog-queries-detail', kwargs={'pk': different_customer_catalog.catalog_query.pk})
+        url = reverse('api:v1:catalog-queries-detail', kwargs={'uuid': different_customer_catalog.catalog_query.uuid})
         response = self.client.get(url)
         assert response.status_code == 404
 

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -2784,6 +2784,7 @@ class CatalogQueryViewTests(APITestMixin):
         response = self.client.get(url)
         response_json = response.json()
         assert response_json.get('uuid') == str(self.catalog_query_object.uuid)
+        assert response_json.get('id') == self.catalog_query_object.id
 
         different_customer_catalog = EnterpriseCatalogFactory()
         # We don't have a jwt token that includes an admin role for the new enterprise so it is

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -137,7 +137,7 @@ urlpatterns = [
         name="enterprise-jobs",
     ),
     path(
-        'catalog-queries/by-uuid/<uuid:uuid>/',
+        'catalog-queries/<uuid:uuid>/',
         CatalogQueryViewSet.as_view({'get': 'get_by_uuid'}),
         name='get-query-by-uuid'
     ),

--- a/enterprise_catalog/apps/api/v1/urls.py
+++ b/enterprise_catalog/apps/api/v1/urls.py
@@ -136,6 +136,11 @@ urlpatterns = [
         EnterpriseJobReadOnlyViewSet.as_view({"get": "list"}),
         name="enterprise-jobs",
     ),
+    path(
+        'catalog-queries/by-uuid/<uuid:uuid>/',
+        CatalogQueryViewSet.as_view({'get': 'get_by_uuid'}),
+        name='get-query-by-uuid'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise_catalog/apps/api/v1/views/catalog_query.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_query.py
@@ -130,6 +130,7 @@ class CatalogQueryViewSet(viewsets.ReadOnlyModelViewSet, BaseViewSet, Permission
             200: CatalogQuery serialized data
             404: If no CatalogQuery matches the given UUID
         """
-        catalog_query = get_object_or_404(self.get_queryset(), uuid=uuid)
+        queryset = self.filter_queryset(self.get_queryset())
+        catalog_query = get_object_or_404(queryset, uuid=uuid)
         serializer = self.get_serializer(catalog_query)
         return Response(serializer.data, status=status.HTTP_200_OK)

--- a/enterprise_catalog/apps/api/v1/views/catalog_query.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_query.py
@@ -34,6 +34,7 @@ class CatalogQueryViewSet(viewsets.ReadOnlyModelViewSet, BaseViewSet, Permission
     permission_required = 'catalog.has_admin_access'
     list_lookup_field = 'enterprise_catalogs__enterprise_uuid'
     role_assignment_class = EnterpriseCatalogRoleAssignment
+    lookup_field = 'uuid'
 
     @property
     def base_queryset(self):

--- a/enterprise_catalog/apps/api/v1/views/catalog_query.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_query.py
@@ -121,16 +121,11 @@ class CatalogQueryViewSet(viewsets.ReadOnlyModelViewSet, BaseViewSet, Permission
             raise ParseError(f"Failed to parse catalog query: {exc}") from exc
         return Response(content_filter_hash)
 
-    @action(
-        detail=False,
-        methods=['get'],
-        url_path=r'by-uuid/(?P<uuid>[0-9a-f-]{36})',
-        url_name='get-by-uuid',
-    )
-    def get_by_uuid(self, request, uuid=None):
+    # NOTE: This endpoint is mapped explicitly in enterprise_catalog/apps/api/v1/urls.py;
+    def get_by_uuid(self, request, uuid=None, **kwargs):
         """
         Retrieve a single CatalogQuery by its UUID field.
-        GET /api/v1/catalog-queries/by-uuid/{uuid}/
+        GET /api/v1/catalog-queries/<uuid>/
         Returns:
             200: CatalogQuery serialized data
             404: If no CatalogQuery matches the given UUID

--- a/enterprise_catalog/apps/api/v1/views/catalog_query.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_query.py
@@ -1,7 +1,8 @@
+from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.utils.functional import cached_property
 from edx_rbac.mixins import PermissionRequiredForListingMixin
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import NotFound, ParseError
 from rest_framework.renderers import JSONRenderer
@@ -34,7 +35,6 @@ class CatalogQueryViewSet(viewsets.ReadOnlyModelViewSet, BaseViewSet, Permission
     permission_required = 'catalog.has_admin_access'
     list_lookup_field = 'enterprise_catalogs__enterprise_uuid'
     role_assignment_class = EnterpriseCatalogRoleAssignment
-    lookup_field = 'uuid'
 
     @property
     def base_queryset(self):
@@ -120,3 +120,21 @@ class CatalogQueryViewSet(viewsets.ReadOnlyModelViewSet, BaseViewSet, Permission
         except ParseError as exc:
             raise ParseError(f"Failed to parse catalog query: {exc}") from exc
         return Response(content_filter_hash)
+
+    @action(
+        detail=False,
+        methods=['get'],
+        url_path=r'by-uuid/(?P<uuid>[0-9a-f-]{36})',
+        url_name='get-by-uuid',
+    )
+    def get_by_uuid(self, request, uuid=None):
+        """
+        Retrieve a single CatalogQuery by its UUID field.
+        GET /api/v1/catalog-queries/by-uuid/{uuid}/
+        Returns:
+            200: CatalogQuery serialized data
+            404: If no CatalogQuery matches the given UUID
+        """
+        catalog_query = get_object_or_404(self.get_queryset(), uuid=uuid)
+        serializer = self.get_serializer(catalog_query)
+        return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
**Description**
Fetching catalog_query_id  using catalog_query_uuid
http://localhost:18160/api/v1/catalog-queries/<Catalog_query_uuid>/

**Testing:**
**API:**
http://localhost:18160/api/v1/catalog-queries/33333333-aaaa-bbbb-cccc-ddddeeee0003/

**Result**
<img width="1206" height="524" alt="image" src="https://github.com/user-attachments/assets/29378c75-553f-4a20-b6ea-923df743ae2a" />

