### PR TITLE
fix: download courses above 1000 in catalog portal

### DIFF
--- a/enterprise_catalog/apps/api/v1/export_utils.py
+++ b/enterprise_catalog/apps/api/v1/export_utils.py
@@ -129,6 +129,66 @@ ALGOLIA_ATTRIBUTES_TO_RETRIEVE = [
 DATE_FORMAT = "%Y-%m-%d"
 
 
+def build_facet_filters(facets):
+    """Build an Algolia `facetFilters` structure from facet_name -> [facet_values]."""
+    facet_filters = []
+    for facet_name, facet_values in facets.items():
+        facet_filters.append([f'{facet_name}:{facet_value}' for facet_value in facet_values])
+    return facet_filters
+
+
+def browse_all_hits(algolia_index, algolia_query, facet_filters, attributes_to_retrieve=None):
+    """
+    Return every hit via `browse_objects`, which (unlike `search`) has no `paginationLimitedTo`
+    cap. Also merges the per-record shards `search`'s `distinct` setting used to collapse.
+
+    Note: shards of the same `aggregation_key` aren't guaranteed to arrive adjacent to each
+    other in the browse cursor, so `_merge_sharded_hits` has to hold every hit in memory
+    rather than merging as a bounded streaming pass. Fine at current enterprise catalog sizes;
+    the hit count is logged so unexpectedly large exports are visible before it becomes one.
+    """
+    raw_hits = algolia_index.browse_objects({
+        'query': algolia_query,
+        'facetFilters': facet_filters,
+        'attributesToRetrieve': attributes_to_retrieve or ALGOLIA_ATTRIBUTES_TO_RETRIEVE,
+    })
+    merged_hits = _merge_sharded_hits(raw_hits)
+    logger.info('browse_all_hits merged %d hits for query %r', len(merged_hits), algolia_query)
+    return merged_hits
+
+
+def _merge_sharded_hits(hits):
+    """Collapse hits sharing an `aggregation_key` into one, unioning list-valued fields."""
+    merged_by_key = {}
+    for hit in hits:
+        agg_key = hit.get('aggregation_key')
+        if agg_key not in merged_by_key:
+            merged_by_key[agg_key] = dict(hit)
+            continue
+        existing = merged_by_key[agg_key]
+        for field, value in hit.items():
+            if not value:
+                continue
+            existing_value = existing.get(field)
+            if isinstance(value, list) and isinstance(existing_value, list):
+                existing[field] = existing_value + [item for item in value if item not in existing_value]
+            elif not existing_value:
+                existing[field] = value
+    return list(merged_by_key.values())
+
+
+def chunked(iterable, size):
+    """Yield successive lists of at most `size` items from `iterable`."""
+    chunk = []
+    for item in iterable:
+        chunk.append(item)
+        if len(chunk) >= size:
+            yield chunk
+            chunk = []
+    if chunk:
+        yield chunk
+
+
 def write_headers_to_sheet(worksheet, headers, cell_format):
     """
     Helper function to write a given list of strings as a header row in a given worksheet.
@@ -149,7 +209,7 @@ def fetch_catalog_types(hit):
         'Subscription'
     ]
 
-    return [catalog for catalog in CATALOG_TYPES if catalog in hit.get('enterprise_catalog_query_titles')]
+    return [catalog for catalog in CATALOG_TYPES if catalog in (hit.get('enterprise_catalog_query_titles') or [])]
 
 
 def program_hit_to_row(hit, use_learner_portal_url=False):

--- a/enterprise_catalog/apps/api/v1/tests/test_export_utils.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_export_utils.py
@@ -15,3 +15,103 @@ class ExportUtilsTests(TestCase):
         """
         # assert that ALGOLIA_ATTRIBUTES_TO_RETRIEVE is a SUBSET of ALGOLIA_FIELDS
         assert set(export_utils.ALGOLIA_ATTRIBUTES_TO_RETRIEVE) <= set(algolia_utils.ALGOLIA_FIELDS)
+
+    def test_fetch_catalog_types_handles_missing_query_titles(self):
+        """
+        Regression test: a hit with no `enterprise_catalog_query_titles` field (e.g. content not
+        associated with any CatalogQuery) must not raise a TypeError.
+        """
+        assert export_utils.fetch_catalog_types({}) == []
+
+    def test_fetch_catalog_types_filters_to_known_types(self):
+        hit = {'enterprise_catalog_query_titles': ['Subscription', 'Some Other Title']}
+        assert export_utils.fetch_catalog_types(hit) == ['Subscription']
+
+    def test_merge_sharded_hits_collapses_duplicate_aggregation_keys(self):
+        """
+        Regression test: Algolia shards large per-record fields across multiple physical
+        records sharing the same `aggregation_key`, each populating only one of those fields.
+        `search()` collapses these via the index's `distinct` setting; `browse_objects()` does
+        not, so `_merge_sharded_hits` must do it instead, or exports would show duplicate rows.
+        """
+        shards = [
+            {
+                'objectID': 'course-uuid-customer-uuids-0',
+                'aggregation_key': 'course:edX+DemoX',
+                'title': 'Demo Course',
+                'enterprise_customer_uuids': ['customer-1'],
+            },
+            {
+                'objectID': 'course-uuid-catalog-uuids-0',
+                'aggregation_key': 'course:edX+DemoX',
+                'title': 'Demo Course',
+                'enterprise_catalog_uuids': ['catalog-1'],
+            },
+            {
+                'objectID': 'course-uuid-catalog-query-uuids-0',
+                'aggregation_key': 'course:edX+DemoX',
+                'title': 'Demo Course',
+                'enterprise_catalog_query_titles': ['Subscription'],
+            },
+            {
+                'objectID': 'other-course-uuid-0',
+                'aggregation_key': 'course:edX+OtherX',
+                'title': 'Other Course',
+                'enterprise_catalog_query_titles': ['Business'],
+            },
+        ]
+
+        merged = export_utils._merge_sharded_hits(shards)  # pylint: disable=protected-access
+
+        assert len(merged) == 2
+        demo_course = next(hit for hit in merged if hit['aggregation_key'] == 'course:edX+DemoX')
+        assert demo_course['enterprise_customer_uuids'] == ['customer-1']
+        assert demo_course['enterprise_catalog_uuids'] == ['catalog-1']
+        assert demo_course['enterprise_catalog_query_titles'] == ['Subscription']
+
+    def test_merge_sharded_hits_ignores_empty_field_values(self):
+        """
+        Regression test: a later shard with a falsy value (e.g. an empty list) for a field
+        must not clobber a non-empty value already collected from an earlier shard.
+        """
+        shards = [
+            {
+                'objectID': 'course-uuid-0',
+                'aggregation_key': 'course:edX+DemoX',
+                'enterprise_customer_uuids': ['customer-1'],
+            },
+            {
+                'objectID': 'course-uuid-1',
+                'aggregation_key': 'course:edX+DemoX',
+                'enterprise_customer_uuids': [],
+            },
+        ]
+
+        merged = export_utils._merge_sharded_hits(shards)  # pylint: disable=protected-access
+
+        assert len(merged) == 1
+        assert merged[0]['enterprise_customer_uuids'] == ['customer-1']
+
+    def test_merge_sharded_hits_unions_list_values_shared_across_shards(self):
+        """
+        Regression test: when two shards of the same `aggregation_key` both populate the same
+        list-valued field (rather than each shard owning a distinct field), the values must be
+        unioned together rather than one shard's value replacing the other's.
+        """
+        shards = [
+            {
+                'objectID': 'course-uuid-0',
+                'aggregation_key': 'course:edX+DemoX',
+                'enterprise_customer_uuids': ['customer-1', 'customer-2'],
+            },
+            {
+                'objectID': 'course-uuid-1',
+                'aggregation_key': 'course:edX+DemoX',
+                'enterprise_customer_uuids': ['customer-2', 'customer-3'],
+            },
+        ]
+
+        merged = export_utils._merge_sharded_hits(shards)  # pylint: disable=protected-access
+
+        assert len(merged) == 1
+        assert merged[0]['enterprise_customer_uuids'] == ['customer-1', 'customer-2', 'customer-3']

--- a/enterprise_catalog/apps/api/v1/tests/test_views.py
+++ b/enterprise_catalog/apps/api/v1/tests/test_views.py
@@ -1,6 +1,8 @@
 import copy
+import io
 import json
 import uuid
+import zipfile
 from collections import OrderedDict
 from datetime import datetime
 from unittest import mock
@@ -801,7 +803,7 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
         """
         Tests a successful request with facets.
         """
-        mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = self.mock_algolia_hits['hits']
         url = self._get_contains_content_base_url()
         facets = 'language=English'
         response = self.client.get(f'{url}?{facets}')
@@ -817,8 +819,8 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
         """
         Tests that the view properly handles situations where data is missing from the Algolia hit.
         """
-        mock_side_effects = [self._get_mock_algolia_hits_with_missing_values(), {'hits': []}]
-        mock_algolia_client.return_value.algolia_index.search.side_effect = mock_side_effects
+        mock_hits = self._get_mock_algolia_hits_with_missing_values()['hits']
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = mock_hits
         url = self._get_contains_content_base_url()
         facets = 'language=English'
         response = self.client.get(f'{url}?{facets}')
@@ -837,6 +839,109 @@ class EnterpriseCatalogCsvDataViewTests(APITestMixin):
             'csv_data': expected_csv_data
         }
         assert response.data == expected_response
+
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_csv_data.DiscoveryApiClient')
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_csv_data.get_initialized_algolia_client')
+    def test_csv_data_returns_more_than_1000_hits(self, mock_algolia_client, mock_discovery_client):
+        """Regression test: exports must not be capped at Algolia's 1000-hit `search()` limit."""
+        mock_discovery_client.return_value.get_courses.return_value = []
+        num_hits = 1500
+        mock_hits = [
+            {
+                'aggregation_key': f'course:Org+{i}',
+                'key': f'Org+{i}',
+                'content_type': 'course',
+                'title': f'Course {i}',
+                'enterprise_catalog_query_titles': ['Subscription'],
+                'advertised_course_run': {},
+            }
+            for i in range(num_hits)
+        ]
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = mock_hits
+        url = self._get_contains_content_base_url()
+        facets = 'enterprise_catalog_query_titles=Subscription'
+        response = self.client.get(f'{url}?{facets}')
+
+        assert response.status_code == 200
+        # header row + one row per hit
+        assert response.data['csv_data'].count('\r\n') == num_hits + 1
+        assert mock_algolia_client.return_value.algolia_index.search.called is False
+
+
+class EnterpriseCatalogCsvViewTests(APITestMixin):
+    """
+    Tests for the CatalogCsvView view (the streaming CSV download endpoint).
+    """
+    mock_algolia_hits = EnterpriseCatalogCsvDataViewTests.mock_algolia_hits
+    expected_result_data = EnterpriseCatalogCsvDataViewTests.expected_result_data
+
+    def setUp(self):
+        super().setUp()
+        self.set_up_staff_user()
+
+    def _get_contains_content_base_url(self):
+        """
+        Helper to construct the base url for the catalog_csv endpoint
+        """
+        return reverse('api:v1:catalog-csv')
+
+    def _get_csv_content(self, response):
+        """
+        Helper to fully consume a streamed CSV response and decode it, stripping the leading BOM.
+        """
+        content = b''.join(response.streaming_content)
+        return content.decode('utf-8-sig')
+
+    def test_facet_validation(self):
+        """
+        Tests that the view validates Algolia facets provided by query params
+        """
+        url = self._get_contains_content_base_url()
+        invalid_facets = 'invalid_facet=wrong'
+        response = self.client.get(f'{url}?{invalid_facets}')
+        assert response.status_code == 400
+        assert response.data == "Error: invalid facet(s): ['invalid_facet'] provided."
+
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_csv.get_initialized_algolia_client')
+    def test_valid_facet_validation(self, mock_algolia_client):
+        """
+        Tests a successful request with facets.
+        """
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = self.mock_algolia_hits['hits']
+        url = self._get_contains_content_base_url()
+        facets = 'language=English'
+        response = self.client.get(f'{url}?{facets}')
+        assert response.status_code == 200
+        assert response['Content-Type'] == 'text/csv;charset=utf-8'
+        assert self._get_csv_content(response) == self.expected_result_data
+
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_csv.DiscoveryApiClient')
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_csv.get_initialized_algolia_client')
+    def test_csv_returns_more_than_1000_hits(self, mock_algolia_client, mock_discovery_client):
+        """Regression test: exports must not be capped at Algolia's 1000-hit `search()` limit."""
+        mock_discovery_client.return_value.get_courses.return_value = []
+        num_hits = 1500
+        mock_hits = [
+            {
+                'aggregation_key': f'course:Org+{i}',
+                'key': f'Org+{i}',
+                'content_type': 'course',
+                'title': f'Course {i}',
+                'enterprise_catalog_query_titles': ['Subscription'],
+                'advertised_course_run': {},
+            }
+            for i in range(num_hits)
+        ]
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = mock_hits
+        url = self._get_contains_content_base_url()
+        facets = 'enterprise_catalog_query_titles=Subscription'
+        response = self.client.get(f'{url}?{facets}')
+
+        assert response.status_code == 200
+        content = self._get_csv_content(response)
+        # header row + one row per hit
+        assert content.count('\r\n') == num_hits + 1
+        assert mock_algolia_client.return_value.algolia_index.search.called is False
 
 
 class EnterpriseCatalogWorkbookViewTests(APITestMixin):
@@ -1034,7 +1139,7 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
                 "objectID": "course-3543aa4e-3c64-4d9a-a343-5d5eda1dacf7-catalog-query-uuids-0"
             },
             {
-                "aggregation_key": "course:MITx+18.01.2x",
+                "aggregation_key": "program:MITx+18.01.2x",
                 "course_keys": ['MITx+18.01.2x'],
                 "content_type": "program",
                 "enterprise_catalog_query_titles": ["A la carte", "Business", "DemoX"],
@@ -1066,7 +1171,7 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
         """
         Tests when algolia returns no hits.
         """
-        mock_algolia_client.return_value.algolia_index.search.side_effect = [{'hits': []}]
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = []
         url = self._get_contains_content_base_url()
         facets = 'language=English'
         response = self.client.get(f'{url}?{facets}')
@@ -1077,7 +1182,7 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
         """
         Tests basic, successful output.
         """
-        mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = self.mock_algolia_hits['hits']
         url = self._get_contains_content_base_url()
         facets = 'language=English'
         response = self.client.get(f'{url}?{facets}')
@@ -1088,11 +1193,61 @@ class EnterpriseCatalogWorkbookViewTests(APITestMixin):
         """
         Tests basic, successful output
         """
-        mock_algolia_client.return_value.algolia_index.search.side_effect = [self.mock_algolia_hits, {'hits': []}]
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = self.mock_algolia_hits['hits']
         url = self._get_contains_content_base_url()
         facets = 'language=English&use_learner_portal_url=true'
         response = self.client.get(f'{url}?{facets}')
         assert response.status_code == 200
+
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_workbook.get_initialized_algolia_client')
+    def test_workbook_includes_more_than_1000_hits(self, mock_algolia_client):
+        """Regression test: exports must not be capped at Algolia's 1000-hit `search()` limit."""
+        num_hits = 1500
+        mock_hits = [
+            {
+                'aggregation_key': f'course:Org+{i}',
+                'key': f'Org+{i}',
+                'content_type': 'course',
+                'title': f'Course {i}',
+                'enterprise_catalog_query_titles': ['Subscription'],
+                'advertised_course_run': {},
+                'course_runs': [],
+            }
+            for i in range(num_hits)
+        ]
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = mock_hits
+        url = self._get_contains_content_base_url()
+        facets = 'enterprise_catalog_query_titles=Subscription'
+        response = self.client.get(f'{url}?{facets}')
+
+        assert response.status_code == 200
+        assert mock_algolia_client.return_value.algolia_index.search.called is False
+
+    @mock.patch('enterprise_catalog.apps.api.v1.views.catalog_workbook.get_initialized_algolia_client')
+    def test_workbook_includes_course_runs_sheet(self, mock_algolia_client):
+        """Regression test: an active course run must produce a populated 'Course Runs' sheet."""
+        hit = {
+            'aggregation_key': 'course:edX+DemoX',
+            'key': 'edX+DemoX',
+            'content_type': 'course',
+            'title': 'Demo Course',
+            'course_runs': [
+                {
+                    'key': 'course-v1:edX+DemoX+1T2024',
+                    'is_active': True,
+                    'pacing_type': 'instructor_paced',
+                },
+            ],
+        }
+        mock_algolia_client.return_value.algolia_index.browse_objects.return_value = [hit]
+        url = self._get_contains_content_base_url()
+        facets = 'language=English'
+        response = self.client.get(f'{url}?{facets}')
+
+        assert response.status_code == 200
+        with zipfile.ZipFile(io.BytesIO(response.content)) as workbook_zip:
+            workbook_xml = workbook_zip.read('xl/workbook.xml').decode('utf-8')
+        assert 'Course Runs' in workbook_xml
 
 
 class EnterpriseCatalogContainsContentItemsTests(APITestMixin):

--- a/enterprise_catalog/apps/api/v1/views/catalog_csv.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_csv.py
@@ -48,25 +48,12 @@ class CatalogCsvView(GenericAPIView):
         # discovery to gather extra, non-indexed fields
         discovery_client = DiscoveryApiClient()
 
-        facet_filters = []
-        for facet_name, facet_values in facets.items():
-            combined_facets = []
-            for facet_value in facet_values:
-                combined_facets.append(f'{facet_name}:{facet_value}')
-            facet_filters.append(combined_facets)
+        facet_filters = export_utils.build_facet_filters(facets)
+        hits = export_utils.browse_all_hits(algolia_client.algolia_index, algoliaQuery, facet_filters)
 
-        search_options = {
-            'facetFilters': facet_filters,
-            'attributesToRetrieve': export_utils.ALGOLIA_ATTRIBUTES_TO_RETRIEVE,
-            'hitsPerPage': 100,
-            'page': 0,
-        }
-
-        # Algolia search will only retrieve all results if you query by empty string.
-        page = algolia_client.algolia_index.search(algoliaQuery, search_options)
-        while len(page['hits']) > 0:
+        for hits_chunk in export_utils.chunked(hits, 100):
             course_keys_chunk = []
-            for hit in page.get('hits', []):
+            for hit in hits_chunk:
                 # ignore program data (for now)
                 if hit.get('content_type') != 'course':
                     continue
@@ -83,7 +70,7 @@ class CatalogCsvView(GenericAPIView):
 
             # combine discovery metadata with the algolia results
             # append the hit to the results
-            for hit in page.get('hits', []):
+            for hit in hits_chunk:
                 # ignore program data (for now)
                 if hit.get('content_type') != 'course':
                     continue
@@ -91,9 +78,6 @@ class CatalogCsvView(GenericAPIView):
                     hit['discovery_course'] = course_by_key.get(hit.get('key'))
                 row = export_utils.hit_to_row(hit)
                 yield writer.writerow(row)
-
-            search_options['page'] = search_options['page'] + 1
-            page = algolia_client.algolia_index.search(algoliaQuery, search_options)
 
     @action(detail=True)
     def get(self, request, **kwargs):

--- a/enterprise_catalog/apps/api/v1/views/catalog_csv_data.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_csv_data.py
@@ -51,26 +51,13 @@ class CatalogCsvDataView(GenericAPIView):
         # discovery to gather extra, non-indexed fields
         discovery_client = DiscoveryApiClient()
 
-        facet_filters = []
-        for facet_name, facet_values in facets.items():
-            combined_facets = []
-            for facet_value in facet_values:
-                combined_facets.append(f'{facet_name}:{facet_value}')
-            facet_filters.append(combined_facets)
+        facet_filters = export_utils.build_facet_filters(facets)
+        hits = export_utils.browse_all_hits(algolia_client.algolia_index, algoliaQuery, facet_filters)
 
-        search_options = {
-            'facetFilters': facet_filters,
-            'attributesToRetrieve': export_utils.ALGOLIA_ATTRIBUTES_TO_RETRIEVE,
-            'hitsPerPage': 100,
-            'page': 0,
-        }
-
-        # Algolia search will only retrieve all results if you query by empty string.
         algolia_hits = []
-        page = algolia_client.algolia_index.search(algoliaQuery, search_options)
-        while len(page['hits']) > 0:
+        for hits_chunk in export_utils.chunked(hits, 100):
             course_keys_chunk = []
-            for hit in page.get('hits', []):
+            for hit in hits_chunk:
                 # ignore program data (for now)
                 if hit.get('content_type') != 'course':
                     continue
@@ -87,16 +74,13 @@ class CatalogCsvDataView(GenericAPIView):
 
             # combine discovery metadata with the algolia results
             # append the hit to the results
-            for hit in page.get('hits', []):
+            for hit in hits_chunk:
                 # ignore program data (for now)
                 if hit.get('content_type') != 'course':
                     continue
                 if course_by_key.get(hit.get('key')):
                     hit['discovery_course'] = course_by_key.get(hit.get('key'))
                 algolia_hits.append(hit)
-
-            search_options['page'] = search_options['page'] + 1
-            page = algolia_client.algolia_index.search(algoliaQuery, search_options)
 
         with StringIO() as file:
             writer = csv.writer(file)

--- a/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
+++ b/enterprise_catalog/apps/api/v1/views/catalog_workbook.py
@@ -1,4 +1,5 @@
 import io
+import itertools
 import logging
 import time
 
@@ -61,25 +62,18 @@ class CatalogWorkbookView(GenericAPIView):
 
         algolia_client = get_initialized_algolia_client()
 
-        facet_filters = []
-        for facet_name, facet_values in facets.items():
-            combined_facets = []
-            for facet_value in facet_values:
-                combined_facets.append(f'{facet_name}:{facet_value}')
-            facet_filters.append(combined_facets)
+        facet_filters = export_utils.build_facet_filters(facets)
+        hits_iterator = iter(export_utils.browse_all_hits(algolia_client.algolia_index, algoliaQuery, facet_filters))
 
-        search_options = {
-            'facetFilters': facet_filters,
-            'attributesToRetrieve': export_utils.ALGOLIA_ATTRIBUTES_TO_RETRIEVE,
-            'hitsPerPage': 100,
-            'page': 0,
-        }
-
-        # Algolia search will only retrieve all results if you query by empty string.
-        page = algolia_client.algolia_index.search(algoliaQuery, search_options)
-
-        if len(page['hits']) == 0:
+        # Peek at the first hit to detect an empty result set (mirrors the old
+        # `if len(page['hits']) == 0` check) without consuming it - `all_hits` below puts
+        # it back at the front of the stream via `itertools.chain`.
+        try:
+            first_hit = next(hits_iterator)
+        except StopIteration:
             return Response(f'Error: invalid query: {algoliaQuery} provided.', status=HTTP_400_BAD_REQUEST)
+
+        all_hits = itertools.chain([first_hit], hits_iterator)
 
         # content row index, starting at 1 which is after header row
         course_row_num = 1
@@ -90,48 +84,45 @@ class CatalogWorkbookView(GenericAPIView):
         edx_course_results_found = False
         edx_program_results_found = False
         course_run_results_found = False
-        while len(page['hits']) > 0:
-            for hit in page.get('hits', []):
-                if hit.get('content_type') == 'course':
-                    is_exec_ed = hit.get('course_type') == 'executive-education-2u'
-                    if is_exec_ed:
-                        if not exec_ed_results_found:
-                            exec_ed_results_found = True
-                            exec_ed_worksheet = workbook.add_worksheet('Executive Education')
-                            export_utils.write_headers_to_sheet(
-                                exec_ed_worksheet, export_utils.CSV_EXEC_ED_COURSE_HEADERS, header_format
-                            )
-                        course_row = export_utils.exec_ed_course_to_row(hit, use_learner_portal_url)
-                        exec_ed_row_num = write_row_data(course_row, exec_ed_worksheet, exec_ed_row_num)
-                    else:
-                        if not edx_course_results_found:
-                            edx_course_results_found = True
-                            course_worksheet = workbook.add_worksheet('Courses')
-                            export_utils.write_headers_to_sheet(
-                                course_worksheet, export_utils.CSV_COURSE_HEADERS, header_format
-                            )
-                        course_row = export_utils.course_hit_to_row(hit, use_learner_portal_url)
-                        course_row_num = write_row_data(course_row, course_worksheet, course_row_num)
-                    for course_run in export_utils.course_hit_runs(hit):
-                        if not course_run_results_found:
-                            course_run_results_found = True
-                            course_run_worksheet = workbook.add_worksheet('Course Runs')
-                            export_utils.write_headers_to_sheet(
-                                course_run_worksheet, export_utils.CSV_COURSE_RUN_HEADERS, header_format
-                            )
-                        course_run_row = export_utils.course_run_to_row(hit, course_run)
-                        course_run_row_num = write_row_data(course_run_row, course_run_worksheet, course_run_row_num)
-                if hit.get('content_type') == 'program':
-                    if not edx_program_results_found:
-                        edx_program_results_found = True
-                        program_worksheet = workbook.add_worksheet('Programs')
+        for hit in all_hits:
+            if hit.get('content_type') == 'course':
+                is_exec_ed = hit.get('course_type') == 'executive-education-2u'
+                if is_exec_ed:
+                    if not exec_ed_results_found:
+                        exec_ed_results_found = True
+                        exec_ed_worksheet = workbook.add_worksheet('Executive Education')
                         export_utils.write_headers_to_sheet(
-                            program_worksheet, export_utils.CSV_PROGRAM_HEADERS, header_format
+                            exec_ed_worksheet, export_utils.CSV_EXEC_ED_COURSE_HEADERS, header_format
                         )
-                    program_row = export_utils.program_hit_to_row(hit, use_learner_portal_url)
-                    program_row_num = write_row_data(program_row, program_worksheet, program_row_num)
-            search_options['page'] = search_options['page'] + 1
-            page = algolia_client.algolia_index.search(algoliaQuery, search_options)
+                    course_row = export_utils.exec_ed_course_to_row(hit, use_learner_portal_url)
+                    exec_ed_row_num = write_row_data(course_row, exec_ed_worksheet, exec_ed_row_num)
+                else:
+                    if not edx_course_results_found:
+                        edx_course_results_found = True
+                        course_worksheet = workbook.add_worksheet('Courses')
+                        export_utils.write_headers_to_sheet(
+                            course_worksheet, export_utils.CSV_COURSE_HEADERS, header_format
+                        )
+                    course_row = export_utils.course_hit_to_row(hit, use_learner_portal_url)
+                    course_row_num = write_row_data(course_row, course_worksheet, course_row_num)
+                for course_run in export_utils.course_hit_runs(hit):
+                    if not course_run_results_found:
+                        course_run_results_found = True
+                        course_run_worksheet = workbook.add_worksheet('Course Runs')
+                        export_utils.write_headers_to_sheet(
+                            course_run_worksheet, export_utils.CSV_COURSE_RUN_HEADERS, header_format
+                        )
+                    course_run_row = export_utils.course_run_to_row(hit, course_run)
+                    course_run_row_num = write_row_data(course_run_row, course_run_worksheet, course_run_row_num)
+            if hit.get('content_type') == 'program':
+                if not edx_program_results_found:
+                    edx_program_results_found = True
+                    program_worksheet = workbook.add_worksheet('Programs')
+                    export_utils.write_headers_to_sheet(
+                        program_worksheet, export_utils.CSV_PROGRAM_HEADERS, header_format
+                    )
+                program_row = export_utils.program_hit_to_row(hit, use_learner_portal_url)
+                program_row_num = write_row_data(program_row, program_worksheet, program_row_num)
 
         # Close the workbook before sending the data.
         workbook.close()


### PR DESCRIPTION
**Summary**
Downloading a CSV/XLSX export from the Explore Catalog page silently capped results at 1000 rows, even when more courses matched the filter. Root cause: catalog_csv, catalog_csv_data, and catalog_workbook paginated Algolia via search(), which enforces Algolia's paginationLimitedTo setting (1000 by default) regardless of actual match count.

**Changes**

1. Switch all three export views from search() pagination to browse_objects(), which has no such cap.
2. Merge Algolia's internal per-record shards back together by aggregation_key (_merge_sharded_hits) — search()'s distinct setting used to collapse these implicitly; browse_objects() doesn't, so without this, exports would show duplicate rows per course.
3.  Fix a related TypeError in fetch_catalog_types when a hit has no enterprise_catalog_query_titles.
4.  Add regression tests covering >1000-hit exports and shard deduplication.


**Test plan**

1.  Added/updated unit tests (135 passing)
2.  Manually verified against a seeded local index with 1200+ courses — export now returns all rows, no duplicates
3.  Lint clean (pycodestyle, isort, pylint)
Test result:
<img width="1838" height="856" alt="image" src="https://github.com/user-attachments/assets/76e9b8a9-aa0b-42ba-96df-9f1200bb8024" />
<img width="1653" height="880" alt="image" src="https://github.com/user-attachments/assets/09d16a5d-7cee-4ca3-bec8-d907f201b2d1" />
<img width="1904" height="857" alt="image" src="https://github.com/user-attachments/assets/08e2ae97-196b-41a4-90e3-92ea4bbe880b" />


