### PR TITLE
chore: remove use of rollout toggle for include_modified

### DIFF
--- a/enterprise_catalog/apps/api_client/discovery.py
+++ b/enterprise_catalog/apps/api_client/discovery.py
@@ -107,23 +107,15 @@ class DiscoveryApiClient(BaseOAuthClient):
         discovery service to fetch search results based on the filter and concatenates
         all results into a returned list.
         """
-        modified_param = (
-            {'include_modified': 'true'} if settings.DISCOVERY_USE_INCLUDE_MODIFIED_PARAM
-            else {'detail_fields': 'true'}
-        )
-        # Strip both keys from caller params so neither leaks through when the other is selected.
-        base_params = {k: v for k, v in request_params.items() if k not in ('detail_fields', 'include_modified')}
+        base_params = dict(request_params.items())
         request_params_customized = base_params | {
             # Increase number of results per page for the course-discovery response
             'page_size': 100,
             # Ensure paginated results are consistently ordered by `aggregation_key` and `start`
             'ordering': 'aggregation_key,start',
-            # Ensures we get the course modified field in the response payload.
-            # Important for de-duplication of ContentMetadata updates.
-            # When DISCOVERY_USE_INCLUDE_MODIFIED_PARAM is True, uses include_modified instead of
-            # detail_fields, which skips expensive serialization of level_type, outcome, and
-            # expanded course run fields.
-        } | modified_param
+            # Ensure the course run `modified` field is included in response payloads
+            'include_modified': 'true',
+        }
         page = 1
         results = []
         try:

--- a/enterprise_catalog/apps/api_client/tests/test_discovery.py
+++ b/enterprise_catalog/apps/api_client/tests/test_discovery.py
@@ -2,7 +2,7 @@
 from unittest import mock
 
 import requests
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from simplejson import JSONDecodeError
 
 from enterprise_catalog.apps.api_client.constants import (
@@ -37,50 +37,15 @@ class TestDiscoveryApiClient(TestCase):
         self.assertEqual(actual_response, expected_response)
 
     @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
-    def test_retrieve_metadata_passes_detail_fields_by_default(self, mock_oauth_client):
+    def test_retrieve_metadata_passes_include_modified(self, mock_oauth_client):
         """
-        retrieve_metadata_for_content_filter passes detail_fields=true when
-        DISCOVERY_USE_INCLUDE_MODIFIED_PARAM is False (the default).
-        """
-        mock_oauth_client.return_value.post.return_value.status_code = 200
-        mock_oauth_client.return_value.post.return_value.json.return_value = {'results': []}
-
-        client = DiscoveryApiClient()
-        client.retrieve_metadata_for_content_filter({}, {})
-
-        called_params = mock_oauth_client.return_value.post.call_args[1]['params']
-        self.assertEqual(called_params.get('detail_fields'), 'true')
-        self.assertNotIn('include_modified', called_params)
-
-    @override_settings(DISCOVERY_USE_INCLUDE_MODIFIED_PARAM=True)
-    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
-    def test_retrieve_metadata_passes_include_modified_when_toggled(self, mock_oauth_client):
-        """
-        retrieve_metadata_for_content_filter passes include_modified=true instead of
-        detail_fields when DISCOVERY_USE_INCLUDE_MODIFIED_PARAM is True.
+        retrieve_metadata_for_content_filter passes include_modified=true
         """
         mock_oauth_client.return_value.post.return_value.status_code = 200
         mock_oauth_client.return_value.post.return_value.json.return_value = {'results': []}
 
         client = DiscoveryApiClient()
         client.retrieve_metadata_for_content_filter({}, {})
-
-        called_params = mock_oauth_client.return_value.post.call_args[1]['params']
-        self.assertEqual(called_params.get('include_modified'), 'true')
-        self.assertNotIn('detail_fields', called_params)
-
-    @override_settings(DISCOVERY_USE_INCLUDE_MODIFIED_PARAM=True)
-    @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
-    def test_retrieve_metadata_strips_conflicting_params_from_caller(self, mock_oauth_client):
-        """
-        Caller-supplied detail_fields/include_modified are stripped so only the
-        toggle-selected param appears in the final request.
-        """
-        mock_oauth_client.return_value.post.return_value.status_code = 200
-        mock_oauth_client.return_value.post.return_value.json.return_value = {'results': []}
-
-        client = DiscoveryApiClient()
-        client.retrieve_metadata_for_content_filter({}, {'detail_fields': 'true', 'include_modified': 'false'})
 
         called_params = mock_oauth_client.return_value.post.call_args[1]['params']
         self.assertEqual(called_params.get('include_modified'), 'true')

--- a/enterprise_catalog/settings/base.py
+++ b/enterprise_catalog/settings/base.py
@@ -419,12 +419,6 @@ ENTERPRISE_CUSTOMER_CACHE_TIMEOUT = ONE_HOUR
 DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT = ONE_HOUR
 DISCOVERY_COURSE_DATA_CACHE_TIMEOUT = ONE_HOUR
 
-# Rollout toggle for use of the "include_modified" query param in requests
-# to the course-discovery /search/all/ endpoint. Will eventually be removed
-# and those requests will *always* send that param.
-# See https://2u-internal.atlassian.net/browse/ENT-11976
-DISCOVERY_USE_INCLUDE_MODIFIED_PARAM = False
-
 # URLs
 LMS_BASE_URL = os.environ.get('LMS_BASE_URL', '')
 DISCOVERY_SERVICE_API_URL = os.environ.get('DISCOVERY_SERVICE_API_URL', '')


### PR DESCRIPTION
Cleanup rollout toggle for ENT-11976

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
