### PR TITLE
chore: remove incremental rollout guard

### DIFF
--- a/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
+++ b/enterprise_catalog/apps/search/management/commands/incremental_reindex_algolia.py
@@ -7,7 +7,7 @@ and prints a summary of dispatched tasks.
 import logging
 
 from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 
 from enterprise_catalog.apps.api_client.algolia import AlgoliaSearchClient
 from enterprise_catalog.apps.catalog.algolia_utils import (
@@ -95,38 +95,26 @@ class Command(BaseCommand):
         options.update(config_overrides)
 
         content_types = options['content_types']  # None means all types
-        index_name = options['index_name']
-        replica_index_name = options['replica_index_name']
+        index_name = options['index_name'] or settings.ALGOLIA['INCREMENTAL_INDEX_NAME']
+        replica_index_name = options['replica_index_name'] or f'{index_name}_repl'
         force_all = options['force_all']
         dry_run = options['dry_run']
         no_async = options['no_async']
-
-        # Safety guard: block writes to the primary production index.
-        # Remove this check as part of the incremental-reindexing cutover.
-        primary_index = settings.ALGOLIA.get('INDEX_NAME')
-        resolved_index = index_name or primary_index
-        if resolved_index and resolved_index == primary_index:
-            raise CommandError(
-                f"Refusing to run against the primary Algolia index '{primary_index}'. "
-                "Pass --index-name targeting a non-primary index. "
-                "Remove this guard when cutting over to incremental reindexing."
-            )
 
         if dry_run:
             self.stdout.write(self.style.WARNING('[DRY-RUN] No Algolia writes will be made.'))
         else:
             self.stdout.write('Configuring Algolia index settings...')
-            replica_name = replica_index_name or f'{index_name}_repl'
             sdk_client = new_search_client_or_error()
             algolia_client = AlgoliaSearchClient()
             algolia_client.algolia_index = sdk_client.init_index(index_name)
-            algolia_client.replica_index = sdk_client.init_index(replica_name)
-            primary_settings = {**ALGOLIA_INDEX_SETTINGS, 'replicas': [f'virtual({replica_name})']}
+            algolia_client.replica_index = sdk_client.init_index(replica_index_name)
+            primary_settings = {**ALGOLIA_INDEX_SETTINGS, 'replicas': [f'virtual({replica_index_name})']}
             algolia_client.set_index_settings(primary_settings)
             algolia_client.set_index_settings(ALGOLIA_REPLICA_INDEX_SETTINGS, primary_index=False)
 
         self.stdout.write(f'Content types: {", ".join(content_types) if content_types else "all"}')
-        self.stdout.write(f'Target index:  {resolved_index or "(not configured)"}')
+        self.stdout.write(f'Target index:  {index_name or "(not configured)"}')
         self.stdout.write(f'Force all:     {force_all}')
         self.stdout.write('')
 

--- a/enterprise_catalog/apps/search/management/commands/tests/test_incremental_reindex_algolia.py
+++ b/enterprise_catalog/apps/search/management/commands/tests/test_incremental_reindex_algolia.py
@@ -6,7 +6,6 @@ from unittest import mock
 
 import ddt
 from django.core.management import call_command
-from django.core.management.base import CommandError
 from django.test import TestCase, override_settings
 
 from enterprise_catalog.apps.catalog.constants import (
@@ -259,31 +258,6 @@ class IncrementalReindexAlgoliaCommandTests(TestCase):
         mock_task.apply_async.return_value.get.return_value = None
         output = self._call()
         assert 'No summary' in output
-
-    # ------------------------------------------------------------------
-    # Primary-index guard (remove at cutover)
-    # ------------------------------------------------------------------
-
-    @override_settings(ALGOLIA={'INDEX_NAME': 'enterprise_catalog'})
-    def test_guard_blocks_default_invocation_against_primary_index(self):
-        """No --index-name defaults to the primary index, which must be blocked."""
-        with self.assertRaises(CommandError) as ctx:
-            self._call()
-        assert 'enterprise_catalog' in str(ctx.exception)
-
-    @override_settings(ALGOLIA={'INDEX_NAME': 'enterprise_catalog'})
-    def test_guard_blocks_explicit_primary_index_name(self):
-        """--index-name matching the primary index is also blocked."""
-        with self.assertRaises(CommandError):
-            self._call('--index-name', 'enterprise_catalog')
-
-    @override_settings(ALGOLIA={'INDEX_NAME': 'enterprise_catalog'})
-    @mock.patch(TASK_PATH)
-    def test_guard_allows_non_primary_index_name(self, mock_task):
-        """--index-name pointing to a different index bypasses the guard."""
-        mock_task.apply_async.return_value.get.return_value = _SAMPLE_SUMMARY
-        output = self._call('--index-name', 'enterprise_catalog_v2')
-        assert 'enterprise_catalog_v2' in output
 
     # ------------------------------------------------------------------
     # Config model override


### PR DESCRIPTION
I've set the "primary" index name to refer to the incremental index name everywhere, so this guard in the management command needs to go away now.

https://2u-internal.atlassian.net/browse/ENT-11699
