### PR TITLE
fix: replace chain(group) with nested chords to prevent ChordCounter duplicate key errors

### DIFF
--- a/enterprise_catalog/apps/search/tasks.py
+++ b/enterprise_catalog/apps/search/tasks.py
@@ -50,7 +50,7 @@ from typing import Any, TypedDict, TypeVar
 from uuid import UUID
 
 from algoliasearch.exceptions import AlgoliaException
-from celery import chain, group, shared_task
+from celery import chord, group, shared_task
 from celery_utils.logged_task import LoggedTask
 from django.conf import settings
 from django.db import IntegrityError
@@ -321,8 +321,9 @@ def _build_ordered_groups(
 
     Tasks use ``.si()`` (immutable signatures) so each task's kwargs are fixed
     at dispatch time and Celery does not forward the previous group's return
-    values as positional arguments.  Empty groups are omitted from the list so
-    callers can pass the result directly to ``chain(*ordered_groups)``.
+    values as positional arguments.  Empty groups are omitted from the list.
+    Callers should pass the list to ``_build_sequential_canvas`` to sequence
+    them as nested chords.
 
     Returns:
         ordered_groups: list of ``group`` objects, one per non-empty content
@@ -368,6 +369,36 @@ def _build_ordered_groups(
     return ordered_groups, dispatched_summary
 
 
+def _build_sequential_canvas(ordered_groups):
+    """
+    Build a Celery canvas that runs each group after the previous one completes.
+
+    Uses nested chords instead of ``chain(group, group)``. ``chain(group, group)``
+    attaches the full remaining chain as a link on every task in each group, so
+    all N tasks in a group concurrently call ``apply_chord`` for the next group
+    when they complete — causing N-1 duplicate ``ChordCounter`` INSERTs. Nested
+    chords route completion through ``on_chord_part_return`` with
+    ``SELECT FOR UPDATE``, which fires the callback exactly once (from the last
+    task) and calls ``apply_chord`` exactly once per group transition.
+
+    Each task in every group is an immutable signature (``.si()``), so the
+    parent chord's results are discarded rather than forwarded as arguments.
+    """
+    if not ordered_groups:
+        return None
+    if len(ordered_groups) == 1:
+        return ordered_groups[0]
+    # Build inside-out. The *last* group fires directly as the chord body;
+    # each preceding group wraps the accumulated canvas as its chord callback, which is
+    # executed *after* the header group is executed.
+    # See https://github.com/celery/celery/blob/e1c419a0cc4b9b3ace211eb5ed1e11b493470cf2/celery/canvas.py#L2065-L2073
+    # for the chord() task signature.
+    canvas = ordered_groups[-1]
+    for grp in reversed(ordered_groups[:-1]):
+        canvas = chord(header=grp, body=canvas)
+    return canvas
+
+
 @shared_task(base=_LoggedTaskWithRetry, bind=True, default_retry_delay=UNREADY_TASK_RETRY_COUNTDOWN_SECONDS)
 def dispatch_algolia_indexing(
     self,  # pylint: disable=unused-argument
@@ -399,11 +430,9 @@ def dispatch_algolia_indexing(
     Because those timestamps are only advanced *after* the child batch tasks
     complete, we must guarantee that all course batches finish before any
     program batches start, and all program batches finish before any pathway
-    batches start.  This is achieved by assembling the batches into a
-    ``chain`` of Celery ``group``\\s (courses → programs → pathways).  Each
-    group runs in parallel internally; Celery does not start the next group
-    until every task in the current group has completed.  Empty groups are
-    omitted from the chain.
+    batches start.  This is achieved by ``_build_sequential_canvas``, which
+    nests the groups as chords so each fires only after the previous one
+    completes.  Empty groups are omitted.
     """
     index_name = index_name or settings.ALGOLIA.get('INCREMENTAL_INDEX_NAME')
 
@@ -453,10 +482,11 @@ def dispatch_algolia_indexing(
     }
 
     if not dry_run and ordered_groups:
+        canvas = _build_sequential_canvas(ordered_groups)
         if use_apply:
-            chain(*ordered_groups).apply()
+            canvas.apply()
         else:
-            chain(*ordered_groups).apply_async()
+            canvas.apply_async()
 
     logger.info('dispatch_algolia_indexing summary=%s', summary)
     return summary
@@ -567,7 +597,7 @@ def dispatch_algolia_indexing_for_catalog_query(
     }
 
     if not dry_run and ordered_groups:
-        chain(*ordered_groups).apply_async()
+        _build_sequential_canvas(ordered_groups).apply_async()
 
     logger.info('dispatch_algolia_indexing_for_catalog_query summary=%s', summary)
     return summary

--- a/enterprise_catalog/apps/search/tests/test_tasks.py
+++ b/enterprise_catalog/apps/search/tests/test_tasks.py
@@ -33,6 +33,7 @@ from enterprise_catalog.apps.search.tasks import (
     IndexingDecision,
     RecordOutcome,
     _build_objects_by_content_key,
+    _build_sequential_canvas,
     _chunked,
     _extract_program_keys,
     _finalize_decision,
@@ -749,9 +750,9 @@ class TestDispatchAlgoliaIndexing(TestCase):
         self.mock_video_si = mock.patch.object(
             search_tasks.index_videos_batch_in_algolia, 'si',
         ).start()
-        # Prevent actual Celery chain/group dispatch
+        # Prevent actual Celery group/chord dispatch
         self.mock_group = mock.patch.object(search_tasks, 'group').start()
-        self.mock_chain = mock.patch.object(search_tasks, 'chain').start()
+        self.mock_chord = mock.patch.object(search_tasks, 'chord').start()
         self.addCleanup(mock.patch.stopall)
 
     def _set_mappings(
@@ -1268,30 +1269,59 @@ class TestDispatchAlgoliaIndexing(TestCase):
     # use_apply
     # ------------------------------------------------------------------
 
-    def test_use_apply_calls_chain_apply(self):
+    def test_use_apply_calls_group_apply(self):
         """
-        use_apply=True causes the dispatched chain to be executed via .apply()
-        rather than .apply_async(), making downstream tasks run synchronously.
+        use_apply=True executes the canvas via .apply() (synchronous).
         """
         course = ContentMetadataFactory(content_type=COURSE, content_key='ua-course')
         self._set_mappings(all_indexable_content_keys=[course.content_key])
 
         dispatch_algolia_indexing(force=True, use_apply=True)
 
-        self.mock_chain.return_value.apply.assert_called_once()
-        self.mock_chain.return_value.apply_async.assert_not_called()
+        self.mock_group.return_value.apply.assert_called()
+        self.mock_group.return_value.apply_async.assert_not_called()
 
-    def test_use_apply_false_calls_chain_apply_async(self):
+    def test_use_apply_false_calls_group_apply_async(self):
         """
-        use_apply=False (default) dispatches via .apply_async().
+        use_apply=False (default) dispatches via .apply_async() with no blocking .get().
         """
         course = ContentMetadataFactory(content_type=COURSE, content_key='ua-async-course')
         self._set_mappings(all_indexable_content_keys=[course.content_key])
 
         dispatch_algolia_indexing(force=True, use_apply=False)
 
-        self.mock_chain.return_value.apply_async.assert_called_once()
-        self.mock_chain.return_value.apply.assert_not_called()
+        self.mock_group.return_value.apply_async.assert_called()
+        self.mock_group.return_value.apply_async.return_value.get.assert_not_called()
+        self.mock_group.return_value.apply.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # chord nesting regression
+    # ------------------------------------------------------------------
+
+    def test_multi_group_dispatch_uses_nested_chords(self):
+        """
+        Regression: chain(group, group) attaches the remaining chain as a link
+        on every task. When N course batches complete concurrently, all N call
+        apply_chord for the programs group, causing N-1 duplicate ChordCounter
+        INSERTs. Nested chords fix this — chord() is called N-1 times (once per
+        group transition), and only the last task in each chord header fires the
+        callback via on_chord_part_return with SELECT FOR UPDATE.
+        """
+        course = ContentMetadataFactory(content_type=COURSE, content_key='chord-course')
+        program = ContentMetadataFactory(content_type=PROGRAM, content_key='chord-program')
+        pathway = ContentMetadataFactory(content_type=LEARNER_PATHWAY, content_key='chord-pathway')
+        self._set_mappings(
+            all_indexable_content_keys=[course.content_key, program.content_key, pathway.content_key],
+        )
+
+        dispatch_algolia_indexing(force=True)
+
+        # 3 groups (courses + programs + pathways) → chord called twice (N-1 = 2)
+        self.assertEqual(self.mock_chord.call_count, 2)
+        # The outermost chord is the canvas; dispatched fire-and-forget — no blocking .get()
+        canvas = self.mock_chord.return_value
+        canvas.apply_async.assert_called_once()
+        canvas.apply_async.return_value.get.assert_not_called()
 
     @override_settings(ALGOLIA={'INCREMENTAL_INDEX_NAME': 'v2-incremental'})
     def test_incremental_index_name_from_settings_when_not_passed(self):
@@ -1399,6 +1429,20 @@ class TestDispatchAlgoliaIndexingHelpers(TestCase):
         result = _group_aggregation_keys_by_content_type({'video:video-key-123'})
         self.assertEqual(result, {COURSE: [], PROGRAM: [], LEARNER_PATHWAY: []})
 
+    def test_build_sequential_canvas_empty_returns_none(self):
+        """
+        ``_build_sequential_canvas([])`` returns ``None`` — the callers guard
+        with ``if not dry_run and ordered_groups:`` so this branch is defensive.
+        """
+        self.assertIsNone(_build_sequential_canvas([]))
+
+    def test_build_sequential_canvas_single_group_returns_group(self):
+        """
+        A single-element list returns that element unwrapped — no chord needed.
+        """
+        grp = mock.sentinel.grp
+        self.assertIs(_build_sequential_canvas([grp]), grp)
+
 
 @override_settings(ALGOLIA_INDEXING_BATCH_SIZE=2)
 class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
@@ -1428,7 +1472,7 @@ class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
             search_tasks.index_pathways_batch_in_algolia, 'si',
         ).start()
         self.mock_group = mock.patch.object(search_tasks, 'group').start()
-        self.mock_chain = mock.patch.object(search_tasks, 'chain').start()
+        self.mock_chord = mock.patch.object(search_tasks, 'chord').start()
         self.addCleanup(mock.patch.stopall)
 
         self.algolia_client.get_aggregation_keys_for_catalog_query.return_value = set()
@@ -1633,6 +1677,27 @@ class TestDispatchAlgoliaIndexingForCatalogQuery(TestCase):
             [call.kwargs['index_name'] for call in self.mock_course_si.call_args_list],
             ['enterprise_catalog_v2', 'enterprise_catalog_v2'],
         )
+
+    def test_multi_group_dispatch_uses_nested_chords(self):
+        """
+        Regression: same as TestDispatchAlgoliaIndexing.test_multi_group_dispatch_uses_nested_chords
+        but for the catalog-query-scoped dispatcher. Three non-empty groups (courses
+        + programs + pathways) must produce two chord calls (N-1 = 2) and fire-and-forget
+        apply_async with no blocking .get().
+        """
+        catalog_query = CatalogQueryFactory()
+        self._create_catalog_membership(COURSE, 'cq-chord-course', catalog_query=catalog_query)
+        self._create_catalog_membership(PROGRAM, 'cq-chord-program', catalog_query=catalog_query)
+        self._create_catalog_membership(LEARNER_PATHWAY, 'cq-chord-pathway', catalog_query=catalog_query)
+
+        search_tasks.dispatch_algolia_indexing_for_catalog_query(
+            catalog_query.id, force=True,
+        )
+
+        self.assertEqual(self.mock_chord.call_count, 2)
+        canvas = self.mock_chord.return_value
+        canvas.apply_async.assert_called_once()
+        canvas.apply_async.return_value.get.assert_not_called()
 
     def test_catalog_query_not_found_returns_empty_summary(self):
         """


### PR DESCRIPTION
## Preamble for humans, written by a human

Doing a straight `chain()` of `groups` in celery is supported but gets structured into a `chord` (by the celery library) under the covers. This results in weird task `link`ing behavior as described below in the "Root cause" section. 

The fix is to build a chord manually with one callback for each chord, each linked to only _its_ parent group task.

There's no user-facing impact to this bug - the content metadata records are updated with full metadata and the search records are all successfully updated. The impact is that the cron job appears to be failed in the argocd UI, and the presence of failed tasks in our datadog monitoring, thus making it hard to discern real failures. It’s also likely that we’re retrying many pathways and videos tasks that we don’t need to.

https://2u-internal.atlassian.net/browse/ENT-12110

## Manual testing
1. Delete all http://localhost:18160/admin/search/contentmetadataindexingstate/ records.
2. run `./manage.py incremental_reindex_algolia --index-name=dusenbery-local-integration-test` (ensuring worker container has been restarted to pick up changes).
3. Observe no failed tasks after execution: http://localhost:18160/admin/django_celery_results/taskresult/?status=FAILURE

## Root cause

`chain(g1, g2, g3)` attaches the full remaining chain as a `link` callback on every individual task in each group. When a group has N tasks and all N complete concurrently, each one calls `apply_chord` to set up the next group's chord counter. `django-celery-results` implements `apply_chord` with a plain `ChordCounter.objects.create()` — no conflict handling — so the first call succeeds and the remaining N-1 raise `IntegrityError: Duplicate entry for key group_id`.

```
chain(courses_group [87 tasks], programs_group, pathways_group)

  course_batch_1  ──link──► chain(programs_group, pathways_group)
  course_batch_2  ──link──► chain(programs_group, pathways_group)
  ...
  course_batch_87 ──link──► chain(programs_group, pathways_group)

All 87 complete concurrently → 87 calls to apply_chord(programs_group.id)
→ ChordCounter INSERT x87
→ 1 succeeds, 86 raise IntegrityError: Duplicate entry for key group_id
```

This is a Celery canvas footgun compounded by the database backend. With Redis, `apply_chord` uses atomic operations that tolerate concurrent calls. With `django-db`, the plain INSERT does not.

## Fix

`chord(g1, body=g2)` routes task completion through [on_chord_part_return](https://docs.celeryq.dev/en/v5.5.1/internals/reference/celery.backends.gcs.html#celery.backends.gcs.GCSBackend.on_chord_part_return), which decrements a counter under `SELECT FOR UPDATE` and fires the callback exactly once — from the last completing task. `apply_chord` is called once per group transition, at the moment the previous group's last task completes.

```
chord(courses_group, body=chord(programs_group, body=pathways_group))

  Dispatch time: apply_chord(courses.id) called once → ChordCounter(count=87) created

  course_batch_1  ──► on_chord_part_return  count 87 → 86
  course_batch_2  ──► on_chord_part_return  count 86 → 85
  ...
  course_batch_87 ──► on_chord_part_return  count  1 →  0  → fires callback (once)
                                                               │
                                                               ▼
                                         chord(programs_group, body=pathways_group).apply_async()
                                         → apply_chord(programs.id) called once → no conflict
```

Each task uses `.si()` (immutable signature), so the parent chord's results are discarded rather than forwarded as arguments when the next group fires.

`_build_sequential_canvas` builds the nested chord structure from the ordered group list returned by `_build_ordered_groups`.

## Changes

- `_build_sequential_canvas`: new helper that builds `chord(g1, body=chord(g2, body=g3))` from an ordered group list
- `dispatch_algolia_indexing` and `dispatch_algolia_indexing_for_catalog_query`: use `_build_sequential_canvas` instead of `chain(*ordered_groups)`
- Removes `chain`, `TASK_TIMEOUT`, and `expiring_task_semaphore` imports (no longer needed)

