### PR TITLE
perf: batch program metadata updates across courses in a batch

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -255,11 +255,14 @@ def update_full_content_metadata_task(self, force=False, dry_run=False):  # pyli
     Args:
         force (bool): If true, forces execution of task and ignores time since last run.
     """
-
+    logger.info('update_full_content_metadata_task starting full update of courses')
     content_keys = [metadata.content_key for metadata in ContentMetadata.objects.filter(content_type=COURSE)]
     _update_full_content_metadata_course(content_keys, dry_run)
+    logger.info('update_full_content_metadata_task completed full update of courses')
+    logger.info('update_full_content_metadata_task starting full update of programs')
     content_keys = [metadata.content_key for metadata in ContentMetadata.objects.filter(content_type=PROGRAM)]
     _update_full_content_metadata_program(content_keys, dry_run)
+    logger.info('update_full_content_metadata_task completed full update of programs')
 
 
 def _update_full_content_metadata_course(content_keys, dry_run=False):
@@ -293,6 +296,7 @@ def _update_full_content_metadata_course(content_keys, dry_run=False):
         # merging the minimal json_metadata retrieved by
         # `/search/all/` with the full json_metadata retrieved by `/courses/`.
         modified_content_metadata_records = []
+        all_program_content_keys = []
         for course_metadata_dict in full_course_dicts:
             content_key = course_metadata_dict.get('key')
             metadata_record = metadata_by_key.get(content_key)
@@ -310,8 +314,17 @@ def _update_full_content_metadata_course(content_keys, dry_run=False):
                 course_metadata_dict.get('programs', []),
                 modified_course_record,
             )
-            _update_full_content_metadata_program(program_content_keys, dry_run)
+            all_program_content_keys.extend(program_content_keys)
 
+        # Batch program updates across all courses in this batch rather than
+        # firing one Discovery request per course. Deduplicate so courses that
+        # share a program don't trigger redundant fetches or duplicate bulk_update rows.
+        unique_program_content_keys = list(dict.fromkeys(all_program_content_keys))
+        if unique_program_content_keys:
+            _update_full_content_metadata_program(unique_program_content_keys, dry_run)
+
+        for modified_course_record in modified_content_metadata_records:
+            course_review = course_reviews_by_content_key.get(modified_course_record.content_key)
             _update_full_restricted_course_metadata(modified_course_record, course_review, dry_run)
 
         if dry_run:
@@ -324,7 +337,7 @@ def _update_full_content_metadata_course(content_keys, dry_run=False):
             )
 
         logger.info(
-            'Successfully updated %d of %d ContentMetadata records with full metadata from course-discovery.',
+            'Successfully updated %d of %d course ContentMetadata records with full metadata from course-discovery.',
             len(modified_content_metadata_records),
             len(full_course_dicts),
         )
@@ -334,7 +347,8 @@ def _update_full_content_metadata_course(content_keys, dry_run=False):
         indexable_course_keys.extend(partitioned_indexable_course_keys)
 
     logger.info(
-        '{} total course keys were updated and are ready for indexing in Algolia'.format(len(indexable_course_keys))
+        '%d total course keys were updated and are ready for indexing in Algolia',
+        len(indexable_course_keys),
     )
 
 
@@ -504,7 +518,7 @@ def _update_full_content_metadata_program(content_keys, dry_run=False):
             )
 
         logger.info(
-            'Successfully updated %d of %d ContentMetadata records with full metadata from course-discovery.',
+            'Successfully updated %d of %d program ContentMetadata records with full metadata from course-discovery.',
             len(modified_content_metadata_records),
             len(full_program_dicts),
         )
@@ -514,7 +528,8 @@ def _update_full_content_metadata_program(content_keys, dry_run=False):
         indexable_program_keys.extend(partitioned_indexable_program_keys)
 
     logger.info(
-        '{} total program keys were updated and are ready for indexing in Algolia'.format(len(indexable_program_keys))
+        '%d total program keys were updated and are ready for indexing in Algolia',
+        len(indexable_program_keys),
     )
 
 

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -399,10 +399,16 @@ class UpdateFullContentMetadataTaskTests(TestCase):
         assert _find_best_mode_seat(seats) == expected_seat
 
     # pylint: disable=unused-argument, too-many-statements
+    @mock.patch(
+        'enterprise_catalog.apps.api.tasks._update_full_content_metadata_program',
+        wraps=tasks._update_full_content_metadata_program,  # pylint: disable=protected-access
+    )
     @mock.patch('enterprise_catalog.apps.api.tasks.task_recently_run', return_value=False)
     @mock.patch('enterprise_catalog.apps.api.tasks.partition_course_keys_for_indexing')
     @mock.patch('enterprise_catalog.apps.api_client.base_oauth.OAuthAPIClient')
-    def test_update_full_metadata(self, mock_oauth_client, mock_partition_course_keys, mock_task_recently_run):
+    def test_update_full_metadata(
+        self, mock_oauth_client, mock_partition_course_keys, mock_task_recently_run, mock_update_program,
+    ):
         """
         Assert that full course metadata is merged with original json_metadata for all ContentMetadata records.
         """
@@ -437,7 +443,7 @@ class UpdateFullContentMetadataTaskTests(TestCase):
         course_run_3_uuid = str(uuid.uuid4())
         course_data_3 = {
             'key': course_key_3,
-            'programs': [],
+            'programs': [program_data],  # shares program_key with course_data_2 to exercise deduplication
             'course_runs': [{
                 'key': f'course-v1:{course_key_3}+1',
                 'uuid': course_run_3_uuid,
@@ -561,7 +567,14 @@ class UpdateFullContentMetadataTaskTests(TestCase):
         # make sure course associated program metadata has been created and linked correctly
         assert ContentMetadata.objects.filter(content_key=program_key).exists()
         assert metadata_2.associated_content_metadata.filter(content_key=program_key).exists()
+        assert metadata_3.associated_content_metadata.filter(content_key=program_key).exists()
         assert not metadata_1.associated_content_metadata.filter(content_key=program_key).exists()
+
+        # course_2 and course_3 both reference program_key; the call to
+        # _update_full_content_metadata_program from within _update_full_content_metadata_course
+        # must deduplicate, so program_key appears exactly once.
+        first_call_keys = mock_update_program.call_args_list[0].args[0]
+        assert first_call_keys == [program_key]
 
     # pylint: disable=unused-argument
     @mock.patch('enterprise_catalog.apps.api.tasks.task_recently_run', return_value=False)


### PR DESCRIPTION
`_update_full_content_metadata_course` was calling `_update_full_content_metadata_program` inside the per-course loop, firing one Discovery request per course. Instead, we should collect program keys across all courses in the batch first, then call once per batch.

Also clarifies log statements to name the content type (course vs. program).

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed
