### PR TITLE
fix: handle missing parent ContentMetadata in _store_record

### DIFF
--- a/enterprise_catalog/apps/catalog/models.py
+++ b/enterprise_catalog/apps/catalog/models.py
@@ -996,7 +996,14 @@ class RestrictedCourseMetadata(BaseContentMetadata):
             raise Exception('Can only store RestrictedContentMetadata with content type of course')
 
         course_key = course_metadata_dict['key']
-        parent_record = ContentMetadata.objects.get(content_key=course_key, content_type=COURSE)
+        try:
+            parent_record = ContentMetadata.objects.get(content_key=course_key, content_type=COURSE)
+        except ContentMetadata.DoesNotExist:
+            LOGGER.warning(
+                'Skipping RestrictedCourseMetadata for %s: unrestricted parent ContentMetadata does not exist.',
+                course_key,
+            )
+            return None
 
         defaults = {}
         if content_uuid := get_content_uuid(course_metadata_dict):
@@ -1028,7 +1035,8 @@ class RestrictedCourseMetadata(BaseContentMetadata):
         and the restricted course runs explicitly allowed by the provided catalog query.
         """
         course_record = cls._store_record(course_metadata_dict, catalog_query, is_full_update=is_full_update)
-        course_record.update_course_run_relationships()
+        if course_record:
+            course_record.update_course_run_relationships()
         return course_record
 
     @classmethod
@@ -1812,11 +1820,13 @@ def synchronize_restricted_content(catalog_query, dry_run=False):
         if dry_run:
             continue
 
-        RestrictedCourseMetadata.store_canonical_record(course_dict)
+        if not RestrictedCourseMetadata.store_canonical_record(course_dict):
+            continue
         restricted_course_record = RestrictedCourseMetadata.store_record_with_query(
             course_dict, catalog_query,
         )
-        results.append(restricted_course_record.content_key)
+        if restricted_course_record:
+            results.append(restricted_course_record.content_key)
 
     restricted_course_run_keys = list(catalog_query.restricted_courses_by_run_key.keys())
     run_content_filter = {

--- a/enterprise_catalog/apps/catalog/tests/test_models.py
+++ b/enterprise_catalog/apps/catalog/tests/test_models.py
@@ -1432,6 +1432,32 @@ class TestRestrictedRunsModels(TestCase):
         self.assertEqual(record.unrestricted_parent, parent_record)
         self.assertIsNone(record.catalog_query)
 
+    def test_store_canonical_record_raises_for_non_course_content_type(self):
+        """
+        _store_record raises when the content_type is not COURSE.
+        """
+        with self.assertRaises(Exception) as ctx:
+            RestrictedCourseMetadata.store_canonical_record({
+                'key': 'program+test',
+                'content_type': PROGRAM,
+                'course_runs': [],
+            })
+        self.assertIn('content type of course', str(ctx.exception))
+
+    def test_store_canonical_record_missing_parent_returns_none(self):
+        """
+        When the unrestricted parent ContentMetadata doesn't exist yet,
+        _store_record should return None rather than raise DoesNotExist.
+        """
+        content_metadata_dict = {
+            'key': 'edX+no-parent-course',
+            'uuid': '22222222-2222-2222-2222-222222222222',
+            'content_type': COURSE,
+            'course_runs': [],
+        }
+        result = RestrictedCourseMetadata.store_canonical_record(content_metadata_dict)
+        self.assertIsNone(result)
+
     def test_store_record_with_query(self):
         """
         Tests that a restricted course to be associated with a particular query
@@ -1673,6 +1699,76 @@ class TestRestrictedRunsModels(TestCase):
         )
         self.assertEqual(restricted_runs[0].json_metadata['other'], 'stuff')
         self.assertEqual(restricted_runs[1].json_metadata['other'], 'things')
+
+    @override_settings(DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT=0)
+    @override_settings(SHOULD_FETCH_RESTRICTED_COURSE_RUNS=True)
+    @mock.patch('enterprise_catalog.apps.catalog.models.DiscoveryApiClient')
+    def test_synchronize_restricted_content_skips_when_canonical_record_missing_parent(self, mock_client):
+        """
+        When store_canonical_record returns None (parent ContentMetadata absent),
+        the course is skipped and not included in results.
+        """
+        catalog_query = factories.CatalogQueryFactory(
+            content_filter={
+                'restricted_runs_allowed': {
+                    'course:edX+orphan': ['course-v1:edX+orphan+run1'],
+                },
+            },
+        )
+        course_dict = {
+            'key': 'edX+orphan',
+            'uuid': '33333333-3333-3333-3333-333333333333',
+            'content_type': COURSE,
+            'course_runs': [],
+        }
+        mock_retrieve = mock_client.return_value.retrieve_metadata_for_content_filter
+        mock_retrieve.side_effect = [
+            [course_dict],
+            [],
+        ]
+
+        # No parent ContentMetadata exists for 'edX+orphan'.
+        result = synchronize_restricted_content(catalog_query)
+
+        self.assertEqual(result, [])
+        self.assertFalse(
+            RestrictedCourseMetadata.objects.filter(content_key='edX+orphan').exists()
+        )
+
+    @override_settings(DISCOVERY_CATALOG_QUERY_CACHE_TIMEOUT=0)
+    @override_settings(SHOULD_FETCH_RESTRICTED_COURSE_RUNS=True)
+    @mock.patch('enterprise_catalog.apps.catalog.models.RestrictedCourseMetadata.store_record_with_query')
+    @mock.patch('enterprise_catalog.apps.catalog.models.DiscoveryApiClient')
+    def test_synchronize_restricted_content_skips_when_store_record_with_query_returns_none(
+        self, mock_client, mock_store_with_query,
+    ):
+        """
+        When store_record_with_query returns None, the course key is not appended to results.
+        """
+        catalog_query = factories.CatalogQueryFactory(
+            content_filter={
+                'restricted_runs_allowed': {
+                    'course:edX+course': ['course-v1:edX+course+run2'],
+                },
+            },
+        )
+        course_dict = {
+            'key': 'edX+course',
+            'uuid': '44444444-4444-4444-4444-444444444444',
+            'content_type': COURSE,
+            'course_runs': [],
+        }
+        factories.ContentMetadataFactory.create(content_key='edX+course', content_type=COURSE)
+        mock_retrieve = mock_client.return_value.retrieve_metadata_for_content_filter
+        mock_retrieve.side_effect = [
+            [course_dict],
+            [],
+        ]
+        mock_store_with_query.return_value = None
+
+        result = synchronize_restricted_content(catalog_query)
+
+        self.assertEqual(result, [])
 
 
 @ddt.ddt


### PR DESCRIPTION
## Summary

`synchronize_restricted_content` calls `RestrictedCourseMetadata.store_canonical_record` for courses that may not have a parent `ContentMetadata` record yet — e.g. when the restricted course isn't in the catalog query's unrestricted content filter. The bare `.get()` at `models.py:999` raised `DoesNotExist` in that case, aborting the entire `update_catalog_metadata_task`.

- `_store_record` now returns `None` and logs a warning when the parent `ContentMetadata` is absent, instead of raising.
- `store_record_with_query` guards against the `None` return before calling `update_course_run_relationships`.
- `synchronize_restricted_content` skips the record and continues when `store_canonical_record` returns `None`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)