### PR TITLE
chore: sync AI instruction files from enterprise template

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -13,63 +13,40 @@ session, equivalent to instructions in this file.
 
 ## PR Review Instructions
 
-When reviewing a PR, run three sequential concern passes and emit a structured verdict. Bias
-toward flagging **excess and redundancy**, not absence — this is the opposite polarity from
-default LLM review, and it is intentional.
+When reviewing a PR, focus on the areas below.
 
-### Pass 1 — Architecture fit (House Rules)
+### Code correctness and performance
 
-Search outside the diff when applying these rules.
+1. Flag incorrect business logic.
+2. Flag areas that are potentially inefficient or unperformant.
 
-1. **Reuse before reinvent.** Before flagging new code as a duplicate, you must be able to name
-   the existing equivalent symbol and its file path. If you cannot name it, do not flag it.
+### Excess and redundancy
+
+Bias toward flagging **excess and redundancy**.
+
+1. **Reuse before reinvent.** Flag code that duplicates existing functionality - identify the existing equivalent symbol.
 2. **Earn every guard.** Defensive code (try/except, null-checks, fallbacks) must address a
-   failure that can actually happen at this call site given the system's invariants. Flag guards
-   against impossible states and fallbacks that mask real errors.
-3. **YAGNI / trust the defaults.** Don't build for hypothetical futures. Don't re-implement what
+   failure that can actually happen at this call site given the system's invariants.
+3. **Don't swallow exceptions.** If you catch an exception, re-raise it or convert it to a more actionable error; avoid catch-and-log-only (or catch-and-ignore) handling.
+4. **YAGNI / trust the defaults.** Don't build for hypothetical futures. Don't re-implement what
    the framework already does (DRF pagination, auth, serializer defaults). Flag speculative
    generality and needless overrides of correct defaults.
-4. **Respect the source of truth.** Data should be read from its canonical owner. Flag calls to
+5. **Respect the source of truth.** Data should be read from its canonical owner. Flag calls to
    external services for data the system already stores locally (e.g. a live Stripe price lookup
    when a local price table keyed by slug exists). Name the local source you're pointing to.
 
-For every finding: cite `file:line`. For rules 1 & 4: name the existing symbol and its path or
-drop the finding. Severity: critical | moderate | minor.
-
-### Pass 2 — Security
+### Security
 
 Check auth/permission classes, input validation at trust boundaries, injection vectors, secrets
 in code, missing PII annotations, CSRF. For Django/DRF backends: verify `edx-drf-extensions`
 and `edx-rbac` patterns. For React frontends: check XSS vectors and exposed keys. Cite
 `file:line` for every finding.
 
-### Pass 3 — Test coverage
+### Test coverage
 
 Flag new logic shipped without tests, tests that assert implementation detail rather than
-behavior, missing edge cases (empty input, permission denied, partial failure), and brittle
-snapshot tests.
+behavior, missing edge cases that can actually happen, and brittle snapshot tests.
 
 ### Output format
 
-```
-HEADLINE: <one sentence — the single most important takeaway for triage>
-
-## House-Rule Findings
-| Rule | Severity | Location | Finding | Should have used |
-|------|----------|----------|---------|-----------------|
-| Reuse before reinvent | moderate | billing/calc.py:42 | reimplements currency formatting | billing/utils.py:format_currency |
-
-## Security & Tests
-1) <severity> <file:line> — <claim>
-
-HOTSPOTS:
-1) <file:symbol> — <why risky or hard to read>
-
-MERGE_READINESS: READY | CHANGES_REQUIRED | REJECT_SCOPE
-<one-sentence rationale>
-```
-
-- **READY**: no confirmed critical or moderate findings.
-- **CHANGES_REQUIRED**: confirmed findings need addressing before merge.
-- **REJECT_SCOPE**: PR exceeds 400 effective LoC or 10 effective files (excluding tests,
-  lockfiles, generated files, migrations). Propose a split instead of a full review.
+Briefly highlight any critical or high severity issues.


### PR DESCRIPTION
## Summary

Syncs `.github/copilot-instructions.md` with the latest conventions from [edx/ai-devtools-internal](https://github.com/edx/ai-devtools-internal) `docs/templates/`.

### Changed
- `.github/copilot-instructions.md`: Updated PR Review Instructions section to simplified format (flatter structure, no table output format)

### No repo-specific content was modified
Repo-specific sections (`## Overview`, `## Architecture Overview`, etc.) were not touched.

🤖 Generated by the `update-ai-instructions` skill.