### PR TITLE
fix: replace chain(group, group) with sequential group.get() in algolia dispatch

### DIFF
--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -50,7 +50,7 @@ from typing import Any, TypedDict, TypeVar
 from uuid import UUID
 
 from algoliasearch.exceptions import AlgoliaException
-from celery import chain, group, shared_task
+from celery import group, shared_task
 from celery_utils.logged_task import LoggedTask
 from django.conf import settings
 from django.db import IntegrityError
@@ -73,6 +73,7 @@ from enterprise_catalog.apps.catalog.constants import (
     COURSE_RUN,
     LEARNER_PATHWAY,
     PROGRAM,
+    TASK_TIMEOUT,
     VIDEO,
 )
 from enterprise_catalog.apps.catalog.models import CatalogQuery, ContentMetadata
@@ -322,7 +323,7 @@ def _build_ordered_groups(
     Tasks use ``.si()`` (immutable signatures) so each task's kwargs are fixed
     at dispatch time and Celery does not forward the previous group's return
     values as positional arguments.  Empty groups are omitted from the list so
-    callers can pass the result directly to ``chain(*ordered_groups)``.
+    callers can iterate and ``.get()`` each group sequentially.
 
     Returns:
         ordered_groups: list of ``group`` objects, one per non-empty content
@@ -399,11 +400,9 @@ def dispatch_algolia_indexing(
     Because those timestamps are only advanced *after* the child batch tasks
     complete, we must guarantee that all course batches finish before any
     program batches start, and all program batches finish before any pathway
-    batches start.  This is achieved by assembling the batches into a
-    ``chain`` of Celery ``group``\\s (courses → programs → pathways).  Each
-    group runs in parallel internally; Celery does not start the next group
-    until every task in the current group has completed.  Empty groups are
-    omitted from the chain.
+    batches start.  This is achieved by dispatching each content-type
+    ``group`` sequentially and blocking on ``.get()`` before advancing to the
+    next.  Empty groups are omitted.
     """
     index_name = index_name or settings.ALGOLIA.get('INCREMENTAL_INDEX_NAME')
 
@@ -453,10 +452,11 @@ def dispatch_algolia_indexing(
     }
 
     if not dry_run and ordered_groups:
-        if use_apply:
-            chain(*ordered_groups).apply()
-        else:
-            chain(*ordered_groups).apply_async()
+        for ordered_group in ordered_groups:
+            if use_apply:
+                ordered_group.apply()
+            else:
+                ordered_group.apply_async().get(timeout=TASK_TIMEOUT, propagate=True)
 
     logger.info('dispatch_algolia_indexing summary=%s', summary)
     return summary
@@ -567,7 +567,8 @@ def dispatch_algolia_indexing_for_catalog_query(
     }
 
     if not dry_run and ordered_groups:
-        chain(*ordered_groups).apply_async()
+        for ordered_group in ordered_groups:
+            ordered_group.apply_async().get(timeout=TASK_TIMEOUT, propagate=True)
 
     logger.info('dispatch_algolia_indexing_for_catalog_query summary=%s', summary)
     return summary

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -749,9 +749,8 @@ class TestDispatchAlgoliaIndexing(TestCase):
         self.mock_video_si = mock.patch.object(
             search_tasks.index_videos_batch_in_algolia, 'si',
         ).start()
-        # Prevent actual Celery chain/group dispatch
+        # Prevent actual Celery group dispatch
         self.mock_group = mock.patch.object(search_tasks, 'group').start()
-        self.mock_chain = mock.patch.object(search_tasks, 'chain').start()
         self.addCleanup(mock.patch.stopall)
 
     def _set_mappings(
@@ -1268,30 +1267,30 @@ class TestDispatchAlgoliaIndexing(TestCase):
     # use_apply
     # ------------------------------------------------------------------
 
-    def test_use_apply_calls_chain_apply(self):
+    def test_use_apply_calls_group_apply(self):
         """
-        use_apply=True causes the dispatched chain to be executed via .apply()
-        rather than .apply_async(), making downstream tasks run synchronously.
+        use_apply=True executes each group via .apply() (synchronous).
         """
         course = ContentMetadataFactory(content_type=COURSE, content_key='ua-course')
         self._set_mappings(all_indexable_content_keys=[course.content_key])
 
         dispatch_algolia_indexing(force=True, use_apply=True)
 
-        self.mock_chain.return_value.apply.assert_called_once()
-        self.mock_chain.return_value.apply_async.assert_not_called()
+        self.mock_group.return_value.apply.assert_called()
+        self.mock_group.return_value.apply_async.assert_not_called()
 
-    def test_use_apply_false_calls_chain_apply_async(self):
+    def test_use_apply_false_calls_group_apply_async_get(self):
         """
-        use_apply=False (default) dispatches via .apply_async().
+        use_apply=False (default) dispatches each group via .apply_async().get().
         """
         course = ContentMetadataFactory(content_type=COURSE, content_key='ua-async-course')
         self._set_mappings(all_indexable_content_keys=[course.content_key])
 
         dispatch_algolia_indexing(force=True, use_apply=False)
 
-        self.mock_chain.return_value.apply_async.assert_called_once()
-        self.mock_chain.return_value.apply.assert_not_called()
+        self.mock_group.return_value.apply_async.assert_called()
+        self.mock_group.return_value.apply_async.return_value.get.assert_called()
+        self.mock_group.return_value.apply.assert_not_called()
 
     @override_settings(ALGOLIA={'INCREMENTAL_INDEX_NAME': 'v2-incremental'})
     def test_incremental_index_name_from_settings_when_not_passed(self):
@@ -1428,7 +1427,6 @@ class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
             search_tasks.index_pathways_batch_in_algolia, 'si',
         ).start()
         self.mock_group = mock.patch.object(search_tasks, 'group').start()
-        self.mock_chain = mock.patch.object(search_tasks, 'chain').start()
         self.addCleanup(mock.patch.stopall)
 
         self.algolia_client.get_aggregation_keys_for_catalog_query.return_value = set()


### PR DESCRIPTION
## Summary

`dispatch_algolia_indexing` and `dispatch_algolia_indexing_for_catalog_query` sequenced content-type batches (courses → programs → pathways → videos) via `chain(*ordered_groups).apply_async()`. Celery implements a chain of groups internally as nested chords, inserting rows into `django_celery_results_chordcounter` to track when each group finishes before starting the next.

Under concurrent invocations (e.g., a scheduled reindex cron firing during a manual `update_content_metadata` run), workers race on that INSERT and MySQL raises `IntegrityError: Duplicate entry for key 'django_celery_results_chordcounter.group_id'`. The chord counter never reaches zero, so the chain silently stalls, programs, pathways, and videos go stale for the affected run.

Replaces the `chain` with explicit sequential `apply_async().get()` calls per group. Same ordering guarantee, no `ChordCounter` involved. Confirmed on latest `django-celery-results`.

https://2u-internal.atlassian.net/browse/ENT-12110

## Test plan

- [ ] Verify in staging that concurrent `dispatch_algolia_indexing` runs no longer produce `chordcounter` duplicate key errors in Datadog

🤖 Generated with [Claude Code](https://claude.com/claude-code)