### PR TITLE
perf: use include_modified param in discovery /search/all/ requests

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -107,15 +107,23 @@ class DiscoveryApiClient(BaseOAuthClient):
         discovery service to fetch search results based on the filter and concatenates
         all results into a returned list.
         """
-        request_params_customized = request_params | {
+        modified_param = (
+            {'include_modified': 'true'} if settings.DISCOVERY_USE_INCLUDE_MODIFIED_PARAM
+            else {'detail_fields': 'true'}
+        )
+        # Strip both keys from caller params so neither leaks through when the other is selected.
+        base_params = {k: v for k, v in request_params.items() if k not in ('detail_fields', 'include_modified')}
+        request_params_customized = base_params | {
             # Increase number of results per page for the course-discovery response
             'page_size': 100,
             # Ensure paginated results are consistently ordered by `aggregation_key` and `start`
             'ordering': 'aggregation_key,start',
-            # Ensures we get the course modified field in the response payload
+            # Ensures we get the course modified field in the response payload.
             # Important for de-duplication of ContentMetadata updates.
-            'detail_fields': 'true',
-        }
+            # When DISCOVERY_USE_INCLUDE_MODIFIED_PARAM is True, uses include_modified instead of
+            # detail_fields, which skips expensive serialization of level_type, outcome, and
+            # expanded course run fields.
+        } | modified_param
         page = 1
         results = []
         try:

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -2,7 +2,7 @@
 from unittest import mock
 
 import requests
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from simplejson import JSONDecodeError
 
 from enterprise_catalog.apps.api_client.constants import (
@@ -35,6 +35,56 @@ class TestDiscoveryApiClient(TestCase):
 
         expected_response = [{'key': 'fakeX'}]
         self.assertEqual(actual_response, expected_response)
+
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
+    def test_retrieve_metadata_passes_detail_fields_by_default(self, mock_oauth_client):
+        """
+        retrieve_metadata_for_content_filter passes detail_fields=true when
+        DISCOVERY_USE_INCLUDE_MODIFIED_PARAM is False (the default).
+        """
+        mock_oauth_client.return_value.post.return_value.status_code = 200
+        mock_oauth_client.return_value.post.return_value.json.return_value = {'results': []}
+
+        client = DiscoveryApiClient()
+        client.retrieve_metadata_for_content_filter({}, {})
+
+        called_params = mock_oauth_client.return_value.post.call_args[1]['params']
+        self.assertEqual(called_params.get('detail_fields'), 'true')
+        self.assertNotIn('include_modified', called_params)
+
+    @override_settings(DISCOVERY_USE_INCLUDE_MODIFIED_PARAM=True)
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
+    def test_retrieve_metadata_passes_include_modified_when_toggled(self, mock_oauth_client):
+        """
+        retrieve_metadata_for_content_filter passes include_modified=true instead of
+        detail_fields when DISCOVERY_USE_INCLUDE_MODIFIED_PARAM is True.
+        """
+        mock_oauth_client.return_value.post.return_value.status_code = 200
+        mock_oauth_client.return_value.post.return_value.json.return_value = {'results': []}
+
+        client = DiscoveryApiClient()
+        client.retrieve_metadata_for_content_filter({}, {})
+
+        called_params = mock_oauth_client.return_value.post.call_args[1]['params']
+        self.assertEqual(called_params.get('include_modified'), 'true')
+        self.assertNotIn('detail_fields', called_params)
+
+    @override_settings(DISCOVERY_USE_INCLUDE_MODIFIED_PARAM=True)
+    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
+    def test_retrieve_metadata_strips_conflicting_params_from_caller(self, mock_oauth_client):
+        """
+        Caller-supplied detail_fields/include_modified are stripped so only the
+        toggle-selected param appears in the final request.
+        """
+        mock_oauth_client.return_value.post.return_value.status_code = 200
+        mock_oauth_client.return_value.post.return_value.json.return_value = {'results': []}
+
+        client = DiscoveryApiClient()
+        client.retrieve_metadata_for_content_filter({}, {'detail_fields': 'true', 'include_modified': 'false'})
+
+        called_params = mock_oauth_client.return_value.post.call_args[1]['params']
+        self.assertEqual(called_params.get('include_modified'), 'true')
+        self.assertNotIn('detail_fields', called_params)
 
     @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
     def test_get_metadata_by_query_with_extra_query_params(self, mock_oauth_client):

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -419,6 +419,12 @@ ENTERPRISE_CUSTOMER_CACHE_TIMEOUT = ONE_HOUR
 DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT = ONE_HOUR
 DISCOVERY_COURSE_DATA_CACHE_TIMEOUT = ONE_HOUR
 
+# Rollout toggle for use of the "include_modified" query param in requests
+# to the course-discovery /search/all/ endpoint. Will eventually be removed
+# and those requests will *always* send that param.
+# See https://2u-internal.atlassian.net/browse/ENT-11976
+DISCOVERY_USE_INCLUDE_MODIFIED_PARAM = False
+
 # URLs
 LMS_BASE_URL = os.environ.get('LMS_BASE_URL', '')
 DISCOVERY_SERVICE_API_URL = os.environ.get('DISCOVERY_SERVICE_API_URL', '')


### PR DESCRIPTION
## Summary

- Adds `DISCOVERY_USE_INCLUDE_MODIFIED_PARAM` setting (default `False`) to `base.py`.
- When `True`, `retrieve_metadata_for_content_filter` passes `include_modified=true` to the discovery `/search/all/` endpoint instead of `detail_fields=true`.
- `include_modified` returns only the `modified` field, skipping expensive serialization of `level_type`, `outcome`, and expanded course run fields that `detail_fields` pulls in (edx/course-discovery#5).

## Rollout plan
- [ ] Flip `DISCOVERY_USE_INCLUDE_MODIFIED_PARAM = True` in the target env once course-discovery with edx/course-discovery#5 is deployed. Verify that response payloads contain same data as usual.

ENT-11976

🤖 Generated with [Claude Code](https://claude.com/claude-code)