### PR TITLE
perf: filter content after pagination in get_content_metadata

### DIFF
--- a/docs/decisions/0014-filter-content-after-pagination.rst
+++ b/docs/decisions/0014-filter-content-after-pagination.rst
@@ -1,0 +1,76 @@
+0014 Filter content after pagination instead of denormalizing flags
+==================================================================
+
+Status
+------
+
+Accepted
+
+Context
+-------
+
+``EnterpriseCatalogGetContentMetadata.get_content_metadata`` was materializing the
+entire catalog queryset on every request before paginating. The sequence was:
+
+.. code-block:: python
+
+    len(queryset)                                                   # evaluates entire catalog
+    queryset = [item for item in queryset if not is_unpublished(item)]  # reads json_metadata per row
+    queryset = [item for item in queryset if is_active(item)]          # reads json_metadata per row again
+    page = self.paginate_queryset(queryset)                        # slices a Python list, not SQL
+
+``is_unpublished`` and ``is_active`` both read ``item.json_metadata`` (a large JSON blob) for every
+row in the catalog, regardless of which page was requested. A 9.7s trace at ``page=207&page_size=10``
+showed ~8.7s unaccounted for by DB or cache -- all of it Python deserializing JSON for rows that
+were never returned. ``page=1&page_size=50`` clocked 7.2s for the same reason: the page number
+barely matters when you deserialize the whole catalog first.
+
+This was introduced by commits that added the unpublished/active filters as list comprehensions
+without realising they forced full queryset evaluation ahead of ``paginate_queryset``.
+
+Decision
+--------
+
+Move the ``is_unpublished`` / ``is_active`` filters to run *after* ``paginate_queryset``. The queryset
+stays lazy, so ``paginate_queryset`` issues SQL ``COUNT`` + ``LIMIT/OFFSET`` and fetches only
+``page_size`` rows. The Python filters then read ``json_metadata`` on those rows only -- 10-50
+items instead of potentially thousands.
+
+The tradeoff: in the normal paginated path the ``count`` field in the response reflects the SQL
+``COUNT``, which includes items that will be filtered. The count is slightly inflated when
+unpublished or inactive courses exist in the catalog. ``next``/``previous`` links still navigate
+correctly. For the ``traverse_pagination`` path all results are materialized and filtered before
+counting, so that count remains exact.
+
+Rejected alternative: denormalizing onto the table
+---------------------------------------------------
+
+The schema approach would add ``is_published`` and ``is_active`` boolean columns to
+``ContentMetadata`` with a composite index, push the filters into SQL, and keep both the queryset
+and the count exact end-to-end. It requires:
+
+1. A migration adding the two columns and index.
+2. A ``ContentMetadata.save()`` override to recompute both flags on every write.
+3. Explicit flag recomputation in the ``bulk_update`` path (``models.py:1320``), which bypasses
+   ``save()``.
+4. A batched backfill management command for existing rows.
+5. Deploy coordination between migration, backfill, and the view change.
+
+This was rejected because the performance win is identical for the real bottleneck -- both
+approaches reduce per-request JSON deserialization from whole-catalog to one page. The count
+inflation in the no-migration approach is minor: the machine-to-machine callers (``AmazonAPIGateway``)
+traverse pages using ``next`` links rather than computing page counts from ``count``. The schema
+approach adds meaningful deploy risk with no runtime benefit over the simpler fix.
+
+Revisit the schema approach if exact counts become a hard requirement from consumers, or if the
+proportion of filtered items grows large enough that under-filled pages cause traversal problems.
+
+Consequences
+------------
+
+- Per-request JSON deserialization drops from whole-catalog to ``page_size`` rows.
+- ``count`` in paginated responses is slightly inflated when filtered items exist. The
+  ``traverse_pagination`` path is unaffected.
+- No migration, no backfill, no deploy coordination beyond a single view change.
+- Secondary costs (867ms M2M ``ORDER BY``, N+1 ``parent_content_key`` lookups) are deferred to a
+  follow-up PR; they are now bounded to one page and no longer on the critical path.

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1559,18 +1559,49 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
-        self.assertEqual(response_data["count"], 0)
+        # count is the SQL total (1 unpublished item exists); results are filtered to empty
+        self.assertEqual(response_data["count"], 1)
         self.assertEqual(response_data["results"], [])
 
         # Test 2: With content_keys parameter explicitly requesting the unpublished course
-        # This tests the regression where unpublished courses were returned when content_keys was provided
-        url_with_keys = f"{url}?content_keys={unpublished_course.content_key}"
-        response_with_keys = self.client.get(url_with_keys)
+        # This tests the regression where unpublished courses were returned when content_keys was provided.
+        # Use data= so the test client URL-encodes the key (content_key may contain '+').
+        response_with_keys = self.client.get(url, data={'content_keys': unpublished_course.content_key})
 
         self.assertEqual(response_with_keys.status_code, status.HTTP_200_OK)
         response_data_with_keys = response_with_keys.json()
-        self.assertEqual(response_data_with_keys["count"], 0)
+        self.assertEqual(response_data_with_keys["count"], 1)
         self.assertEqual(response_data_with_keys["results"], [])
+
+    @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
+    def test_filtering_occurs_after_pagination(self, mock_api_client):  # pylint: disable=unused-argument
+        """
+        Verify that is_unpublished/is_active filtering happens after paginate_queryset.
+
+        The observable consequence: response 'count' equals the SQL total (which includes
+        items that will be filtered), while 'results' contains only the filtered items.
+        This proves json_metadata is read for page_size rows only, not the whole catalog.
+        """
+        published_courses = ContentMetadataFactory.create_batch(3, content_type=COURSE)
+        unpublished_course = ContentMetadataFactory(
+            content_type=COURSE,
+            json_metadata={"status": "unpublished", "course_runs": []},
+        )
+        all_items = published_courses + [unpublished_course]
+        self.add_metadata_to_catalog(self.enterprise_catalog, all_items)
+
+        url = self._get_content_metadata_url(self.enterprise_catalog)
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        # SQL COUNT includes the unpublished course; filtering is post-pagination
+        self.assertEqual(data['count'], len(all_items))
+        # Results are still correctly filtered
+        self.assertEqual(len(data['results']), len(published_courses))
+        result_content_keys = [r['key'] for r in data['results']]
+        self.assertNotIn(unpublished_course.content_key, result_content_keys)
 
     @mock.patch('enterprise_catalog.apps.api_client.enterprise_cache.EnterpriseApiClient')
     @ddt.data(
@@ -1622,8 +1653,8 @@ class EnterpriseCatalogGetContentMetadataTests(APITestMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_data = response.json()
-        # excluded expire course (API won't return it)
-        self.assertEqual((response_data['count']), len(metadata) - 1)
+        # count is the SQL COUNT and includes the inactive course; results are filtered post-pagination
+        self.assertEqual((response_data['count']), len(metadata))
         self.assertEqual(
             uuid.UUID(response_data['uuid']), self.enterprise_catalog.uuid)
         self.assertEqual(response_data['title'], self.enterprise_catalog.title)

--- a/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
+++ b/enterprise_catalog/apps/api/v1/views/enterprise_catalog_get_content_metadata.py
@@ -87,9 +87,14 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
 
     @extend_schema(
         description=(
-            "GET calls to the `enterprise-catalogs/{catalog_id}` endpoint return a list of all of the active courses "
-            "in a specified course catalog. You can then make a GET call to the "
-            "`/enterprise-catalogs/{catalog_id}/courses/{course_key}` endpoint to return details about a single course."
+            "Returns paginated content metadata for a catalog. "
+            "Unpublished courses (no published runs) are always excluded from `results`. "
+            "Inactive courses are also excluded unless `content_keys` is provided. "
+            "\n\n"
+            "**Note on `count`:** in the default paginated path, `count` reflects a SQL COUNT of all "
+            "catalog rows before the unpublished/inactive filters are applied, so it may be slightly "
+            "higher than the number of items actually returned across all pages. "
+            "Use `traverse_pagination=true` to get an exact filtered count on a single page."
         ),
         parameters=[
             OpenApiParameter(
@@ -98,7 +103,18 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
                 location=OpenApiParameter.QUERY,
                 description=(
                     "A list of content keys to filter the results. "
-                    "If not provided, all content metadata is returned."
+                    "If not provided, all content metadata is returned. "
+                    "When provided, the inactive-course filter is skipped."
+                ),
+            ),
+            OpenApiParameter(
+                name="traverse_pagination",
+                type=bool,
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "If true, all results are collected onto a single page and `count` is exact "
+                    "(filtered). If false or omitted, standard pagination applies and `count` may "
+                    "be slightly inflated by unpublished or inactive courses."
                 ),
             ),
             OpenApiParameter(
@@ -264,46 +280,50 @@ class EnterpriseCatalogGetContentMetadata(BaseViewSet, GenericAPIView):
             return active
         return True
 
-    @action(detail=True)
+    def _apply_content_filters(self, items, content_keys_filter):
+        """
+        Remove unpublished courses and, when no content_keys filter is active, inactive courses.
+        Reads json_metadata only for the given items, not the whole catalog.
+        """
+        items = [item for item in items if not self.is_unpublished(item)]
+        if not content_keys_filter:
+            items = [item for item in items if self.is_active(item)]
+        return items
+
     def get_content_metadata(self, request, traverse_pagination, content_keys_filter):
         """
-        Returns all the content metadata associated with the enterprise catalog.
+        Returns content metadata associated with the enterprise catalog, excluding unpublished courses.
 
-        The parameter `traverse_pagination`, if provided, will collect the results onto a single page.
+        `traverse_pagination`: if true, materializes and filters the full result set onto one page;
+        `count` in the response is exact. If false, uses SQL COUNT + LIMIT/OFFSET so `count` may
+        be slightly inflated by unpublished or inactive courses that exist in the catalog but are
+        filtered from `results`.
 
-        The parameter `content_keys_filter`, if provided, will result in only content metadata associated with the
-        provided content keys being returned.
+        `content_keys_filter`: if provided, only content matching those keys is returned and the
+        inactive-course filter is skipped.
         """
         queryset = self.filter_queryset(self.get_queryset(content_keys_filter=content_keys_filter))
-        logger.debug(f'[get_content_metadata]: Original queryset length: {len(queryset)}, {self.enterprise_catalog}')
-
-        # Always filter out unpublished courses
-        queryset = [item for item in queryset if not self.is_unpublished(item)]
-        logger.debug(f'[get_content_metadata]: After unpublished filter, queryset length: {len(queryset)}, '
-                     f'{self.enterprise_catalog}')
-
-        # Additionally filter out inactive courses if content_keys_filter is not provided
-        if not content_keys_filter:
-            queryset = [item for item in queryset if self.is_active(item)]
-            logger.debug(f'[get_content_metadata]: After active filter, queryset length: {len(queryset)}, '
-                         f'{self.enterprise_catalog}')
+        # paginate_queryset issues SQL COUNT + LIMIT/OFFSET; no json_metadata loaded yet
+        page = self.paginate_queryset(queryset)
 
         context = self.get_serializer_context()
         context['enterprise_catalog'] = self.enterprise_catalog
-        page = self.paginate_queryset(queryset)
 
-        # Traverse pagination query parameter signals that we should collect the results onto a single page
-        if page is not None and not traverse_pagination:
-            serializer = ContentMetadataSerializer(page, context=context, many=True)
-            paginated_response = self.get_paginated_response(serializer.data)
-            return self.get_response_with_enterprise_fields(paginated_response)
+        # Traverse pagination: materialize and filter the full result set so count is exact
+        if page is None or traverse_pagination:
+            results = self._apply_content_filters(queryset, content_keys_filter)
+            serializer = ContentMetadataSerializer(results, context=context, many=True)
+            ordered_data = OrderedDict([
+                ('previous', None),
+                ('next', None),
+                ('count', len(results)),
+                ('results', serializer.data),
+            ])
+            return self.get_response_with_enterprise_fields(Response(ordered_data))
 
-        serializer = ContentMetadataSerializer(queryset, context=context, many=True)
-        ordered_data = OrderedDict({
-            'previous': None,
-            'next': None,
-            'count': len(queryset),
-            'results': serializer.data,
-        })
-        response = Response(ordered_data)
-        return self.get_response_with_enterprise_fields(response)
+        # Normal paginated path: filter the page only (page_size rows, not the whole catalog).
+        # The paginator's COUNT is slightly inflated when inactive/unpublished items exist,
+        # but next/previous links navigate correctly and the serialization cost is bounded.
+        page = self._apply_content_filters(page, content_keys_filter)
+        serializer = ContentMetadataSerializer(page, context=context, many=True)
+        return self.get_response_with_enterprise_fields(self.get_paginated_response(serializer.data))


### PR DESCRIPTION
## Summary

- `get_content_metadata` was materializing the entire catalog queryset before paginating. `is_unpublished` and `is_active` ran as list comprehensions that read `json_metadata` on every row in the catalog on every request, then handed a Python list to `paginate_queryset`. A 9.7s trace at `page=207&page_size=10` showed ~8.7s unaccounted for by DB or cache — all of it Python deserializing JSON blobs for rows never returned. `page=1&page_size=50` clocked 7.2s for the same reason: page number barely matters when you load the whole catalog first.
- Moves the filters to run after `paginate_queryset`. The queryset stays lazy; the DB handles `COUNT` + `LIMIT/OFFSET`. `json_metadata` is read for `page_size` rows only.
- Adds ADR `0014` documenting the fix and why denormalizing `is_published`/`is_active` onto the table was rejected.

**Known tradeoff:** in the normal paginated path, the `count` field reflects the SQL `COUNT` and is slightly inflated when filtered items exist. `next`/`previous` links are unaffected. The `traverse_pagination` count remains exact. See `docs/decisions/0014` for full rationale.

https://2u-internal.atlassian.net/browse/ENT-12072

PR that introduced regression: https://github.com/edx/enterprise-catalog/pull/37

## Test plan

- [x] `pytest enterprise_catalog/apps/api/v1/tests/test_views.py -k GetContentMetadata` — 21 tests pass
- [ ] `make quality` — clean
- [x] New test `test_filtering_occurs_after_pagination` asserts `count` equals SQL total while `results` exclude the filtered item

🤖 Generated with [Claude Code](https://claude.com/claude-code)