### PR TITLE
fix: keep unrestricted advertised run on restricted course overrides

### DIFF
--- a/enterprise_catalog/apps/api/tasks.py
+++ b/enterprise_catalog/apps/api/tasks.py
@@ -373,10 +373,27 @@ def _update_full_restricted_course_metadata(modified_metadata_record, course_rev
 
     full_restricted_metadata = metadata_list[0]
 
+    # The include_restricted discovery fetch advertises a *restricted* run, but the
+    # unrestricted parent's advertised run is the one we want to surface. The canonical
+    # (catalog_query=NULL) restricted override feeds the Algolia payload for every catalog
+    # the course belongs to -- including catalogs whose content_filter disallows restricted
+    # runs -- so letting the restricted run stay advertised leaks it into those records.
+    # We restore the parent's advertised run here.
+    parent_advertised_run_uuid = modified_metadata_record._json_metadata.get(  # pylint: disable=protected-access
+        'advertised_course_run_uuid'
+    )
+
     for restricted_course in restricted_courses:
         # First, update the restricted course record's json metadata to use the full metadata
         # from above.
         restricted_course.update_metadata(full_restricted_metadata, is_full_update=True)
+
+        # Skipped for "unicorn" courses whose parent has no advertised run.
+        # Instead keep the unrestricted parent's advertised run (must happen before normalization
+        # below, since normalized_metadata is derived from the advertised run).
+        if parent_advertised_run_uuid:
+            # pylint: disable=protected-access
+            restricted_course._json_metadata['advertised_course_run_uuid'] = parent_advertised_run_uuid
 
         # Last, run the "standard" transformations below to update with the full
         # course metadata, do normalization, etc.

--- a/enterprise_catalog/apps/api/tests/test_tasks.py
+++ b/enterprise_catalog/apps/api/tests/test_tasks.py
@@ -18,9 +18,12 @@ from enterprise_catalog.apps.api_client.discovery import CatalogQueryMetadata
 from enterprise_catalog.apps.catalog.constants import (
     COURSE,
     COURSE_RUN,
+    COURSE_RUN_RESTRICTION_TYPE_KEY,
     EXEC_ED_2U_COURSE_TYPE,
     LEARNER_PATHWAY,
     PROGRAM,
+    RESTRICTED_RUNS_ALLOWED_KEY,
+    RESTRICTION_FOR_B2B,
 )
 from enterprise_catalog.apps.catalog.models import CatalogQuery, ContentMetadata
 from enterprise_catalog.apps.catalog.serializers import (
@@ -31,6 +34,7 @@ from enterprise_catalog.apps.catalog.tests.factories import (
     CatalogQueryFactory,
     ContentMetadataFactory,
     EnterpriseCatalogFactory,
+    RestrictedCourseMetadataFactory,
 )
 from enterprise_catalog.apps.catalog.utils import localized_utcnow
 
@@ -346,6 +350,111 @@ class FetchMissingPathwayMetadataTaskTests(TestCase):
         assert course_catalog_query.content_filter['status'] == 'published'
         assert course_catalog_query.content_filter['content_type'] == 'course'
         assert course_catalog_query.content_filter['key'] == [test_course]
+
+
+@ddt.ddt
+class UpdateFullRestrictedCourseMetadataTests(TestCase):
+    """
+    Tests for `_update_full_restricted_course_metadata`, which populates restricted
+    course overrides from discovery's ``include_restricted`` course fetch.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.course_key = 'edX+HAL'
+        self.non_restricted_uuid = str(uuid.uuid4())
+        self.restricted_uuid = str(uuid.uuid4())
+        self.non_restricted_run = {
+            'key': 'course-v1:edX+HAL+nonrestricted',
+            'uuid': self.non_restricted_uuid,
+            'start': '2023-03-01T00:00:00Z',
+            'end': '2024-03-01T00:00:00Z',
+            'first_enrollable_paid_seat_price': 100,
+            'seats': [{'type': CourseMode.VERIFIED, 'upgrade_deadline': '2023-03-15T00:00:00Z'}],
+            'enrollment_start': '2023-02-01T00:00:00Z',
+        }
+        self.restricted_run = {
+            'key': 'course-v1:edX+HAL+restricted',
+            'uuid': self.restricted_uuid,
+            COURSE_RUN_RESTRICTION_TYPE_KEY: RESTRICTION_FOR_B2B,
+            'start': '2024-03-01T00:00:00Z',
+            'end': '2025-03-01T00:00:00Z',
+            'first_enrollable_paid_seat_price': 200,
+            'seats': [{'type': CourseMode.VERIFIED, 'upgrade_deadline': '2024-03-15T00:00:00Z'}],
+            'enrollment_start': '2024-02-01T00:00:00Z',
+        }
+        # What discovery returns for the ``include_restricted`` fetch: it advertises
+        # the *restricted* run, which is exactly the value we must not persist.
+        self.full_restricted_metadata = {
+            'key': self.course_key,
+            'content_type': COURSE,
+            'advertised_course_run_uuid': self.restricted_uuid,
+            'course_runs': [self.non_restricted_run, self.restricted_run],
+        }
+
+    def _make_parent(self, advertised_course_run_uuid):
+        parent = ContentMetadataFactory(content_type=COURSE, content_key=self.course_key)
+        parent._json_metadata = {  # pylint: disable=protected-access
+            'key': self.course_key,
+            'content_type': COURSE,
+            'advertised_course_run_uuid': advertised_course_run_uuid,
+            'course_runs': [self.non_restricted_run],
+        }
+        parent.save()
+        return parent
+
+    @mock.patch('enterprise_catalog.apps.api.tasks._fetch_courses_by_keys')
+    def test_restored_from_unrestricted_parent(self, mock_fetch):
+        """
+        The canonical (catalog_query=NULL) and per-query restricted overrides should both
+        keep the unrestricted parent's advertised run, not discovery's restricted run.
+        """
+        mock_fetch.return_value = [self.full_restricted_metadata]
+        parent = self._make_parent(self.non_restricted_uuid)
+
+        canonical = RestrictedCourseMetadataFactory(
+            content_key=self.course_key, content_type=COURSE,
+            unrestricted_parent=parent, catalog_query=None,
+            _json_metadata={'key': self.course_key, 'content_type': COURSE},
+        )
+        catalog_query = CatalogQueryFactory(content_filter={
+            RESTRICTED_RUNS_ALLOWED_KEY: {self.course_key: [self.restricted_run['key']]},
+        })
+        per_query = RestrictedCourseMetadataFactory(
+            content_key=self.course_key, content_type=COURSE,
+            unrestricted_parent=parent, catalog_query=catalog_query,
+            _json_metadata={'key': self.course_key, 'content_type': COURSE},
+        )
+
+        tasks._update_full_restricted_course_metadata(parent, None, dry_run=False)  # pylint: disable=protected-access
+
+        canonical.refresh_from_db()
+        per_query.refresh_from_db()
+        # pylint: disable=protected-access
+        self.assertEqual(canonical._json_metadata['advertised_course_run_uuid'], self.non_restricted_uuid)
+        self.assertEqual(per_query._json_metadata['advertised_course_run_uuid'], self.non_restricted_uuid)
+
+    @mock.patch('enterprise_catalog.apps.api.tasks._fetch_courses_by_keys')
+    def test_unicorn_course_keeps_restricted_advertised_run(self, mock_fetch):
+        """
+        A "unicorn" course whose unrestricted parent has no advertised run keeps
+        discovery's restricted advertised run (it is only indexed for catalogs that
+        explicitly allow the restricted run).
+        """
+        mock_fetch.return_value = [self.full_restricted_metadata]
+        parent = self._make_parent(None)
+
+        canonical = RestrictedCourseMetadataFactory(
+            content_key=self.course_key, content_type=COURSE,
+            unrestricted_parent=parent, catalog_query=None,
+            _json_metadata={'key': self.course_key, 'content_type': COURSE},
+        )
+
+        tasks._update_full_restricted_course_metadata(parent, None, dry_run=False)  # pylint: disable=protected-access
+
+        canonical.refresh_from_db()
+        # pylint: disable=protected-access
+        self.assertEqual(canonical._json_metadata['advertised_course_run_uuid'], self.restricted_uuid)
 
 
 @ddt.ddt


### PR DESCRIPTION
## What

Restricted courses were surfacing a **restricted** run as the `advertised_course_run` in their Algolia records, even for catalogs whose `content_filter` allows no restricted runs (found on `University_of_TorontoX+HAL` in the "A la carte" catalog). The plain `ContentMetadata` record's `advertised_course_run_uuid` was correct (non-restricted) the whole time.

## Why

Two Discovery fetches populate two records:

1. The normal `/api/v1/courses` fetch advertises the non-restricted run and updates `ContentMetadata`. Correct.
2. `_update_full_restricted_course_metadata` refetches with `include_restricted=custom-b2b-enterprise`. In that view Discovery advertises the **restricted** run, and `update_metadata(is_full_update=True)` wrote that `advertised_course_run_uuid` verbatim onto the `RestrictedCourseMetadata` records. `filter_restricted_runs` recomputes runs/keys/prices but never the advertised pointer.

At index time, `_get_algolia_products_for_batch` calls `prefetch_restricted_overrides()` with no catalog query, so `ContentMetadata.json_metadata` returns the **canonical** (`catalog_query = NULL`) restricted override. That single blob is keyed by `content_key` and fanned out to every catalog/customer/query the course belongs to, so the restricted advertised run leaked into catalogs that disallow restricted runs.

```
        include_restricted fetch  -->  RestrictedCourseMetadata (canonical, query=NULL)
                                        advertised_uuid = R  (restricted)
                                                  |
                              prefetch_restricted_overrides() -> json_metadata
                                                  |  (one blob, keyed by content_key)
              +-------------------------+---------+---------+-------------------------+
              v                         v                   v
      "A la carte" catalog      catalog allowing R      other catalog
      advertised = R  (BUG)     advertised = R          advertised = R  (BUG)
```

## Fix

In `_update_full_restricted_course_metadata`, restore the unrestricted parent's `advertised_course_run_uuid` on each restricted override (canonical + per-query) before normalization runs, so `normalized_metadata` is derived from the correct run too. Guarded so "unicorn" courses (parent has no advertised run) keep Discovery's restricted advertised run, since they are only indexed for catalogs that explicitly allow the restricted run.

## Rollout

Write-time fix. Existing rows stay wrong until `update_full_content_metadata` reruns for the affected courses, followed by an Algolia reindex.

## Post-review

* [ ] Squash commits into discrete sets of changes
* [ ] Ensure that once the changes have been [deployed to stage](https://gocd.tools.edx.org/go/pipeline/activity/stage-enterprise_catalog), prod is manually deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
