### PR TITLE
fix: run update_full_content_metadata_task synchronously in update_content_metadata command

### DIFF
--- a/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py
@@ -68,7 +68,7 @@ class UpdateContentMetadataCommandTests(TestCase):
             mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False, dry_run=False),
             mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False, dry_run=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with(force=False, dry_run=False)
+        mock_full_metadata_task.apply.assert_called_once_with(kwargs={"force": False, "dry_run": False})
 
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
     @mock.patch(
@@ -97,7 +97,7 @@ class UpdateContentMetadataCommandTests(TestCase):
             mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=False, dry_run=False),
             mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=False, dry_run=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with(force=False, dry_run=False)
+        mock_full_metadata_task.apply.assert_called_once_with(kwargs={"force": False, "dry_run": False})
 
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
     @mock.patch(
@@ -120,7 +120,7 @@ class UpdateContentMetadataCommandTests(TestCase):
             mock_catalog_task.s(catalog_query_id=self.catalog_query_a, force=True, dry_run=False),
             mock_catalog_task.s(catalog_query_id=self.catalog_query_b, force=True, dry_run=False),
         ])
-        mock_full_metadata_task.si.assert_called_once_with(force=True, dry_run=False)
+        mock_full_metadata_task.apply.assert_called_once_with(kwargs={"force": True, "dry_run": False})
 
     @mock.patch('enterprise_catalog.apps.catalog.management.commands.update_content_metadata.dispatch_algolia_indexing')
     @mock.patch(

--- a/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
+++ b/enterprise_catalog/apps/catalog/management/commands/update_content_metadata.py
@@ -52,25 +52,17 @@ class Command(BaseCommand):
             propagate=True,
         )
 
-    def _update_full_content_metadata_task_async(self, **kwargs):
+    def _update_full_content_metadata_task_sync(self, **kwargs):
         """
-        Returns a task signature for the `update_full_content_metadata_task`.
+        Runs `update_full_content_metadata_task` synchronously via `.apply()`.
 
-        Note that the keys get filtered down to course content keys inside the task.
+        Runs in-process to avoid Celery worker timeouts on large datasets.
         """
-        message = (
-            'Spinning off update_full_content_metadata_task from update_content_metadata command'
+        logger.info(
+            'Running update_full_content_metadata_task synchronously from update_content_metadata command'
             ' to replace minimal json_metadata from /search/all/ with full json_metadata from /courses/.'
         )
-        logger.info(message)
-
-        # task.si() is used as a shortcut for an immutable signature to avoid calling this with the results from the
-        # previously run `update_catalog_metadata_task`.
-        # https://docs.celeryproject.org/en/master/userguide/canvas.html#immutability
-        return update_full_content_metadata_task.si(**kwargs).apply_async().get(
-            timeout=TASK_TIMEOUT,
-            propagate=True,
-        )
+        return update_full_content_metadata_task.apply(kwargs=kwargs)
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -168,10 +160,7 @@ class Command(BaseCommand):
             )
 
         try:
-            if no_async:
-                update_full_content_metadata_task.apply(kwargs=flags)
-            else:
-                self._update_full_content_metadata_task_async(**flags)
+            self._update_full_content_metadata_task_sync(**flags)
             logger.info('Finished doing full update of metadata records.')
         except TaskRecentlyRunError:
             logger.info(


### PR DESCRIPTION
## Summary

- `update_full_content_metadata_task` was dispatched via `apply_async().get(timeout=3h)` inside the `update_content_metadata` management command. The task appeared to timeout mid-run with no obvious error in the logs -- it does a lot of work and was being silently cut off by the Celery worker timeout.
- Switch to `.apply()` so the task runs in-process under the management command, bypassing the Celery worker timeout entirely.
- Rename the helper method from `_update_full_content_metadata_task_async` to `_update_full_content_metadata_task_sync` and collapse the `no_async` branch for this task (both paths now do the same thing).
- There's no efficiency lost here, the update-full path doesn't utilize parallelism.

## Test plan

- [ ] Existing unit tests updated and passing (`pytest enterprise_catalog/apps/catalog/management/commands/tests/test_update_content_metadata.py`)
- [ ] Quality checks passing (`make quality`)
- [ ] Smoke test: run `./manage.py update_content_metadata` in a dev environment and confirm `update_full_content_metadata_task` completes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)